### PR TITLE
[Feature]: Xiao ESP32-C6 (Meshimi) Add MAX17261 fuel gauge support with voltage + temperature telemetry

### DIFF
--- a/variants/xiao_c6/MeshimiBoard.cpp
+++ b/variants/xiao_c6/MeshimiBoard.cpp
@@ -1,0 +1,156 @@
+// Build only for Meshimi board-enabled targets
+#ifdef USE_MESHIMI_BOARD
+#include "MeshimiBoard.h"
+
+// MAX17261 driver
+#include <max17261.h>
+#include <Arduino.h>
+#include <Wire.h>
+#include <math.h>
+#include <string.h>
+
+static struct max17261_conf g_max17261_conf;
+static bool g_max17261_inited = false;
+static bool g_max17261_conf_inited = false;
+static uint32_t g_last_mv_read_ms = 0;
+static uint16_t g_last_mv_cached = 0;
+static uint32_t g_last_temp_read_ms = 0;
+static float g_last_temp_cached = NAN;
+
+static constexpr uint8_t kMax17261Address = 0x36;  // I2C address
+static uint32_t g_last_init_attempt_ms = 0;
+static uint8_t g_init_attempts = 0;
+static constexpr uint8_t kMaxInitAttempts = 3;
+
+static inline void ensure_gauge_initialized() {
+  if (g_max17261_inited) {
+    return;
+  }
+  if (g_init_attempts >= kMaxInitAttempts) {
+    return;
+  }
+  uint32_t now = millis();
+  if ((now - g_last_init_attempt_ms) < 5000) {
+    return;
+  }
+  if (!g_max17261_conf_inited) {
+    memset(&g_max17261_conf, 0, sizeof(g_max17261_conf));
+    g_max17261_conf.DesignCap = 5000; // mAh
+    g_max17261_conf.IchgTerm = 25;    // mA
+    g_max17261_conf.VEmpty = ((3300 / 10) << 7) | ((3880 / 40) & 0x7F);
+    g_max17261_conf.R100 = 1;
+    g_max17261_conf.ChargeVoltage = 4200; // mV
+    g_max17261_conf_inited = true;
+  }
+  Wire.setClock(400000);
+  g_last_init_attempt_ms = now;
+  g_init_attempts++;
+  if (max17261_init(&g_max17261_conf) == 0) {
+    g_max17261_inited = true;
+  }
+}
+
+void MeshimiBoard::begin() {
+  XiaoC6Board::begin();
+
+  // Basic configuration values; tune for your battery pack if needed
+  memset(&g_max17261_conf, 0, sizeof(g_max17261_conf));
+
+  g_max17261_conf.DesignCap = 5000; // mAh
+  g_max17261_conf.IchgTerm = 25;    // mA
+  g_max17261_conf.VEmpty = ( (3300 / 10) << 7) | ((3880 / 40) & 0x7F);
+  g_max17261_conf.R100 = 1;
+  g_max17261_conf.ChargeVoltage = 4200; // mV
+  g_max17261_conf_inited = true;
+
+  // Ensure I2C bus is running at a reasonable fast mode for fuel gauge
+  Wire.setClock(400000);
+
+  g_max17261_inited = (max17261_init(&g_max17261_conf) == 0);
+}
+
+uint16_t MeshimiBoard::getBattMilliVolts() {
+  ensure_gauge_initialized();
+
+  // Low-rate cache to avoid frequent I2C transactions
+  uint32_t now = millis();
+  if (g_last_mv_cached != 0 && (now - g_last_mv_read_ms) < 1000) {
+    return g_last_mv_cached;
+  }
+
+  if (!g_max17261_inited) {
+    // fall back to board ADC if available without hitting I2C
+    uint16_t fallback = ESP32Board::getBattMilliVolts();
+    g_last_mv_cached = fallback;
+    g_last_mv_read_ms = now;
+    return fallback;
+  }
+
+  uint16_t mv = max17261_get_voltage(&g_max17261_conf);
+  if (mv == 0) {
+    // fall back to board ADC if available
+    uint16_t fallback = ESP32Board::getBattMilliVolts();
+    g_last_mv_cached = fallback;
+    g_last_mv_read_ms = now;
+    return fallback;
+  }
+
+  g_last_mv_cached = mv;
+  g_last_mv_read_ms = now;
+  return mv;
+}
+
+float MeshimiBoard::getBattTemperatureC() {
+  ensure_gauge_initialized();
+
+  // Low-rate cache to avoid frequent I2C transactions
+  uint32_t now = millis();
+  if (!isnan(g_last_temp_cached) && (now - g_last_temp_read_ms) < 1000) {
+    return g_last_temp_cached;
+  }
+
+  if (!g_max17261_inited) {
+    // Temperature unavailable without gauge
+    g_last_temp_cached = NAN;
+    g_last_temp_read_ms = now;
+    return g_last_temp_cached;
+  }
+
+  float t = max17261_get_die_temperature(&g_max17261_conf);
+  g_last_temp_cached = t;
+  g_last_temp_read_ms = now;
+  return t;
+}
+
+// Default weak hooks mapping to Arduino Wire/delay
+extern "C" max17261_err_t max17261_read_word(struct max17261_conf* conf, uint8_t reg, uint16_t* value) {
+  Wire.beginTransmission(kMax17261Address);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) {
+    return -1;
+  }
+  int read = Wire.requestFrom((uint8_t)kMax17261Address, (uint8_t)2, (bool)true);
+  if (read != 2) {
+    return -2;
+  }
+  uint8_t first = Wire.read();
+  uint8_t second = Wire.read();
+  // MAX1726x registers are little-endian (LSB then MSB)
+  *value = static_cast<uint16_t>(second) << 8 | first;
+  return 0;
+}
+
+extern "C" max17261_err_t max17261_write_word(struct max17261_conf* conf, uint8_t reg, uint16_t val) {
+  Wire.beginTransmission(kMax17261Address);
+  Wire.write(reg);
+  Wire.write(static_cast<uint8_t>(val & 0xFF));
+  Wire.write(static_cast<uint8_t>((val >> 8) & 0xFF));
+  return (Wire.endTransmission(true) == 0) ? 0 : 1;
+}
+
+extern "C" max17261_err_t max17261_delay_ms(struct max17261_conf* conf, uint32_t period) {
+  delay(period);
+  return 0;
+}
+
+#endif // USE_MESHIMI_BOARD

--- a/variants/xiao_c6/MeshimiBoard.h
+++ b/variants/xiao_c6/MeshimiBoard.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Arduino.h>
+#include "XiaoC6Board.h"
+
+// Meshimi-specific board implementation for Xiao ESP32-C6
+class MeshimiBoard : public XiaoC6Board {
+public:
+  void begin();
+  uint16_t getBattMilliVolts() override;
+  float getBattTemperatureC();
+
+  const char* getManufacturerName() const override {
+    return "Meshimi";
+  }
+};
+
+

--- a/variants/xiao_c6/MeshimiSensors.cpp
+++ b/variants/xiao_c6/MeshimiSensors.cpp
@@ -1,0 +1,16 @@
+#include "MeshimiSensors.h"
+#include "target.h"
+#include <math.h>
+
+bool MeshimiSensorManager::querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) {
+  // Add battery temperature from MAX17261 when environment telemetry is requested
+  if (requester_permissions & TELEM_PERM_ENVIRONMENT) {
+    float t = board.getBattTemperatureC();
+    if (!isnan(t)) {
+      telemetry.addTemperature(TELEM_CHANNEL_SELF, t);
+    }
+  }
+  return true;
+}
+
+

--- a/variants/xiao_c6/MeshimiSensors.h
+++ b/variants/xiao_c6/MeshimiSensors.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <helpers/SensorManager.h>
+#include "MeshimiBoard.h"
+
+class MeshimiSensorManager : public SensorManager {
+public:
+  bool begin() override { return true; }
+  bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
+};

--- a/variants/xiao_c6/XiaoC6Board.cpp
+++ b/variants/xiao_c6/XiaoC6Board.cpp
@@ -1,7 +1,10 @@
 #include <Arduino.h>
 #include "target.h"
+#ifdef USE_MESHIMI_BOARD
+#include "MeshimiSensors.h"
+#endif
 
-XiaoC6Board board;
+BOARD_CLASS board;
 
 #if defined(P_LORA_SCLK)
   static SPIClass spi(0);
@@ -14,7 +17,11 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 ESP32RTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
+#ifdef USE_MESHIMI_BOARD
+MeshimiSensorManager sensors;
+#else
 SensorManager sensors;
+#endif
 
 bool radio_init() {
   fallback_clock.begin();

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -89,6 +89,7 @@ build_flags =
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D USE_XIAO_ESP32C6_EXTERNAL_ANTENNA=1
+  -D USE_MESHIMI_BOARD=1
 
 [env:Meshimi_Repeater]
 extends = Meshimi
@@ -103,6 +104,7 @@ build_flags =
   -D MAX_NEIGHBOURS=8
 lib_deps =
   ${Meshimi.lib_deps}
+  https://github.com/alexbegoon/max17261-driver.git
 
 [env:Meshimi_companion_radio_ble]
 extends = Meshimi
@@ -121,3 +123,4 @@ build_src_filter = ${Meshimi.build_src_filter}
 lib_deps =
   ${Meshimi.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  https://github.com/alexbegoon/max17261-driver.git

--- a/variants/xiao_c6/target.h
+++ b/variants/xiao_c6/target.h
@@ -2,17 +2,28 @@
 
 #define RADIOLIB_STATIC_ONLY 1
 #include <RadioLib.h>
+#ifdef USE_MESHIMI_BOARD
+#include "MeshimiBoard.h"
+#include "MeshimiSensors.h"
+using BOARD_CLASS = MeshimiBoard;
+#else
 #include <XiaoC6Board.h>
+using BOARD_CLASS = XiaoC6Board;
+#endif
 #include <helpers/radiolib/RadioLibWrappers.h>
 #include <helpers/ESP32Board.h>
 #include <helpers/radiolib/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
 
-extern XiaoC6Board board;
+extern BOARD_CLASS board;
 extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
+#ifdef USE_MESHIMI_BOARD
+extern MeshimiSensorManager sensors;
+#else
 extern SensorManager sensors;
+#endif
 
 bool radio_init();
 uint32_t radio_get_rng_seed();


### PR DESCRIPTION
-  Introduces MAX17261 fuel gauge support for the Xiao ESP32-C6 Meshimi variant, providing accurate battery voltage and die temperature readings, and wiring temperature into telemetry.
- New board class: variants/xiao_c6/MeshimiBoard.{h,cpp}
- Telemetry integration: variants/xiao_c6/MeshimiSensors.{h,cpp}


#### Screenshots:

<img width="200px" src="https://github.com/user-attachments/assets/87ea7a05-7c43-4461-b168-6bfe5172288c" />

<img width="200px" src="https://github.com/user-attachments/assets/b7bdb278-3cfe-4795-8bbc-7dd29f6b6dc2" />
