### PR TITLE
Improving T114 power consumption

### DIFF
--- a/src/helpers/nrf52/T114Board.cpp
+++ b/src/helpers/nrf52/T114Board.cpp
@@ -26,6 +26,45 @@ void T114Board::begin() {
 
   pinMode(PIN_VBAT_READ, INPUT);
 
+  // Enable SoftDevice low-power mode
+  sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
+
+  // Enable DC/DC converter for better efficiency (REG1 stage)
+  NRF_POWER->DCDCEN = 1;
+
+  // Power down unused communication peripherals
+  // UART1 - Not used on T114
+  NRF_UARTE1->ENABLE = 0;
+
+  // SPIM2/SPIS2 - Not used (SPI is on SPIM0)
+  NRF_SPIM2->ENABLE = 0;
+  NRF_SPIS2->ENABLE = 0;
+
+  // TWI1 (I2C1) - Not used (I2C is on TWI0)
+  NRF_TWIM1->ENABLE = 0;
+  NRF_TWIS1->ENABLE = 0;
+
+  // PWM modules - Not used for standard T114 functions
+  NRF_PWM1->ENABLE = 0;
+  NRF_PWM2->ENABLE = 0;
+  NRF_PWM3->ENABLE = 0;
+
+  // PDM (Digital Microphone Interface) - Not used
+  NRF_PDM->ENABLE = 0;
+
+  // I2S - Not used
+  NRF_I2S->ENABLE = 0;
+
+  // QSPI - Not used (no external flash)
+  NRF_QSPI->ENABLE = 0;
+
+  // Disable unused analog peripherals
+  // SAADC channels - only keep what's needed for battery monitoring
+  NRF_SAADC->ENABLE = 0;  // Re-enable only when needed for measurements
+
+  // COMP - Comparator not used
+  NRF_COMP->ENABLE = 0;
+
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
   Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
 #endif

--- a/src/helpers/nrf52/T114Board.h
+++ b/src/helpers/nrf52/T114Board.h
@@ -40,6 +40,9 @@ public:
 
   uint16_t getBattMilliVolts() override {
     int adcvalue = 0;
+
+    NRF_SAADC->ENABLE = 1;
+
     analogReadResolution(12);
     analogReference(AR_INTERNAL_3_0);
     pinMode(PIN_BAT_CTL, OUTPUT);          // battery adc can be read only ctrl pin 6 set to high
@@ -48,6 +51,8 @@ public:
     delay(10);
     adcvalue = analogRead(PIN_VBAT_READ);
     digitalWrite(6, 0);
+
+    NRF_SAADC->ENABLE = 0;
 
     return (uint16_t)((float)adcvalue * MV_LSB * 4.9);
   }


### PR DESCRIPTION
This change addresses the low-hanging-fruit of power optimization: disabling unused hardware and peripherals in the CPU, and enabling the nRF's `sd_power_mode_set(NRF_POWER_MODE_LOWPWR);` mode.

This code has been tested for multiple days on a T114 as a Bluetooth companion, and found to perform identically compared to before these changes were made.  It has not yet been tested as a repeater or room server, though there should be no difference in performance under those roles.

This change takes my test hardware's standby (screen off, GPS off, receiving normally; what happens when you leave the node alone until the screen times out) power consumption from about 22 mA to about 17 mA.  This represents about a 20% reduction in power consumption, which is significant, given how much of the time nodes spend in this state.  Power consumption is reduced by a similar 2-3 mA in other states (screen on, or transmitting an advert at 0 dBm).

The risk of this change is very low.  The unused peripherals aren't in use, so powering them is just heating the board for no benefit.  The LOWPWR mode is used in a few other boards, including the T1000e.

These changes could easily be made to other nRF boards.  The LOWPWR mode is probably providing most of the benefit, and could be applied across all nRF-based devices with little risk, though obviously this change should be tested in the real world on the impacted hardware before it's rolled out across the codebase.