### PR TITLE
ThinkNode M1: low battery auto shutdown

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -551,7 +551,22 @@ void UITask::loop() {
   if (millis() > next_batt_chck) {
     uint16_t milliVolts = getBattMilliVolts();
     if (milliVolts > 0 && milliVolts < AUTO_SHUTDOWN_MILLIVOLTS) {
+
+      // show low battery shutdown alert
+      // we should only do this for eink displays, which will persist after power loss
+      #ifdef THINKNODE_M1
+      if (_display != NULL) {
+        _display->startFrame();
+        _display->setTextSize(2);
+        _display->setColor(DisplayDriver::RED);
+        _display->drawTextCentered(_display->width() / 2, 20, "Low Battery.");
+        _display->drawTextCentered(_display->width() / 2, 40, "Shutting Down!");
+        _display->endFrame();
+      }
+      #endif
+
       shutdown();
+
     }
     next_batt_chck = millis() + 8000;
   }

--- a/src/helpers/nrf52/ThinkNodeM1Board.h
+++ b/src/helpers/nrf52/ThinkNodeM1Board.h
@@ -57,6 +57,14 @@ public:
   }
 
   void powerOff() override {
+
+    // turn off all leds, sd_power_system_off will not do this for us
+    #ifdef P_LORA_TX_LED
+    digitalWrite(P_LORA_TX_LED, LOW);
+    #endif
+
+    // power off board
     sd_power_system_off();
+
   }
 };

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -77,6 +77,7 @@ build_flags =
   -D DISPLAY_CLASS=GxEPDDisplay
   -D OFFLINE_QUEUE_SIZE=256
   -D PIN_BUZZER=6
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M1.build_src_filter}


### PR DESCRIPTION
This PR enables automatic shutdown when the ThinkNode M1 battery hits 3.3v or less.
We want to avoid writing to flash when voltage is low, as it can lead to file system corruption.

It also shows a `Low Battery. Shutting Down!` message on screen before it shuts down.

Since this is an eink display, it will persist after power loss. This is gated behind an `#ifdef THINKNODE_M1` as I don't have other eink displays to test the aesthetics of the font size and spacing.

I noticed the blue status LED was still on when powering down, so this is manually disabled as well.

<img src="https://github.com/user-attachments/assets/44cda31c-531b-486b-bc6a-dba5a083500d" width="200px"/>
