### PR TITLE
ThinkNode M1: add missing crc lib dep

### DIFF
--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -92,4 +92,5 @@ lib_deps =
   ${ThinkNode_M1.lib_deps}
   densaugeo/base64 @ ~1.4.0
   zinggjm/GxEPD2 @ 1.6.2
+  bakercp/CRC32 @ ^2.0.0
   end2endzone/NonBlockingRTTTL@^1.3.0


### PR DESCRIPTION
This PR adds the crc32 libdep to the ThinkNode M1. This fixes a compilation error, due to the addition of `#include <CRC32.h>` in the GXEPD display driver, which was added in #722