### PR TITLE
new-ui: add double/triple clicks, buzzer and gps toggle functions

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -495,6 +495,10 @@ void UITask::loop() {
     c = checkDisplayOn(KEY_SELECT);
   } else if (ev == BUTTON_EVENT_LONG_PRESS) {
     c = handleLongPress(KEY_ENTER);
+  } else if (ev == BUTTON_EVENT_DOUBLE_CLICK) {
+    c = handleDoubleClick(KEY_ENTER);
+  } else if (ev == BUTTON_EVENT_TRIPLE_CLICK) {
+    c = handleTripleClick(KEY_ENTER);
   }
 #endif
 #if defined(WIO_TRACKER_L1)
@@ -604,10 +608,43 @@ char UITask::handleLongPress(char c) {
   return c;
 }
 
-/*
-void UITask::handleButtonTriplePress() {
-  MESH_DEBUG_PRINTLN("UITask: triple press triggered");
-  // Toggle buzzer quiet mode
+char UITask::handleDoubleClick(char c) {
+  MESH_DEBUG_PRINTLN("UITask: double click triggered");
+  c = 0;
+  return c;
+}
+
+char UITask::handleTripleClick(char c) {
+  MESH_DEBUG_PRINTLN("UITask: triple click triggered");
+  toggleBuzzer();
+  c = 0;
+  return c;
+}
+
+void UITask::toggleGPS() {
+    if (_sensors != NULL) {
+    // toggle GPS on/off
+    int num = _sensors->getNumSettings();
+    for (int i = 0; i < num; i++) {
+      if (strcmp(_sensors->getSettingName(i), "gps") == 0) {
+        if (strcmp(_sensors->getSettingValue(i), "1") == 0) {
+          _sensors->setSettingValue("gps", "0");
+          soundBuzzer(UIEventType::ack);
+          showAlert("GPS: Disabled", 600);
+        } else {
+          _sensors->setSettingValue("gps", "1");
+          soundBuzzer(UIEventType::ack);
+          showAlert("GPS: Enabled", 600);
+        }
+        _next_refresh = 0;
+        break;
+      }
+    }
+  }
+}
+
+void UITask::toggleBuzzer() {
+    // Toggle buzzer quiet mode
   #ifdef PIN_BUZZER
     if (buzzer.isQuiet()) {
       buzzer.quiet(false);
@@ -620,4 +657,3 @@ void UITask::handleButtonTriplePress() {
     _next_refresh = 0;  // trigger refresh
   #endif
 }
-*/

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -223,11 +223,11 @@ public:
   }
 
   bool handleInput(char c) override {
-    if (c == KEY_LEFT) {
+    if (c == KEY_LEFT || c == KEY_PREV) {
       _page = (_page + HomePage::Count - 1) % HomePage::Count;
       return true;
     }
-    if (c == KEY_RIGHT || c == KEY_SELECT) {
+    if (c == KEY_NEXT || c == KEY_RIGHT) {
       _page = (_page + 1) % HomePage::Count;
       if (_page == HomePage::RECENT) {
         _task->showAlert("Recent adverts", 800);
@@ -325,7 +325,7 @@ public:
   }
 
   bool handleInput(char c) override {
-    if (c == KEY_SELECT || c == KEY_RIGHT) {
+    if (c == KEY_NEXT || c == KEY_RIGHT) {
       num_unread--;
       if (num_unread == 0) {
         _task->gotoHomeScreen();
@@ -492,13 +492,13 @@ void UITask::loop() {
 #if defined(PIN_USER_BTN)
   int ev = user_btn.check();
   if (ev == BUTTON_EVENT_CLICK) {
-    c = checkDisplayOn(KEY_SELECT);
+    c = checkDisplayOn(KEY_NEXT);
   } else if (ev == BUTTON_EVENT_LONG_PRESS) {
     c = handleLongPress(KEY_ENTER);
   } else if (ev == BUTTON_EVENT_DOUBLE_CLICK) {
-    c = handleDoubleClick(KEY_ENTER);
+    c = handleDoubleClick(KEY_PREV);
   } else if (ev == BUTTON_EVENT_TRIPLE_CLICK) {
-    c = handleTripleClick(KEY_ENTER);
+    c = handleTripleClick(KEY_SELECT);
   }
 #endif
 #if defined(WIO_TRACKER_L1)
@@ -518,9 +518,13 @@ void UITask::loop() {
 #if defined(PIN_USER_BTN_ANA)
   ev = analog_btn.check();
   if (ev == BUTTON_EVENT_CLICK) {
-    c = checkDisplayOn(KEY_SELECT);
+    c = checkDisplayOn(KEY_NEXT);
   } else if (ev == BUTTON_EVENT_LONG_PRESS) {
     c = handleLongPress(KEY_ENTER);
+  } else if (ev == BUTTON_EVENT_DOUBLE_CLICK) {
+    c = handleDoubleClick(KEY_PREV);
+  } else if (ev == BUTTON_EVENT_TRIPLE_CLICK) {
+    c = handleTripleClick(KEY_SELECT);
   }
 #endif
 
@@ -611,7 +615,6 @@ char UITask::handleLongPress(char c) {
 char UITask::handleDoubleClick(char c) {
   MESH_DEBUG_PRINTLN("UITask: double click triggered");
   checkDisplayOn(c);
-  c = 0;
   return c;
 }
 

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -610,12 +610,14 @@ char UITask::handleLongPress(char c) {
 
 char UITask::handleDoubleClick(char c) {
   MESH_DEBUG_PRINTLN("UITask: double click triggered");
+  checkDisplayOn(c);
   c = 0;
   return c;
 }
 
 char UITask::handleTripleClick(char c) {
   MESH_DEBUG_PRINTLN("UITask: triple click triggered");
+  checkDisplayOn(c);
   toggleBuzzer();
   c = 0;
   return c;

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -632,11 +632,11 @@ void UITask::toggleGPS() {
         if (strcmp(_sensors->getSettingValue(i), "1") == 0) {
           _sensors->setSettingValue("gps", "0");
           soundBuzzer(UIEventType::ack);
-          showAlert("GPS: Disabled", 600);
+          showAlert("GPS: Disabled", 800);
         } else {
           _sensors->setSettingValue("gps", "1");
           soundBuzzer(UIEventType::ack);
-          showAlert("GPS: Enabled", 600);
+          showAlert("GPS: Enabled", 800);
         }
         _next_refresh = 0;
         break;
@@ -651,10 +651,10 @@ void UITask::toggleBuzzer() {
     if (buzzer.isQuiet()) {
       buzzer.quiet(false);
       soundBuzzer(UIEventType::ack);
-      showAlert("Buzzer: ON", 600);
+      showAlert("Buzzer: ON", 800);
     } else {
       buzzer.quiet(true);
-      showAlert("Buzzer: OFF", 600);
+      showAlert("Buzzer: OFF", 800);
     }
     _next_refresh = 0;  // trigger refresh
   #endif

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -37,6 +37,8 @@ class UITask : public AbstractUITask {
   // Button action handlers
   char checkDisplayOn(char c);
   char handleLongPress(char c);
+  char handleDoubleClick(char c);
+  char handleTripleClick(char c);
 
   void setCurrScreen(UIScreen* c);
 
@@ -54,6 +56,10 @@ public:
   int  getMsgCount() const { return _msgcount; }
   bool hasDisplay() const { return _display != NULL; }
   bool isButtonPressed() const;
+
+  void toggleBuzzer();
+  void toggleGPS();
+
 
   // from AbstractUITask
   void msgRead(int msgcount) override;

--- a/src/helpers/ui/MomentaryButton.cpp
+++ b/src/helpers/ui/MomentaryButton.cpp
@@ -11,7 +11,7 @@ MomentaryButton::MomentaryButton(int8_t pin, int long_press_millis, bool reverse
   _threshold = 0;
   _click_count = 0;
   _last_click_time = 0;
-  _multi_click_window = 500;
+  _multi_click_window = 260;
   _pending_click = false;
 }
 
@@ -26,7 +26,7 @@ MomentaryButton::MomentaryButton(int8_t pin, int long_press_millis, int analog_t
   _threshold = analog_threshold;
   _click_count = 0;
   _last_click_time = 0;
-  _multi_click_window = 500;
+  _multi_click_window = 260;
   _pending_click = false;
 }
 
@@ -81,6 +81,9 @@ int MomentaryButton::check(bool repeat_click) {
       }
       if (event == BUTTON_EVENT_CLICK && cancel) {
         event = BUTTON_EVENT_NONE;
+        _click_count = 0;
+        _last_click_time = 0;
+        _pending_click = false;
       }
       down_at = 0;
     }
@@ -93,6 +96,9 @@ int MomentaryButton::check(bool repeat_click) {
   if (_long_millis > 0 && down_at > 0 && (unsigned long)(millis() - down_at) >= _long_millis) {
     event = BUTTON_EVENT_LONG_PRESS;
     down_at = 0;
+    _click_count = 0;
+    _last_click_time = 0;
+    _pending_click = false;
   }
   if (down_at > 0 && repeat_click) {
     unsigned long diff = (unsigned long)(millis() - down_at);
@@ -118,6 +124,7 @@ int MomentaryButton::check(bool repeat_click) {
         break;
     }
     _click_count = 0;
+    _last_click_time = 0;
     _pending_click = false;
   }
 

--- a/src/helpers/ui/MomentaryButton.h
+++ b/src/helpers/ui/MomentaryButton.h
@@ -5,6 +5,8 @@
 #define BUTTON_EVENT_NONE        0
 #define BUTTON_EVENT_CLICK       1
 #define BUTTON_EVENT_LONG_PRESS  2
+#define BUTTON_EVENT_DOUBLE_CLICK 3
+#define BUTTON_EVENT_TRIPLE_CLICK 4
 
 class MomentaryButton {
   int8_t _pin;
@@ -13,6 +15,10 @@ class MomentaryButton {
   int _long_millis;
   int _threshold;  // analog mode
   unsigned long down_at;
+  uint8_t _click_count;
+  unsigned long _last_click_time;
+  int _multi_click_window;
+  bool _pending_click;
 
   bool isPressed(int level) const;
 

--- a/src/helpers/ui/UIScreen.h
+++ b/src/helpers/ui/UIScreen.h
@@ -2,13 +2,17 @@
 
 #include "DisplayDriver.h"
 
-#define KEY_LEFT     0xB4
-#define KEY_UP       0xB5
-#define KEY_DOWN     0xB6
-#define KEY_RIGHT    0xB7
-#define KEY_SELECT     10
-#define KEY_ENTER      13
-#define KEY_BACK       27   // Esc
+#define KEY_LEFT           0xB4
+#define KEY_UP             0xB5
+#define KEY_DOWN           0xB6
+#define KEY_RIGHT          0xB7
+#define KEY_SELECT           10
+#define KEY_ENTER            13
+#define KEY_CANCEL           27   // Esc
+#define KEY_HOME           0xF0
+#define KEY_NEXT           0xF1
+#define KEY_PREV           0xF2
+#define KEY_CONTEXT_MENU   0xF3
 
 class UIScreen {
 protected:


### PR DESCRIPTION
This adds double and triple click functionality to user button, as well as buzzer and gps toggle functions, and hooks triple click to buzzer toggle for now.

I left out the old quad-press for GPS for now because it's available in the app anyway.