### PR TITLE
Fix repeater/room server uptime rollover issue.

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -195,7 +195,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
         stats.n_packets_recv = radio_driver.getPacketsRecv();
         stats.n_packets_sent = radio_driver.getPacketsSent();
         stats.total_air_time_secs = getTotalAirTime() / 1000;
-        stats.total_up_time_secs = _ms->getMillis() / 1000;
+        stats.total_up_time_secs = getUptimeSecs();
         stats.n_sent_flood = getNumSentFlood();
         stats.n_sent_direct = getNumSentDirect();
         stats.n_recv_flood = getNumRecvFlood();
@@ -253,6 +253,14 @@ protected:
     if (_prefs.disable_fwd) return false;
     if (packet->isRouteFlood() && packet->path_len >= _prefs.flood_max) return false;
     return true;
+  }
+  
+  uint32_t getUptimeSecs() const {
+    if (_cli.bootTime == 0) {
+      return _ms->getMillis() / 1000;
+    } else {
+      return (getRTCClock()->getCurrentTime() - _cli.bootTime);
+    }
   }
 
   const char* getLogDateTime() override {
@@ -647,6 +655,10 @@ public:
 
   void setLoggingOn(bool enable) override { _logging = enable; }
 
+  void setBootTime(uint32_t boot_time) {
+    _cli.bootTime = boot_time;   // set the boot time for CLI
+  }
+  
   void eraseLogFile() override {
     _fs->remove(PACKET_LOG_FILE);
   }

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -656,7 +656,7 @@ public:
   void setLoggingOn(bool enable) override { _logging = enable; }
 
   void setBootTime(uint32_t boot_time) {
-    _cli.bootTime = boot_time;   // set the boot time for CLI
+    _cli.bootTime = boot_time;
   }
   
   void eraseLogFile() override {

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -305,7 +305,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
         stats.n_packets_recv = radio_driver.getPacketsRecv();
         stats.n_packets_sent = radio_driver.getPacketsSent();
         stats.total_air_time_secs = getTotalAirTime() / 1000;
-        stats.total_up_time_secs = _ms->getMillis() / 1000;
+        stats.total_up_time_secs = getUptimeSecs();
         stats.n_sent_flood = getNumSentFlood();
         stats.n_sent_direct = getNumSentDirect();
         stats.n_recv_flood = getNumRecvFlood();
@@ -401,6 +401,14 @@ protected:
   int calcRxDelay(float score, uint32_t air_time) const override {
     if (_prefs.rx_delay_base <= 0.0f) return 0;
     return (int) ((pow(_prefs.rx_delay_base, 0.85f - score) - 1.0) * air_time);
+  }
+
+  uint32_t getUptimeSecs() const {
+    if (_cli.bootTime == 0) {
+      return _ms->getMillis() / 1000;
+    } else {
+      return (getRTCClock()->getCurrentTime() - _cli.bootTime);
+    }
   }
 
   const char* getLogDateTime() override {
@@ -805,6 +813,10 @@ public:
     } else {
       next_flood_advert = 0;  // stop the timer
     }
+  }
+
+  void setBootTime(uint32_t boot_time) {
+    _cli.bootTime = boot_time;   // set the boot time for CLI
   }
 
   void setLoggingOn(bool enable) override { _logging = enable; }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -143,6 +143,10 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
     } else if (memcmp(command, "clock sync", 10) == 0) {
       uint32_t curr = getRTCClock()->getCurrentTime();
       if (sender_timestamp > curr) {
+        if (bootTime == 0) {
+          MESH_DEBUG_PRINTLN("clock sync: setting boot time...");
+          _callbacks->setBootTime(sender_timestamp - (millis()/1000));
+        } 
         getRTCClock()->setCurrentTime(sender_timestamp + 1);
         uint32_t now = getRTCClock()->getCurrentTime();
         DateTime dt = DateTime(now);
@@ -162,6 +166,10 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       uint32_t secs = _atoi(&command[5]);
       uint32_t curr = getRTCClock()->getCurrentTime();
       if (secs > curr) {
+        if (bootTime == 0) {
+          MESH_DEBUG_PRINTLN("clock set time: setting boot time...");
+          _callbacks->setBootTime(sender_timestamp - (millis()/1000));
+        } 
         getRTCClock()->setCurrentTime(secs);
         uint32_t now = getRTCClock()->getCurrentTime();
         DateTime dt = DateTime(now);

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -144,7 +144,6 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       uint32_t curr = getRTCClock()->getCurrentTime();
       if (sender_timestamp > curr) {
         if (bootTime == 0) {
-          MESH_DEBUG_PRINTLN("clock sync: setting boot time...");
           _callbacks->setBootTime(sender_timestamp - (millis()/1000));
         } 
         getRTCClock()->setCurrentTime(sender_timestamp + 1);
@@ -167,7 +166,6 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       uint32_t curr = getRTCClock()->getCurrentTime();
       if (secs > curr) {
         if (bootTime == 0) {
-          MESH_DEBUG_PRINTLN("clock set time: setting boot time...");
           _callbacks->setBootTime(sender_timestamp - (millis()/1000));
         } 
         getRTCClock()->setCurrentTime(secs);

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -44,7 +44,7 @@ public:
   virtual void setTxPower(uint8_t power_dbm) = 0;
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual const uint8_t* getSelfIdPubKey() = 0;
-  virtual void clearStats() = 0;  
+  virtual void clearStats() = 0;
   virtual void setBootTime(uint32_t bootTime) = 0;
 };
 

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -44,7 +44,8 @@ public:
   virtual void setTxPower(uint8_t power_dbm) = 0;
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual const uint8_t* getSelfIdPubKey() = 0;
-  virtual void clearStats() = 0;
+  virtual void clearStats() = 0;  
+  virtual void setBootTime(uint32_t bootTime) = 0;
 };
 
 class CommonCLI {
@@ -65,6 +66,7 @@ public:
   CommonCLI(mesh::MainBoard& board, mesh::RTCClock& rtc, NodePrefs* prefs, CommonCLICallbacks* callbacks)
       : _board(&board), _rtc(&rtc), _prefs(prefs), _callbacks(callbacks) { }
 
+  uint32_t bootTime = 0;
   void loadPrefs(FILESYSTEM* _fs);
   void savePrefs(FILESYSTEM* _fs);
   void handleCommand(uint32_t sender_timestamp, const char* command, char* reply);


### PR DESCRIPTION
Currently total_up_time_secs is based on millis() so the maximum is ~50 day before it rolls over to 0.

This PR adds a bootTime var to CommonCLI which gets set at first time sync, after which we can use that to compute uptime in seconds.