### PR TITLE
Add new UI to Heltec v3 WiFi Companion

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -129,6 +129,7 @@ lib_deps =
 extends = Heltec_lora32_v3
 build_flags =
   ${Heltec_lora32_v3.build_flags}
+  -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D DISPLAY_CLASS=SSD1306Display
@@ -141,7 +142,8 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<helpers/esp32/*.cpp>
-  +<../examples/companion_radio>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
Heltec v3 WiFi companion was failing to build due to missing `UITask.h`. Might as well migrate to the new UI. It should be noted the UI to toggle BLE is visible for the WiFi companion firmware, but we should still get this fix merged before a new release.