### PR TITLE
Add deep sleep with USER button wake-up for Heltec V3

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -293,10 +293,24 @@ void UITask::shutdown(bool restart){
 
   #endif // PIN_BUZZER
 
-  if (restart)
+  if (restart) {
     _board->reboot();
-  else
+  } else {
+    // Show power-off message on display
+    if (_display != NULL) {
+      _display->startFrame();
+      _display->setCursor(0, 0);
+      _display->setTextSize(2);
+      _display->print("Power Off");
+      _display->setCursor(0, 20);
+      _display->setTextSize(1);
+      _display->print("Sleeping...");
+      _display->endFrame();
+      delay(2000);  // Show message for 2 seconds
+    }
+    
     _board->powerOff();
+  }
 }
 
 void UITask::loop() {

--- a/src/helpers/HeltecV3Board.h
+++ b/src/helpers/HeltecV3Board.h
@@ -84,9 +84,18 @@ public:
     esp_deep_sleep_start();   // CPU halts here and never returns!
   }
 
+  void enterPowerOffSleep() {
+    // Simple power-off sleep, wake only with reset button
+    esp_deep_sleep_start();  // Never returns
+  }
+
+
   void powerOff() override {
-    // TODO: re-enable this when there is a definite wake-up source pin:
-    //  enterDeepSleep(0);
+    // Simple power-off, wake only with reset button
+    Serial.println("Entering deep sleep...");
+    Serial.flush();  // Ensure message is sent before sleep
+    
+    enterPowerOffSleep();  // Simple deep sleep, no wake sources
   }
 
   uint16_t getBattMilliVolts() override {


### PR DESCRIPTION
## Problem
Currently meshcore running on heltec v3 boards can't be turned off so the battery drains very quickly and stays dead which is bad for the device. 

## Summary
- Implements deep sleep functionality for Heltec V3 boards when the USER button is held for 5 seconds
- Reset button is required to start again (this is because the USER button has a mode conflict issue which prevents it from being a way to keep the device asleep *and* wake the device reliably)
- Shows power-off confirmation message on display before sleep

## Test Plan
- [x] Verify device enters deep sleep when holding the power button for 5 seconds
- [x] Confirm RESET button press wakes device from sleep
- [x] Validate display shows power-off message before sleep