### PR TITLE
SensorMesh: handleIncomingMsg from admin

### DIFF
--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -140,7 +140,8 @@ protected:
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;
-
+  virtual bool handleIncomingMsg(ContactInfo& from, uint32_t timestamp, uint8_t* data, uint flags, size_t len);
+  void sendAckTo(const ContactInfo& dest, uint32_t ack_hash);
 private:
   FILESYSTEM* _fs;
   unsigned long next_local_advert, next_flood_advert;


### PR DESCRIPTION
I've been using this in custom firmware since last week

Not exactly a "sensor" feature, but it gives the possibility to receive msgs (my use has been to relay them on serial port or display them on screen).

By default, messages are ignored as before, but by overloading handleIncomingMsg you can treat the messages. If the function returns `true`, an ack is sent back to the sender (I've reused the ack logic from BaseChat).

See how its used in 
* https://github.com/fdlamotte/MCSerialGW/blob/c757c345cc8beb993bdb9d52727220eaf7e20de0/src/main.cpp#L60-L69
* https://github.com/fdlamotte/MCDisplay/blob/61010fd8440716f682288de73dd1a5fcdcb3723a/src/main.cpp#L76-L89

I was not sure about pushing this, this are not "really" sensors features, but the sensor type was the closest in behaviour + I'm not really in favor of multiplying the types of nodes and features from sensor mesh are really interesting for this kind of job (I think they are necessary for any "autonomous" device, repeaters too).

The good part of that is that it worked out of the box with the whole current ecosystem, including closed parts ... and interaction with tdeck is great ! (well tdeck can't send msgs to sensors)