### PR TITLE
[companion] Emit error when radio init fails

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -104,7 +104,20 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  if (!radio_init()) {
+#ifdef DISPLAY_CLASS
+  if (disp != NULL) {
+    disp->startFrame();
+    disp->clear();
+    disp->setCursor(0, 0);
+    disp->print("Radio init failure!");
+    disp->setCursor(0, 12);
+    disp->print("Device might be flashed with incompatible firmware.");
+    disp->endFrame();
+  }
+#endif
+    halt();
+  }
 
   fast_rng.begin(radio_get_rng_seed());
 


### PR DESCRIPTION
# Problem

When the example companion app inits, it will print `Please wait...`, attempt radio init, and then silently halt on radio init failure. The absence of error logging means that users can't determine if they've flashed the wrong firmware or if the radio has gotten hung during initialization.

# Solution

Print a failure message on radio init failure.