### PR TITLE
tidy up thinknode_m1 variant

### DIFF
--- a/variants/thinknode_m1/ThinkNodeM1Board.cpp
+++ b/variants/thinknode_m1/ThinkNodeM1Board.cpp
@@ -1,10 +1,10 @@
-#include <Arduino.h>
 #include "ThinkNodeM1Board.h"
+#include <Arduino.h>
 
 #ifdef THINKNODE_M1
 
-#include <bluefruit.h>
 #include <Wire.h>
+#include <bluefruit.h>
 
 static BLEDfu bledfu;
 
@@ -26,14 +26,14 @@ void ThinkNodeM1Board::begin() {
 
   Wire.begin();
 
-  #ifdef P_LORA_TX_LED
-    pinMode(P_LORA_TX_LED, OUTPUT);
-    digitalWrite(P_LORA_TX_LED, LOW);
-  #endif
+#ifdef P_LORA_TX_LED
+  pinMode(P_LORA_TX_LED, OUTPUT);
+  digitalWrite(P_LORA_TX_LED, LOW);
+#endif
 
   pinMode(SX126X_POWER_EN, OUTPUT);
   digitalWrite(SX126X_POWER_EN, HIGH);
-  delay(10);   // give sx1262 some time to power up
+  delay(10); // give sx1262 some time to power up
 }
 
 uint16_t ThinkNodeM1Board::getBattMilliVolts() {
@@ -50,7 +50,7 @@ uint16_t ThinkNodeM1Board::getBattMilliVolts() {
   return (uint16_t)((float)adcvalue * REAL_VBAT_MV_PER_LSB);
 }
 
-bool ThinkNodeM1Board::startOTAUpdate(const char* id, char reply[]) {
+bool ThinkNodeM1Board::startOTAUpdate(const char *id, char reply[]) {
   // Config the peripheral connection with maximum bandwidth
   // more SRAM required by SoftDevice
   // Note: All config***() function must be called before begin()

--- a/variants/thinknode_m1/ThinkNodeM1Board.h
+++ b/variants/thinknode_m1/ThinkNodeM1Board.h
@@ -3,19 +3,6 @@
 #include <MeshCore.h>
 #include <Arduino.h>
 
-// LoRa radio module pins for Elecrow ThinkNode M1
-#define  P_LORA_DIO_1     20
-#define  P_LORA_NSS       24
-#define  P_LORA_RESET     25
-#define  P_LORA_BUSY      17
-#define  P_LORA_SCLK      19
-#define  P_LORA_MISO      23
-#define  P_LORA_MOSI      22
-#define  SX126X_POWER_EN  37
-
-#define SX126X_DIO2_AS_RF_SWITCH  true
-#define SX126X_DIO3_TCXO_VOLTAGE   1.8
-
 // built-ins
 #define VBAT_MV_PER_LSB   (0.73242188F)   // 3.0V ADC range and 12-bit ADC resolution = 3000mV/4096
 

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -1,33 +1,35 @@
-[nrf52840_thinknode_m1]
+[ThinkNode_M1]
 extends = nrf52_base
-platform_packages = framework-arduinoadafruitnrf52
+board = thinknode_m1
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   -I src/helpers/nrf52
   -I lib/nrf52/s140_nrf52_6.1.1_API/include
   -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
-lib_deps =
-  ${nrf52_base.lib_deps}
-  rweather/Crypto @ ^0.4.0
-
-[ThinkNode_M1]
-extends = nrf52840_thinknode_m1
-board = thinknode_m1
-board_build.ldscript = boards/nrf52840_s140_v6.ld
-build_flags = ${nrf52840_thinknode_m1.build_flags}
   -I variants/thinknode_m1
   -D THINKNODE_M1=1
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
-  -D LORA_TX_POWER=22
-  -D P_LORA_TX_LED=13
+  -D P_LORA_DIO_1=20
+  -D P_LORA_NSS=24
+  -D P_LORA_RESET=25
+  -D P_LORA_BUSY=17
+  -D P_LORA_SCLK=19
+  -D P_LORA_MISO=23
+  -D P_LORA_MOSI=22
+  -D SX126X_POWER_EN=37
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-build_src_filter = ${nrf52840_thinknode_m1.build_src_filter}
+  -D LORA_TX_POWER=22
+  -D P_LORA_TX_LED=13
+build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
-  +<helpers/nrf52/ThinkNodeM1Board.cpp>
+  +<ThinkNodeM1Board.cpp>
   +<../variants/thinknode_m1>
 lib_deps =
-  ${nrf52840_thinknode_m1.lib_deps}
+  ${nrf52_base.lib_deps}
   stevemarple/MicroNMEA @ ^2.0.6
 debug_tool = jlink
 upload_protocol = nrfutil
@@ -81,7 +83,6 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M1.build_src_filter}
-  +<helpers/nrf52/ThinkNodeM1.cpp>
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<helpers/ui/GxEPDDisplay.cpp>
   +<helpers/ui/buzzer.cpp>

--- a/variants/thinknode_m1/target.h
+++ b/variants/thinknode_m1/target.h
@@ -3,7 +3,7 @@
 #define RADIOLIB_STATIC_ONLY 1
 #include <RadioLib.h>
 #include <helpers/radiolib/RadioLibWrappers.h>
-#include <helpers/nrf52/ThinkNodeM1Board.h>
+#include <ThinkNodeM1Board.h>
 #include <helpers/radiolib/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>


### PR DESCRIPTION
- moved board class files to `variants/thinknode_m1` folder
- simplified platfomio.ini definitions (as we did on other nrf52 boards already)
- moved LoRa pins from board files into platformio.ini
