### PR TITLE
Fix: WisMesh Pocket user button

### DIFF
--- a/variants/rak4631/target.cpp
+++ b/variants/rak4631/target.cpp
@@ -10,7 +10,7 @@ RAK4631Board board;
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;
-  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true, true);
 
   #if defined(PIN_USER_BTN_ANA)
   MomentaryButton analog_btn(PIN_USER_BTN_ANA, 1000, 20);


### PR DESCRIPTION
This PR fixes the issue where the user button on the WisMesh Pocket stopped working after migrating to the new `MomentaryButton`.