### PR TITLE
Add Elecrow CRT01262M variant and display/IRQ improvements

### DIFF
--- a/src/helpers/radiolib/CustomSX1276.h
+++ b/src/helpers/radiolib/CustomSX1276.h
@@ -87,4 +87,42 @@ class CustomSX1276 : public SX1276 {
       }
       return 0; // timed out
     }
+
+    // IRQ polling helpers for SX127x when DIO0 is not connected
+    // RegIrqFlags address (SX127x): 0x12
+    // Bit masks for key IRQ flags
+    #ifndef SX127X_IRQ_TX_DONE
+      #define SX127X_IRQ_TX_DONE             0x08
+    #endif
+    #ifndef SX127X_IRQ_RX_DONE
+      #define SX127X_IRQ_RX_DONE             0x40
+    #endif
+    #ifndef SX127X_IRQ_PAYLOAD_CRC_ERROR
+      #define SX127X_IRQ_PAYLOAD_CRC_ERROR   0x20
+    #endif
+    #ifndef SX127X_IRQ_VALID_HEADER
+      #define SX127X_IRQ_VALID_HEADER        0x10
+    #endif
+    #ifndef SX127X_IRQ_RX_TIMEOUT
+      #define SX127X_IRQ_RX_TIMEOUT          0x80
+    #endif
+    #ifndef SX127X_IRQ_CAD_DONE
+      #define SX127X_IRQ_CAD_DONE            0x04
+    #endif
+    #ifndef SX127X_IRQ_CAD_DETECTED
+      #define SX127X_IRQ_CAD_DETECTED        0x01
+    #endif
+    #ifndef SX127X_IRQ_FHSS_CHANGE_CHANNEL
+      #define SX127X_IRQ_FHSS_CHANGE_CHANNEL 0x02
+    #endif
+
+    // Read RegIrqFlags (0x12)
+    uint8_t getIRQFlags() {
+      return this->mod->SPIreadRegister(0x12);
+    }
+
+    // Clear specific IRQ bits by writing 1s to RegIrqFlags
+    void clearIrqFlags(uint8_t mask) {
+      this->mod->SPIwriteRegister(0x12, mask);
+    }
 };

--- a/src/helpers/ui/ST7735Display.cpp
+++ b/src/helpers/ui/ST7735Display.cpp
@@ -4,8 +4,21 @@
   #define DISPLAY_ROTATION 2
 #endif
 
-#define SCALE_X  1.25f     // 160 / 128
-#define SCALE_Y  1.25f      // 80 / 64
+#ifndef DISPLAY_SCALE_X
+  #define DISPLAY_SCALE_X  1.25f
+#endif
+#ifndef DISPLAY_SCALE_Y
+  #define DISPLAY_SCALE_Y  1.25f
+#endif
+#define SCALE_X DISPLAY_SCALE_X
+#define SCALE_Y DISPLAY_SCALE_Y
+
+#ifndef TFT_OFFSET_X
+  #define TFT_OFFSET_X 0
+#endif
+#ifndef TFT_OFFSET_Y
+  #define TFT_OFFSET_Y 0
+#endif
 
 bool ST7735Display::i2c_probe(TwoWire& wire, uint8_t addr) {
   return true;
@@ -22,15 +35,41 @@ bool ST7735Display::begin() {
 
     pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
     digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+#if defined(PIN_TFT_RST) && (PIN_TFT_RST >= 0)
     digitalWrite(PIN_TFT_RST, HIGH);
+#endif
 
+  #ifdef DISPLAY_INITR
+    display.initR(DISPLAY_INITR);
+  #else
     display.initR(INITR_MINI160x80_PLUGIN);
+  #endif
     display.setRotation(DISPLAY_ROTATION);
     display.setSPISpeed(40000000);
     display.fillScreen(ST77XX_BLACK);
     display.setTextColor(ST77XX_WHITE);
-    display.setTextSize(2); 
+    display.setTextSize(1);
     display.cp437(true);         // Use full 256 char 'Code Page 437' font
+  
+  #if defined(DISPLAY_CENTER_CONTENT)
+    #ifndef DISPLAY_PANEL_W
+      #define DISPLAY_PANEL_W 160
+    #endif
+    #ifndef DISPLAY_PANEL_H
+      #define DISPLAY_PANEL_H 80
+    #endif
+    const float physicalW = (float)DISPLAY_PANEL_W;
+    const float physicalH = (float)DISPLAY_PANEL_H;
+    const float logicalW = 128.0f * SCALE_X;
+    const float logicalH = 64.0f * SCALE_Y;
+    float offX = (physicalW - logicalW) * 0.5f;
+    float offY = (physicalH - logicalH) * 0.5f;
+    _offsetX = (int16_t)(offX + 0.5f) + TFT_OFFSET_X;
+    _offsetY = (int16_t)(offY + 0.5f) + TFT_OFFSET_Y;
+  #else
+    _offsetX = TFT_OFFSET_X;
+    _offsetY = TFT_OFFSET_Y;
+  #endif
   
     _isOn = true;
   }
@@ -44,7 +83,9 @@ void ST7735Display::turnOn() {
 void ST7735Display::turnOff() {
   if (_isOn) {
     digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+  #if defined(PIN_TFT_RST) && (PIN_TFT_RST >= 0)
     digitalWrite(PIN_TFT_RST, LOW);
+  #endif
     digitalWrite(PIN_TFT_LEDA_CTL, LOW);
     _isOn = false;
 
@@ -58,9 +99,9 @@ void ST7735Display::clear() {
 }
 
 void ST7735Display::startFrame(Color bkg) {
-  display.fillScreen(0x00);
+  display.fillScreen(ST77XX_BLACK);
   display.setTextColor(ST77XX_WHITE);
-  display.setTextSize(1);      // This one affects size of Please wait... message
+  display.setTextSize(1);
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 }
 
@@ -99,7 +140,7 @@ void ST7735Display::setColor(Color c) {
 }
 
 void ST7735Display::setCursor(int x, int y) {
-  display.setCursor(x*SCALE_X, y*SCALE_Y);
+  display.setCursor((x*SCALE_X) + _offsetX, (y*SCALE_Y) + _offsetY);
 }
 
 void ST7735Display::print(const char* str) {
@@ -107,22 +148,24 @@ void ST7735Display::print(const char* str) {
 }
 
 void ST7735Display::fillRect(int x, int y, int w, int h) {
-  display.fillRect(x*SCALE_X, y*SCALE_Y, w*SCALE_X, h*SCALE_Y, _color);
+  display.fillRect((x*SCALE_X) + _offsetX, (y*SCALE_Y) + _offsetY, w*SCALE_X, h*SCALE_Y, _color);
 }
 
 void ST7735Display::drawRect(int x, int y, int w, int h) {
-  display.drawRect(x*SCALE_X, y*SCALE_Y, w*SCALE_X, h*SCALE_Y, _color);
+  display.drawRect((x*SCALE_X) + _offsetX, (y*SCALE_Y) + _offsetY, w*SCALE_X, h*SCALE_Y, _color);
 }
 
 void ST7735Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
-  display.drawBitmap(x*SCALE_X, y*SCALE_Y, bits, w, h, _color);
+  display.drawBitmap((x*SCALE_X) + _offsetX, (y*SCALE_Y) + _offsetY, bits, w, h, _color);
 }
 
 uint16_t ST7735Display::getTextWidth(const char* str) {
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
-  return w / SCALE_X;
+  uint16_t logical = (uint16_t)(w / SCALE_X);
+  if (logical > width()) logical = width();
+  return logical;
 }
 
 void ST7735Display::endFrame() {

--- a/src/helpers/ui/ST7735Display.h
+++ b/src/helpers/ui/ST7735Display.h
@@ -12,6 +12,8 @@ class ST7735Display : public DisplayDriver {
   bool _isOn;
   uint16_t _color;
   RefCountedDigitalPin* _peripher_power;
+  int16_t _offsetX;
+  int16_t _offsetY;
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:
@@ -21,6 +23,8 @@ public:
       _peripher_power(peripher_power)
   {
     _isOn = false;
+    _offsetX = 0;
+    _offsetY = 0;
   }
 #else
   ST7735Display(RefCountedDigitalPin* peripher_power=NULL) : DisplayDriver(128, 64),
@@ -28,6 +32,8 @@ public:
       _peripher_power(peripher_power)
   {
     _isOn = false;
+    _offsetX = 0;
+    _offsetY = 0;
   }
 #endif
   bool begin();

--- a/variants/elecrow_crt01262m/platformio.ini
+++ b/variants/elecrow_crt01262m/platformio.ini
@@ -1,0 +1,118 @@
+﻿[elecrow_crt01262m_base]
+extends = esp32_base
+board = esp32dev
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/elecrow_crt01262m
+  -D RADIO_CLASS=CustomSX1276
+  -D WRAPPER_CLASS=CustomSX1276Wrapper
+  -D LORA_TX_POWER=20
+  ; SX127x pin mapping per elecrow_crt01262m.md
+  -D P_LORA_DIO_0=RADIOLIB_NC
+  -D P_LORA_DIO_1=34
+  -D P_LORA_NSS=14
+  -D P_LORA_RESET=12
+  -D P_LORA_BUSY=RADIOLIB_NC
+  -D P_LORA_SCLK=33
+  -D P_LORA_MISO=35
+  -D P_LORA_MOSI=32
+  ; ST7735S display pins
+  -D PIN_TFT_CS=2
+  -D PIN_TFT_DC=4
+  -D PIN_TFT_SDA=32
+  -D PIN_TFT_SCL=33
+  -D PIN_TFT_RST=-1
+  -D USE_PIN_TFT=1
+  -D PIN_TFT_LEDA_CTL=16
+  -D DISPLAY_INITR=INITR_GREENTAB
+  -D DISPLAY_PANEL_W=128
+  -D DISPLAY_PANEL_H=160
+  -D DISPLAY_CENTER_CONTENT=1
+  -D DISPLAY_SCALE_X=0.95f
+  -D DISPLAY_SCALE_Y=2.40f
+  ; Board specific IO
+  -D PIN_LED_BUILTIN=5
+  -D PIN_USER_BTN=0
+  ; Enable IRQ polling mode for SX127x (DIO0 not connected)
+  -D RF95_USE_POLLING=1
+  ; Optional current limit for SX127x PA
+  -D SX127X_CURRENT_LIMIT=120
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/elecrow_crt01262m>
+lib_deps =
+  ${esp32_base.lib_deps}
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
+
+[env:elecrow_crt01262m_repeater]
+extends = elecrow_crt01262m_base
+build_flags =
+  ${elecrow_crt01262m_base.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D DISPLAY_ROTATION=0
+  -D DISPLAY_INITR=INITR_GREENTAB
+  -D DISPLAY_PANEL_W=128
+  -D DISPLAY_PANEL_H=160
+  -D DISPLAY_CENTER_CONTENT=1
+  -D DISPLAY_SCALE_X=0.95f
+  -D DISPLAY_SCALE_Y=2.40f
+  -D ADVERT_NAME='"Elecrow CRT01262M Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+build_src_filter = ${elecrow_crt01262m_base.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${elecrow_crt01262m_base.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:elecrow_crt01262m_room_server]
+extends = elecrow_crt01262m_base
+build_flags =
+  ${elecrow_crt01262m_base.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D DISPLAY_ROTATION=0
+  -D DISPLAY_INITR=INITR_GREENTAB
+  -D DISPLAY_PANEL_W=128
+  -D DISPLAY_PANEL_H=160
+  -D DISPLAY_CENTER_CONTENT=1
+  -D DISPLAY_SCALE_X=0.95f
+  -D DISPLAY_SCALE_Y=2.40f
+  -D ADVERT_NAME='"Elecrow CRT01262M Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+build_src_filter = ${elecrow_crt01262m_base.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${elecrow_crt01262m_base.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:elecrow_crt01262m_companion_radio_ble]
+extends = elecrow_crt01262m_base
+build_flags =
+  ${elecrow_crt01262m_base.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D DISPLAY_ROTATION=0
+  -D DISPLAY_INITR=INITR_GREENTAB
+  -D DISPLAY_PANEL_W=128
+  -D DISPLAY_PANEL_H=160
+  -D DISPLAY_CENTER_CONTENT=1
+  -D DISPLAY_SCALE_X=0.95f
+  -D DISPLAY_SCALE_Y=2.40f
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+board_build.partitions = huge_app.csv
+build_src_filter = ${elecrow_crt01262m_base.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/ST7735Display.cpp>
+  +<../examples/companion_radio>
+lib_deps =
+  ${elecrow_crt01262m_base.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+

--- a/variants/elecrow_crt01262m/target.cpp
+++ b/variants/elecrow_crt01262m/target.cpp
@@ -1,0 +1,55 @@
+﻿#include <Arduino.h>
+#include "target.h"
+
+ESP32Board board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi;
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_0 /* DIO0 NC */, P_LORA_RESET, P_LORA_DIO_1 /* use DIO1 pin param as RadioLib "gpio" for SX127x */ , spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_0 /* DIO0 NC */, P_LORA_RESET, P_LORA_DIO_1 /* use DIO1 pin param as RadioLib "gpio" for SX127x */);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}
+
+

--- a/variants/elecrow_crt01262m/target.h
+++ b/variants/elecrow_crt01262m/target.h
@@ -1,0 +1,29 @@
+﻿#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/ESP32Board.h>
+#include <helpers/radiolib/CustomSX1276Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/ST7735Display.h>
+#endif
+
+extern ESP32Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();
+
+


### PR DESCRIPTION
Introduces a new hardware variant for the Elecrow CRT01262M, including platformio configuration and target initialization files. Enhances ST7735Display with configurable scaling, centering, and offset support, and adds SX127x IRQ polling helpers for use when DIO0 is not connected. Updates RadioLibWrapper to support IRQ polling mode, improving compatibility with hardware lacking DIO0.