### PR TITLE
Set correct max upload size for NRF52 companion targets, add QSPIFLASH to USB targets

### DIFF
--- a/variants/heltec_mesh_solar/platformio.ini
+++ b/variants/heltec_mesh_solar/platformio.ini
@@ -57,6 +57,7 @@ build_flags =
 
 [env:Heltec_mesh_solar_companion_radio_ble]
 extends = Heltec_mesh_solar
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_mesh_solar.build_flags}
   -D MAX_CONTACTS=350
@@ -75,6 +76,7 @@ lib_deps =
 
 [env:Heltec_mesh_solar_companion_radio_usb]
 extends = Heltec_mesh_solar
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_mesh_solar.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -70,6 +70,7 @@ build_flags =
 
 [env:Heltec_t114_without_display_companion_radio_ble]
 extends = Heltec_t114
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
   -I examples/companion_radio/ui-new
@@ -90,6 +91,7 @@ lib_deps =
 
 [env:Heltec_t114_without_display_companion_radio_usb]
 extends = Heltec_t114
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
   -I examples/companion_radio/ui-new
@@ -158,6 +160,7 @@ build_flags =
 
 [env:Heltec_t114_companion_radio_ble]
 extends = Heltec_t114_with_display
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new
@@ -178,6 +181,7 @@ lib_deps =
 
 [env:Heltec_t114_companion_radio_usb]
 extends = Heltec_t114_with_display
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -101,6 +101,7 @@ build_src_filter = ${nrf52840_xiao.build_src_filter}
 
 [ikoka_stick_nrf_companion_radio_ble]
 extends = ikoka_stick_nrf_baseboard
+board_upload.maximum_size = 708608
 build_flags =
   ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=350
@@ -121,6 +122,7 @@ lib_deps =
 
 [ikoka_stick_nrf_companion_radio_usb]
 extends = ikoka_stick_nrf_baseboard
+board_upload.maximum_size = 708608
 build_flags =
   ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=350
@@ -172,6 +174,7 @@ build_src_filter = ${ikoka_stick_nrf_baseboard.build_src_filter}
 extends =
    ikoka_stick_nrf_e22_22dbm
    ikoka_stick_nrf_companion_radio_usb
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_usb.build_flags}
    ${ikoka_stick_nrf_e22_22dbm.build_flags}
@@ -183,6 +186,7 @@ build_src_filter =
 extends =
    ikoka_stick_nrf_e22_22dbm
    ikoka_stick_nrf_companion_radio_ble
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_ble.build_flags}
    ${ikoka_stick_nrf_e22_22dbm.build_flags}
@@ -219,6 +223,7 @@ build_src_filter =
 extends =
    ikoka_stick_nrf_e22_30dbm
    ikoka_stick_nrf_companion_radio_usb
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_usb.build_flags}
    ${ikoka_stick_nrf_e22_30dbm.build_flags}
@@ -230,6 +235,7 @@ build_src_filter =
 extends =
    ikoka_stick_nrf_e22_30dbm
    ikoka_stick_nrf_companion_radio_ble
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_ble.build_flags}
    ${ikoka_stick_nrf_e22_30dbm.build_flags}
@@ -266,6 +272,7 @@ build_src_filter =
 extends =
    ikoka_stick_nrf_e22_33dbm
    ikoka_stick_nrf_companion_radio_usb
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_usb.build_flags}
    ${ikoka_stick_nrf_e22_33dbm.build_flags}
@@ -277,6 +284,7 @@ build_src_filter =
 extends =
    ikoka_stick_nrf_e22_33dbm
    ikoka_stick_nrf_companion_radio_ble
+board_upload.maximum_size = 708608
 build_flags =
    ${ikoka_stick_nrf_companion_radio_ble.build_flags}
    ${ikoka_stick_nrf_e22_33dbm.build_flags}

--- a/variants/lilygo_techo/platformio.ini
+++ b/variants/lilygo_techo/platformio.ini
@@ -78,6 +78,7 @@ build_flags =
 
 [env:LilyGo_T-Echo_companion_radio_ble]
 extends = LilyGo_T-Echo
+board_upload.maximum_size = 712704
 build_flags =
   ${LilyGo_T-Echo.build_flags}
   -I src/helpers/ui
@@ -101,6 +102,7 @@ lib_deps =
 
 [env:LilyGo_T-Echo_companion_radio_usb]
 extends = LilyGo_T-Echo
+board_upload.maximum_size = 712704
 build_flags =
   ${LilyGo_T-Echo.build_flags}
   -I src/helpers/ui

--- a/variants/lilygo_techo/platformio.ini
+++ b/variants/lilygo_techo/platformio.ini
@@ -112,6 +112,7 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
   -D UI_RECENT_LIST_SIZE=9
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+  -D QSPIFLASH=1
 build_src_filter = ${LilyGo_T-Echo.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>

--- a/variants/mesh_pocket/platformio.ini
+++ b/variants/mesh_pocket/platformio.ini
@@ -67,6 +67,7 @@ build_flags =
 
 [env:Mesh_pocket_companion_radio_ble]
 extends = Mesh_pocket
+board_upload.maximum_size = 712704
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new
@@ -89,6 +90,7 @@ lib_deps =
 
 [env:Mesh_pocket_companion_radio_usb]
 extends = Mesh_pocket
+board_upload.maximum_size = 712704
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/minewsemi_me25ls01/platformio.ini
+++ b/variants/minewsemi_me25ls01/platformio.ini
@@ -50,6 +50,7 @@ lib_deps = ${nrf52840_me25ls01.lib_deps}
 
 [env:Minewsemi_me25ls01_companion_radio_ble]
 extends = me25ls01
+board_upload.maximum_size = 708608
 build_flags = ${me25ls01.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
@@ -147,6 +148,7 @@ lib_deps = ${me25ls01.lib_deps}
 
 [env:Minewsemi_me25ls01_companion_radio_usb]
 extends = me25ls01
+board_upload.maximum_size = 708608
 build_flags = ${me25ls01.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350

--- a/variants/nano_g2_ultra/platformio.ini
+++ b/variants/nano_g2_ultra/platformio.ini
@@ -70,6 +70,7 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D QSPIFLASH=1
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=SH1106Display
   -D PIN_BUZZER=4

--- a/variants/nano_g2_ultra/platformio.ini
+++ b/variants/nano_g2_ultra/platformio.ini
@@ -31,6 +31,7 @@ upload_protocol = nrfutil
 
 [env:Nano_G2_Ultra_companion_radio_ble]
 extends = Nano_G2_Ultra
+board_upload.maximum_size = 712704
 build_flags =
   ${Nano_G2_Ultra.build_flags}
   -I src/helpers/ui
@@ -62,6 +63,7 @@ lib_deps =
 
 [env:Nano_G2_Ultra_companion_radio_usb]
 extends = Nano_G2_Ultra
+board_upload.maximum_size = 712704
 build_flags =
   ${Nano_G2_Ultra.build_flags}
   -I src/helpers/ui

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -86,6 +86,7 @@ lib_deps = ${Faketec.lib_deps}
 
 [env:Faketec_companion_radio_usb]
 extends = Faketec
+board_upload.maximum_size = 712704
 build_flags = ${Faketec.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
@@ -104,6 +105,7 @@ lib_deps = ${Faketec.lib_deps}
 
 [env:Faketec_companion_radio_ble]
 extends = Faketec
+board_upload.maximum_size = 712704
 build_flags = ${Faketec.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -64,6 +64,7 @@ build_src_filter = ${rak4631.build_src_filter}
 
 [env:RAK_4631_companion_radio_usb]
 extends = rak4631
+board_upload.maximum_size = 712704
 build_flags =
   ${rak4631.build_flags}
   -I examples/companion_radio/ui-new
@@ -83,6 +84,7 @@ lib_deps =
 
 [env:RAK_4631_companion_radio_ble]
 extends = rak4631
+board_upload.maximum_size = 712704
 build_flags =
   ${rak4631.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -66,6 +66,7 @@ build_src_filter = ${rak_wismesh_tag.build_src_filter}
 
 [env:RAK_WisMesh_Tag_companion_radio_usb]
 extends = rak_wismesh_tag
+board_upload.maximum_size = 712704
 build_flags =
   ${rak_wismesh_tag.build_flags}
   -I examples/companion_radio/ui-orig
@@ -83,6 +84,7 @@ lib_deps =
 
 [env:RAK_WisMesh_Tag_companion_radio_ble]
 extends = rak_wismesh_tag
+board_upload.maximum_size = 712704
 build_flags =
   ${rak_wismesh_tag.build_flags}
   -I examples/companion_radio/ui-orig

--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -74,6 +74,7 @@ build_src_filter = ${SenseCap_Solar.build_src_filter}
 
 [env:SenseCap_Solar_companion_radio_ble]
 extends = SenseCap_Solar
+board_upload.maximum_size = 708608
 build_flags =
   ${SenseCap_Solar.build_flags}
   -D MAX_CONTACTS=350
@@ -92,6 +93,7 @@ lib_deps =
 
 [env:SenseCap_Solar_companion_radio_usb]
 extends = SenseCap_Solar
+board_upload.maximum_size = 708608
 build_flags =
   ${SenseCap_Solar.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -68,10 +68,11 @@ lib_deps = ${t1000-e.lib_deps}
 
 [env:t1000e_companion_radio_usb]
 extends = t1000-e
+board_upload.maximum_size = 708608
 build_flags = ${t1000-e.build_flags}
   -I examples/companion_radio/ui-orig
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
   -D OFFLINE_QUEUE_SIZE=256
@@ -89,6 +90,7 @@ lib_deps = ${t1000-e.lib_deps}
 
 [env:t1000e_companion_radio_ble]
 extends = t1000-e
+board_upload.maximum_size = 708608
 build_flags = ${t1000-e.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -67,6 +67,7 @@ lib_deps =
 
 [env:ThinkNode_M1_companion_radio_ble]
 extends = ThinkNode_M1
+board_upload.maximum_size = 712704
 build_flags =
   ${ThinkNode_M1.build_flags}
   -I src/helpers/ui
@@ -99,6 +100,7 @@ lib_deps =
 
 [env:ThinkNode_M1_companion_radio_usb]
 extends = ThinkNode_M1
+board_upload.maximum_size = 712704
 build_flags =
   ${ThinkNode_M1.build_flags}
   -I src/helpers/ui

--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -55,10 +55,11 @@ lib_deps = ${WioTrackerL1.lib_deps}
 
 [env:WioTrackerL1_companion_radio_usb]
 extends = WioTrackerL1
+board_upload.maximum_size = 708608
 build_flags = ${WioTrackerL1.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D DISPLAY_CLASS=SH1106Display
   -D OFFLINE_QUEUE_SIZE=256
   -D PIN_BUZZER=12
@@ -77,6 +78,7 @@ lib_deps = ${WioTrackerL1.lib_deps}
 
 [env:WioTrackerL1_companion_radio_ble]
 extends = WioTrackerL1
+board_upload.maximum_size = 708608
 build_flags = ${WioTrackerL1.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -82,6 +82,7 @@ build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D QSPIFLASH=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Xiao_nrf52.build_src_filter}

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -57,6 +57,7 @@ upload_protocol = nrfutil
 
 [env:Xiao_nrf52_companion_radio_ble]
 extends = Xiao_nrf52
+board_upload.maximum_size = 708608
 build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350
@@ -76,6 +77,7 @@ lib_deps =
 
 [env:Xiao_nrf52_companion_radio_usb]
 extends = Xiao_nrf52
+board_upload.maximum_size = 708608
 build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350


### PR DESCRIPTION
This PR corrects the max upload size for NRF companion targets so we can't accidentally overwrite it with a big firmware in future.
It also adds QSPIFLASH for a couple of variants which were missing it for their companion USB targets.

I did consider whether the variants with QSPIFLASH enabled should keep the full max upload size, but given that EXTRAFS is still defined at the root platformio.ini level it is probably safer to reflect that.

For future reference this is how to calculate max upload size, when ExtraFS starts at D4000:
SoftDevice S140 v7.3.0 - D4000 - 27000 = AD000 / 708608 bytes in decimal
SoftDevice S140 v6.1.1 - D4000 - 26000 = AE000 / 712704 bytes in decimal

