### PR TITLE
t1000: wait for button release before powering off

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -84,12 +84,21 @@ public:
         digitalWrite(PIN_3V3_EN, LOW);
     #endif
 
+    // set led on and wait for button release before poweroff
+    #ifdef LED_PIN
+    digitalWrite(LED_PIN, HIGH);
+    #endif
+    #ifdef BUTTON_PIN
+    while(digitalRead(BUTTON_PIN));
+    #endif
     #ifdef LED_PIN
     digitalWrite(LED_PIN, LOW);
     #endif
+
     #ifdef BUTTON_PIN
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_HIGH);
     #endif
+
     sd_power_system_off();
   }
 


### PR DESCRIPTION
Wanted to make this as simple as possible

As the t1000 will wake on button press, wait for button to be released before powering off

To show that power off has been acked, the led is on until button release ...