### PR TITLE
SX127x Polling IRQ Support

### DIFF
--- a/src/helpers/radiolib/CustomSX1276.h
+++ b/src/helpers/radiolib/CustomSX1276.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RadioLib.h>
+#include <Arduino.h>
 
 #define RH_RF95_MODEM_STATUS_CLEAR               0x10
 #define RH_RF95_MODEM_STATUS_HEADER_INFO_VALID   0x08
@@ -36,10 +37,11 @@ class CustomSX1276 : public SX1276 {
         spi->begin();
       }
     #else
-      if (spi) spi->begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+      if (spi) spi->begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI, P_LORA_NSS);
     #endif
   #endif
-      int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16);
+
+      int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX127X_SYNC_WORD, LORA_TX_POWER, 16);
       // if radio init fails with -707/-706, try again with tcxo voltage set to 0.0f
       if (status != RADIOLIB_ERR_NONE) {
         Serial.print("ERROR: radio init failed: ");

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -19,4 +19,54 @@ public:
     int sf = ((CustomSX1276 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);
   }
+
+  // Poll RadioLib IRQ flags to simulate ISR on DIO0-less boards
+  void pollIrq() override {
+  #if defined(SX127X_USE_POLLING)
+    // Read raw IRQ flags from SX127x
+    uint16_t irq = ((SX1276 *)_radio)->getIRQFlags();
+    if (irq == 0) return;
+
+    // Bit masks per Semtech SX1276 datasheet
+    constexpr uint8_t SX127X_IRQ_RX_DONE            = 0x40;
+    constexpr uint8_t SX127X_IRQ_TX_DONE            = 0x08;
+    constexpr uint8_t SX127X_IRQ_PAYLOAD_CRC_ERROR  = 0x20;
+    constexpr uint8_t SX127X_IRQ_VALID_HEADER       = 0x10;
+    constexpr uint8_t SX127X_IRQ_CAD_DONE           = 0x04;
+    constexpr uint8_t SX127X_IRQ_FHSS_CHANGE_CH     = 0x02;
+    constexpr uint8_t SX127X_IRQ_CAD_DETECTED       = 0x01;
+    constexpr uint8_t SX127X_IRQ_RX_TIMEOUT         = 0x80;
+
+    bool txDoneBit = (irq & SX127X_IRQ_TX_DONE) != 0;
+    bool rxDoneBit = (irq & SX127X_IRQ_RX_DONE) != 0;
+    bool validHeaderBit = (irq & SX127X_IRQ_VALID_HEADER) != 0;
+
+    if (txDoneBit) {
+      ((SX1276 *)_radio)->clearIrqFlags(SX127X_IRQ_TX_DONE);
+      notifyISR();
+      return;
+    }
+
+    // RX done: do not clear here
+    if (rxDoneBit) {
+      notifyISR();
+      return;
+    }
+
+    // Cleanup non-terminal flags
+    uint8_t cleanupMask = 0x00;
+    if (irq & SX127X_IRQ_PAYLOAD_CRC_ERROR)    cleanupMask |= SX127X_IRQ_PAYLOAD_CRC_ERROR;
+    if (irq & SX127X_IRQ_RX_TIMEOUT)           cleanupMask |= SX127X_IRQ_RX_TIMEOUT;
+    if (irq & SX127X_IRQ_CAD_DONE)             cleanupMask |= SX127X_IRQ_CAD_DONE;
+    if (irq & SX127X_IRQ_CAD_DETECTED)         cleanupMask |= SX127X_IRQ_CAD_DETECTED;
+    if (irq & SX127X_IRQ_FHSS_CHANGE_CH)       cleanupMask |= SX127X_IRQ_FHSS_CHANGE_CH;
+    if (cleanupMask) {
+      ((SX1276 *)_radio)->clearIrqFlags(cleanupMask);
+    }
+
+    if (validHeaderBit) {
+      MESH_DEBUG_PRINTLN("SX1276 poll: VALID_HEADER seen, waiting for RX_DONE...");
+    }
+  #endif
+  }
 };

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -16,6 +16,9 @@ protected:
   void startRecv();
   float packetScoreInt(float snr, int sf, int packet_len);
   virtual bool isReceivingPacket() =0;
+ 
+  void notifyISR();
+  virtual void pollIrq() { }
 
 public:
   RadioLibWrapper(PhysicalLayer& radio, mesh::MainBoard& board) : _radio(&radio), _board(&board) { n_recv = n_sent = 0; }


### PR DESCRIPTION
This PR adds support for polling SX127x IRQ flags, enabling MeshCore to run on boards that do not have DIO0 connected to the MCU.

I am currently running this in the custom variant of a Elecrow CRT01262M, which i could also add once this has been merged / accepted.

https://www.elecrow.com/wiki/lora-basic-gateway-module.html
https://www.elecrow.com/lorawan-gateway-module-based-on-esp32-1-channel-for-long-range-communication.html