### PR TITLE
Fix: Reset ESP32 RTC clock on software reset

### DIFF
--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -94,7 +94,7 @@ public:
   ESP32RTCClock() { }
   void begin() {
     esp_reset_reason_t reason = esp_reset_reason();
-    if (reason == ESP_RST_POWERON) {
+    if (reason == ESP_RST_POWERON || reason == ESP_RST_SW) {
       // start with some date/time in the recent past
       struct timeval tv;
       tv.tv_sec = 1715770351;  // 15 May 2024, 8:50pm


### PR DESCRIPTION
Updated `ESP32RTCClock::begin()` to treat software reset (`ESP_RST_SW`) the same as power-on reset (`ESP_RST_POWERON`), ensuring the clock resets to the default time (15 May 2024, 8:50pm) when triggered via the CLI reboot command or any other software-initiated reset.

No personal issues with a good old-fashioned power cycle, but some have reported their clock getting accidentally set far into the future. Probably less funny when the device is zip-tied 8m up a tree ... not exactly reset-button friendly!
