### PR TITLE
default.nix: add python3 to the shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@ in
   pkgs.mkShell {
     buildInputs = [
       pkgs.platformio
+      pkgs.python3
       # optional: needed as a programmer i.e. for esp32
       pkgs.avrdude
     ];


### PR DESCRIPTION
There are many systems that chose to not have a global python install, namely my own systems :p
I end up having to nix-shell -p python3 anytime I want to run the build.sh as the last step uf2conv depends on python.