### PR TITLE
WiFi Companion: always accept new connections

### DIFF
--- a/src/helpers/esp32/SerialWifiInterface.cpp
+++ b/src/helpers/esp32/SerialWifiInterface.cpp
@@ -44,7 +44,18 @@ bool SerialWifiInterface::isWriteBusy() const {
 }
 
 size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
-  if (!client) client = server.available();
+  // check if new client connected
+  auto newClient = server.available();
+  if (newClient) {
+
+    // disconnect existing client
+    deviceConnected = false;
+    client.stop();
+
+    // switch active connection to new client
+    client = newClient;
+    
+  }
 
   if (client.connected()) {
     if (!deviceConnected) {


### PR DESCRIPTION
This PR fixes the issue described in #670.

Currently, when a client connects to a WiFi Companion, the firmware will not accept any new connections until the current client disconnects. This can be problematic if the connection is lost without it being noticed. The board can get stuck in a state where it won't accept new connections until a reboot.

This change disconnects any existing connection, and the new connection is allowed to take place.

I've tested this by connecting to WiFi Companion via Mac, then connecting via Android, which correctly disconnects the Mac and allows the Android to connect. I've also tested connecting via WiFi, then killing the app, and reconnecting via a VPN.

Connections appear to work more reliably this way. As mentioned in the linked issue, I also prefer this behaviour of disconnecting the existing client.