### PR TITLE
Ikoka Stick: repeater/room server functionality

### DIFF
--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -93,12 +93,6 @@ lib_deps =
   ${ikoka_stick_nrf.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
-[env:ikoka_stick_nrf_alt_pinout_companion_radio_ble]
-extends = env:ikoka_stick_nrf_companion_radio_ble
-build_flags =
-  ${env:ikoka_stick_nrf_companion_radio_ble.build_flags}
-  -D SX1262_XIAO_S3_VARIANT
-
 [env:ikoka_stick_nrf_repeater]
 extends = ikoka_stick_nrf
 build_flags =
@@ -111,13 +105,8 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
-  +<../examples/simple_repeater/main.cpp>
-
-[env:ikoka_stick_nrf_alt_pinout_repeater]
-extends = env:ikoka_stick_nrf_repeater
-build_flags =
-  ${env:ikoka_stick_nrf_repeater.build_flags}
-  -D SX1262_XIAO_S3_VARIANT
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_repeater>
 
 [env:ikoka_stick_nrf_room_server]
 extends = ikoka_stick_nrf
@@ -130,4 +119,4 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
-  +<../examples/simple_room_server/main.cpp>
+  +<../examples/simple_room_server>


### PR DESCRIPTION
Make Repeater and Room Server work as build targets.

Remove esp32-related alternate pinout cruft from the Ikoka Stick NRF build tree.