### PR TITLE
Refactor packet scoring to use airtime

### DIFF
--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -14,9 +14,5 @@ public:
   }
   float getLastRSSI() const override { return ((CustomLLCC68 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLLCC68 *)_radio)->getSNR(); }
-
-  float packetScore(float snr, int packet_len) override {
-    int sf = ((CustomLLCC68 *)_radio)->spreadingFactor;
-    return packetScoreInt(snr, sf, packet_len);
-  }
+  int getCurrentSF() const override { return ((CustomLLCC68 *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -23,4 +23,5 @@ public:
   float getLastRSSI() const override { return ((CustomLR1110 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLR1110 *)_radio)->getSNR(); }
   int16_t setRxBoostedGainMode(bool en) { return ((CustomLR1110 *)_radio)->setRxBoostedGainMode(en); };
+  int getCurrentSF() const override { return ((CustomLR1110 *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -15,9 +15,5 @@ public:
   }
   float getLastRSSI() const override { return ((CustomSTM32WLx *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSTM32WLx *)_radio)->getSNR(); }
-
-  float packetScore(float snr, int packet_len) override {
-    int sf = ((CustomSTM32WLx *)_radio)->spreadingFactor;
-    return packetScoreInt(snr, sf, packet_len);
-  }
+  int getCurrentSF() const override { return ((CustomSTM32WLx *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -14,9 +14,5 @@ public:
   }
   float getLastRSSI() const override { return ((CustomSX1262 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1262 *)_radio)->getSNR(); }
-
-  float packetScore(float snr, int packet_len) override {
-    int sf = ((CustomSX1262 *)_radio)->spreadingFactor;
-    return packetScoreInt(snr, sf, packet_len);
-  }
+  int getCurrentSF() const override { return ((CustomSX1262 *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -14,9 +14,5 @@ public:
   }
   float getLastRSSI() const override { return ((CustomSX1268 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1268 *)_radio)->getSNR(); }
-
-  float packetScore(float snr, int packet_len) override {
-    int sf = ((CustomSX1268 *)_radio)->spreadingFactor;
-    return packetScoreInt(snr, sf, packet_len);
-  }
+  int getCurrentSF() const override { return ((CustomSX1268 *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -14,9 +14,5 @@ public:
   }
   float getLastRSSI() const override { return ((CustomSX1276 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1276 *)_radio)->getSNR(); }
-
-  float packetScore(float snr, int packet_len) override {
-    int sf = ((CustomSX1276 *)_radio)->spreadingFactor;
-    return packetScoreInt(snr, sf, packet_len);
-  }
+  int getCurrentSF() const override { return ((CustomSX1276 *)_radio)->spreadingFactor; }
 };

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -14,7 +14,7 @@ protected:
 
   void idle();
   void startRecv();
-  float packetScoreInt(float snr, int sf, int packet_len);
+  float packetScoreByAirtime(float snr, int sf, uint32_t airtime_ms);
   virtual bool isReceivingPacket() =0;
 
 public:
@@ -50,7 +50,9 @@ public:
   virtual float getLastRSSI() const override;
   virtual float getLastSNR() const override;
 
-  float packetScore(float snr, int packet_len) override { return packetScoreInt(snr, 10, packet_len); }  // assume sf=10
+  // Default assumed SF=10, kept as fallback for backward compatibility.
+  virtual int getCurrentSF() const { return 10; }
+  float packetScore(float snr, int packet_len) override { return packetScoreByAirtime(snr, getCurrentSF(), getEstAirtimeFor(packet_len)); }
 };
 
 /**


### PR DESCRIPTION
Replaces the packetScoreInt method with packetScoreByAirtime, which penalizes based on time-on-air instead of packet length.

**_Note:_** SF was also hardcoded to 10