### PR TITLE
Ikoka Stick: Use New Companion UI. Fix repeater & room server roles.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 # usage
 # sh build.sh build-firmware RAK_4631_Repeater
 # sh build.sh build-firmwares
+# sh build.sh build-matching-firmwares RAK_4631
 # sh build.sh build-companion-firmwares
 # sh build.sh build-repeater-firmwares
 # sh build.sh build-room-server-firmwares
@@ -144,6 +145,16 @@ mkdir -p out
 if [[ $1 == "build-firmware" ]]; then
   if [ "$2" ]; then
     build_firmware $2
+  else
+    echo "usage: $0 build-firmware <target>"
+    exit 1
+  fi
+elif [[ $1 == "build-matching-firmwares" ]]; then
+  if [ "$2" ]; then
+     build_all_firmwares_matching $2
+  else
+     echo "usage: $0 build-matching-firmwares <build-match-spec>"
+    exit 1
   fi
 elif [[ $1 == "build-firmwares" ]]; then
   build_firmwares

--- a/variants/ikoka_stick_nrf/ikoka_stick_nrf_board.h
+++ b/variants/ikoka_stick_nrf/ikoka_stick_nrf_board.h
@@ -29,10 +29,10 @@ public:
 
 #if defined(P_LORA_TX_LED)
   void onBeforeTransmit() override {
-    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED on
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
   }
   void onAfterTransmit() override {
-    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED off
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
   }
 #endif
 

--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -55,6 +55,7 @@ build_flags = ${nrf52840_xiao.build_flags}
 build_src_filter = ${nrf52840_xiao.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/sensors>
+  +<helpers/ui/MomentaryButton.cpp>
   +<helpers/ui/SSD1306Display.cpp>
   +<../variants/ikoka_stick_nrf>
 debug_tool = jlink
@@ -68,12 +69,14 @@ build_flags =
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=256
+  -I examples/companion_radio/ui-new
 ;  -D BLE_DEBUG_LOGGING=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
-  +<../examples/companion_radio>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${ikoka_stick_nrf.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -84,11 +87,13 @@ build_flags =
   ${ikoka_stick_nrf.build_flags}
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
+  -I examples/companion_radio/ui-new
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
-  +<../examples/companion_radio>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${ikoka_stick_nrf.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -106,7 +111,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
-  +<../examples/simple_repeater>
+  +<../examples/simple_repeater/*.cpp>
 
 [env:ikoka_stick_nrf_room_server]
 extends = ikoka_stick_nrf
@@ -119,4 +124,4 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ikoka_stick_nrf.build_src_filter}
-  +<../examples/simple_room_server>
+  +<../examples/simple_room_server/*.cpp>

--- a/variants/ikoka_stick_nrf/target.cpp
+++ b/variants/ikoka_stick_nrf/target.cpp
@@ -6,6 +6,7 @@ ikoka_stick_nrf_board board;
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
 #endif
 
 RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);

--- a/variants/ikoka_stick_nrf/target.h
+++ b/variants/ikoka_stick_nrf/target.h
@@ -11,7 +11,9 @@
 
 #ifdef DISPLAY_CLASS
   #include <helpers/ui/SSD1306Display.h>
+  #include <helpers/ui/MomentaryButton.h>
   extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
 #endif
 
 extern ikoka_stick_nrf_board board;


### PR DESCRIPTION
Ikoka Stick: Use new UI, make repeater & room server work

    * Enable the new UI on the BLE and USB Companion roles.
    * Fix compilation issues with the repeater and room server roles.
    * Remove ESP32-related alternate pinout cruft from the NRF build tree.
    * build.sh: add build-matching-firmwares command to allow e.g. building all roles for a given variant by passing the variant name.
