### PR TITLE
Station G2: Adds repeater variant with packet logging on

### DIFF
--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -45,6 +45,25 @@ lib_deps =
   ${Station_G2.lib_deps}
   ${esp32_ota.lib_deps}
 
+[env:Station_G2_logging_repeater]
+extends = Station_G2
+build_flags =
+  ${Station_G2.build_flags}
+  -D ADVERT_NAME='"Station G2 Logging Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+  -D MESH_PACKET_LOGGING=1
+  -D SX126X_RX_BOOSTED_GAIN=1
+;  https://wiki.uniteng.com/en/meshtastic/station-g2#impact-of-lora-node-dense-areashigh-noise-environments-on-rf-performance
+;  -D MESH_DEBUG=1
+build_src_filter = ${Station_G2.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Station_G2.lib_deps}
+  ${esp32_ota.lib_deps}
+
 [env:Station_G2_room_server]
 extends = Station_G2
 build_src_filter = ${Station_G2.build_src_filter}


### PR DESCRIPTION
Adds a variant to Station G2 which turns on mesh packet logging to serial. Useful for telemetry logging. Sites such as map.w0z.is depend on this functionality (in combination with Cisien's scripts).