### PR TITLE
Changed radio_init to use radio.std_init

### DIFF
--- a/variants/waveshare_rp2040_lora/target.cpp
+++ b/variants/waveshare_rp2040_lora/target.cpp
@@ -12,18 +12,8 @@ VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
 SensorManager sensors;
 
-#ifndef LORA_CR
-#define LORA_CR 5
-#endif
-
 bool radio_init() {
   rtc_clock.begin(Wire);
-
-#ifdef SX126X_DIO3_TCXO_VOLTAGE
-  float tcxo = SX126X_DIO3_TCXO_VOLTAGE;
-#else
-  float tcxo = 1.6f;
-#endif
 
   SPI1.setSCK(P_LORA_SCLK);
   SPI1.setTX(P_LORA_MOSI);
@@ -34,30 +24,8 @@ bool radio_init() {
 
   SPI1.begin(false);
 
-  int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE,
-                           LORA_TX_POWER, 8, tcxo);
-
-  if (status != RADIOLIB_ERR_NONE) {
-    Serial.print("ERROR: radio init failed: ");
-    Serial.println(status);
-    return false; // fail
-  }
-
-  radio.setCRC(1);
-
-#ifdef SX126X_CURRENT_LIMIT
-  radio.setCurrentLimit(SX126X_CURRENT_LIMIT);
-#endif
-
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-  radio.setDio2AsRfSwitch(SX126X_DIO2_AS_RF_SWITCH);
-#endif
-
-#ifdef SX126X_RX_BOOSTED_GAIN
-  radio.setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
-#endif
-
-  return true; // success
+  //passing NULL skips init of SPI
+  return radio.std_init(NULL);
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
The waveshare_rp2040_lora variant is not following the other variants by using radio.std_init to set up the radio.

The original code looks to have been pulled from generic-e22 code which also has the same preamble of 8 hard code into the function call to radio.begin. 
[Line 36](https://github.com/wel97459/MeshCore/blob/c48ec40ae680647d483b9eff8029f23bcebf3718/variants/generic-e22/target.cpp#L36)

The hardcode preamble in the radio.std_init function is 16.
