### PR TITLE
Techo display improvements

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -519,6 +519,14 @@ void UITask::loop() {
     c = handleLongPress(KEY_ENTER);
   }
 #endif
+#if defined(DISP_BACKLIGHT) && defined(BACKLIGHT_BTN)
+  static int next_btn_check = 0;
+  if (millis() > next_btn_check) {
+    bool touch_state = digitalRead(PIN_BUTTON2);
+    digitalWrite(DISP_BACKLIGHT, !touch_state);
+    next_btn_check = millis() + 300;
+  }
+#endif
 
   if (c != 0 && curr) {
     curr->handleInput(c);

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -32,6 +32,12 @@ class UITask : public AbstractUITask {
   UIScreen* msg_preview;
   UIScreen* curr;
 
+#ifdef PIN_STATUS_LED
+int status_led_state = 0;
+int next_status_led_change = 0;
+int last_status_led_increment = 0;
+#endif
+
   void userLedHandler();
   
   // Button action handlers

--- a/src/helpers/ui/GxEPDDisplay.cpp
+++ b/src/helpers/ui/GxEPDDisplay.cpp
@@ -19,6 +19,7 @@ bool GxEPDDisplay::begin() {
   display.fillScreen(GxEPD_WHITE);
   display.display(true);
   #if DISP_BACKLIGHT
+  digitalWrite(DISP_BACKLIGHT, LOW);
   pinMode(DISP_BACKLIGHT, OUTPUT);
   #endif
   _init = true;
@@ -27,14 +28,14 @@ bool GxEPDDisplay::begin() {
 
 void GxEPDDisplay::turnOn() {
   if (!_init) begin();
-#if DISP_BACKLIGHT
+#if defined(DISP_BACKLIGHT) && !defined(BACLIGHT_BTN)
   digitalWrite(DISP_BACKLIGHT, HIGH);
 #endif
   _isOn = true;
 }
 
 void GxEPDDisplay::turnOff() {
-#if DISP_BACKLIGHT
+#if defined(DISP_BACKLIGHT) && !defined(BACKLIGHT_BTN)
   digitalWrite(DISP_BACKLIGHT, LOW);
 #endif
   _isOn = false;

--- a/src/helpers/ui/GxEPDDisplay.cpp
+++ b/src/helpers/ui/GxEPDDisplay.cpp
@@ -28,7 +28,7 @@ bool GxEPDDisplay::begin() {
 
 void GxEPDDisplay::turnOn() {
   if (!_init) begin();
-#if defined(DISP_BACKLIGHT) && !defined(BACLIGHT_BTN)
+#if defined(DISP_BACKLIGHT) && !defined(BACKLIGHT_BTN)
   digitalWrite(DISP_BACKLIGHT, HIGH);
 #endif
   _isOn = true;

--- a/src/helpers/ui/UIScreen.h
+++ b/src/helpers/ui/UIScreen.h
@@ -13,9 +13,13 @@
 class UIScreen {
 protected:
   UIScreen() { }
+  bool _changed = true;
+  bool _entered = true;
 public:
   virtual int render(DisplayDriver& display) =0;   // return value is number of millis until next render
   virtual bool handleInput(char c) { return false; }
   virtual void poll() { }
+  virtual void enter () { _entered = true; }
+  bool has_changed () { return _changed; } 
 };
 

--- a/variants/techo/platformio.ini
+++ b/variants/techo/platformio.ini
@@ -78,6 +78,7 @@ build_flags =
   -D DISPLAY_CLASS=GxEPDDisplay
   -D OFFLINE_QUEUE_SIZE=256
   -D UI_RECENT_LIST_SIZE=9
+  -D BACKLIGHT_BTN=PIN_BUTTON2
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_Techo.build_src_filter}

--- a/variants/techo/platformio.ini
+++ b/variants/techo/platformio.ini
@@ -74,13 +74,15 @@ build_flags =
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
-  -D BLE_DEBUG_LOGGING=1
   -D DISPLAY_CLASS=GxEPDDisplay
+  -D EINK_SCREEN=1
   -D OFFLINE_QUEUE_SIZE=256
   -D UI_RECENT_LIST_SIZE=9
   -D BACKLIGHT_BTN=PIN_BUTTON2
+  -D AUTO_OFF_MILLIS=0
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
+;  -D BLE_DEBUG_LOGGING=1
 build_src_filter = ${LilyGo_Techo.build_src_filter}
   +<helpers/nrf52/TechoBoard.cpp>
   +<helpers/nrf52/SerialBLEInterface.cpp>


### PR DESCRIPTION

Better management of the backlight (using the touch button)

Track changes in a screen
 * _changed (queried with has_changed) is set when a change was found with previous refresh while updating
 * _entered is set when entering (and will force a change)

for the moment, conditional refresh is only enabled when EINK_DISPLAY is defined

when refresh is not performed, the display receives a `startFrame` and no `endFrame`, but that is not really an issue as the buffer is normally cleared with next `startFrame`, maybe some double buffering setups could suffer (hence EINK_DISPLAY)
