### PR TITLE
Adds name filtering and text truncation for display in HomeScreen

### DIFF
--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string.h>
 
 class DisplayDriver {
   int _w, _h;
@@ -31,5 +32,60 @@ public:
     setCursor(mid_x - w/2, y);
     print(str);
   }
+  
+  // convert UTF-8 characters to displayable block characters for compatibility
+  virtual void translateUTF8ToBlocks(char* dest, const char* src, size_t dest_size) {
+    size_t j = 0;
+    for (size_t i = 0; src[i] != 0 && j < dest_size - 1; i++) {
+      unsigned char c = (unsigned char)src[i];
+      if (c >= 32 && c <= 126) {
+        dest[j++] = c;  // ASCII printable
+      } else if (c >= 0x80) {
+        dest[j++] = '\xDB';  // CP437 full block █
+        while (src[i+1] && (src[i+1] & 0xC0) == 0x80) 
+          i++;  // skip UTF-8 continuation bytes
+      }
+    }
+    dest[j] = 0;
+  }
+  
+  // draw text with ellipsis if it exceeds max_width
+  virtual void drawTextEllipsized(int x, int y, int max_width, const char* str) {
+    char temp_str[256];  // reasonable buffer size
+    size_t len = strlen(str);
+    if (len >= sizeof(temp_str)) len = sizeof(temp_str) - 1;
+    memcpy(temp_str, str, len);
+    temp_str[len] = 0;
+    
+    if (getTextWidth(temp_str) <= max_width) {
+      setCursor(x, y);
+      print(temp_str);
+      return;
+    }
+    
+    // for variable-width fonts (GxEPD), add space after ellipsis
+    // for fixed-width fonts (OLED), keep tight spacing to save precious characters
+    const char* ellipsis;
+    // use a simple heuristic: if 'i' and 'l' have different widths, it's variable-width
+    int i_width = getTextWidth("i");
+    int l_width = getTextWidth("l");
+    if (i_width != l_width) {
+      ellipsis = "... ";  // variable-width fonts: add space
+    } else {
+      ellipsis = "...";   // fixed-width fonts: no space
+    }
+    
+    int ellipsis_width = getTextWidth(ellipsis);
+    int str_len = strlen(temp_str);
+    
+    while (str_len > 0 && getTextWidth(temp_str) > max_width - ellipsis_width) {
+      temp_str[--str_len] = 0;
+    }
+    strcat(temp_str, ellipsis);
+    
+    setCursor(x, y);
+    print(temp_str);
+  }
+  
   virtual void endFrame() = 0;
 };


### PR DESCRIPTION
Adds methods to replace non-ASCII characters and truncate text with ellipsis based on available width in Recent adverts. For devices like the Nano G2 Ultra, this addresses the multiple glitched characters that a single emoji would render as and instead shows "`█`".

Lilygo T-Echo Before and After:

<img width="300px" alt="image" src="https://github.com/user-attachments/assets/5cad7b10-5509-4f56-8c9b-a1bcf7be14b3" />
<img width="300px" alt="image" src="https://github.com/user-attachments/assets/ae7aa9d3-c14b-4f6d-aba3-3d86b0e528ee" />

Nano G2 Ultra Before and After:

<img width="300px" alt="image" src="https://github.com/user-attachments/assets/09e15ed7-ce16-40ea-8257-bab58a64411b" />
<img width="300px" alt="image" src="https://github.com/user-attachments/assets/0cb5e559-f63b-4ff5-8d40-a98b91051326" />

Note: This doesn't address text truncation of the companion node name in the top, only in the list of recently heard adverts.
