### PR TITLE
New linker scripts for NRF52 companion envs

### DIFF
--- a/boards/nrf52840_s140_v6_extrafs.ld
+++ b/boards/nrf52840_s140_v6_extrafs.ld
@@ -1,0 +1,38 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x26000, LENGTH = 0xD4000 - 0x26000
+
+  /* SRAM required by Softdevice depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */ 
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+  
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7_extrafs.ld
+++ b/boards/nrf52840_s140_v7_extrafs.ld
@@ -1,0 +1,38 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0xD4000 - 0x27000
+
+  /* SRAM required by Softdevice depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */ 
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+  
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/variants/heltec_mesh_solar/platformio.ini
+++ b/variants/heltec_mesh_solar/platformio.ini
@@ -57,6 +57,8 @@ build_flags =
 
 [env:Heltec_mesh_solar_companion_radio_ble]
 extends = Heltec_mesh_solar
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_mesh_solar.build_flags}
   -D MAX_CONTACTS=350
@@ -75,6 +77,8 @@ lib_deps =
 
 [env:Heltec_mesh_solar_companion_radio_usb]
 extends = Heltec_mesh_solar
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_mesh_solar.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -70,6 +70,8 @@ build_flags =
 
 [env:Heltec_t114_without_display_companion_radio_ble]
 extends = Heltec_t114
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
   -I examples/companion_radio/ui-new
@@ -90,6 +92,8 @@ lib_deps =
 
 [env:Heltec_t114_without_display_companion_radio_usb]
 extends = Heltec_t114
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
   -I examples/companion_radio/ui-new
@@ -158,6 +162,8 @@ build_flags =
 
 [env:Heltec_t114_companion_radio_ble]
 extends = Heltec_t114_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new
@@ -178,6 +184,8 @@ lib_deps =
 
 [env:Heltec_t114_companion_radio_usb]
 extends = Heltec_t114_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -101,6 +101,8 @@ build_src_filter = ${nrf52840_xiao.build_src_filter}
 
 [ikoka_stick_nrf_companion_radio_ble]
 extends = ikoka_stick_nrf_baseboard
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=350
@@ -121,6 +123,8 @@ lib_deps =
 
 [ikoka_stick_nrf_companion_radio_usb]
 extends = ikoka_stick_nrf_baseboard
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/lilygo_techo/platformio.ini
+++ b/variants/lilygo_techo/platformio.ini
@@ -78,6 +78,8 @@ build_flags =
 
 [env:LilyGo_T-Echo_companion_radio_ble]
 extends = LilyGo_T-Echo
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${LilyGo_T-Echo.build_flags}
   -I src/helpers/ui
@@ -101,6 +103,8 @@ lib_deps =
 
 [env:LilyGo_T-Echo_companion_radio_usb]
 extends = LilyGo_T-Echo
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${LilyGo_T-Echo.build_flags}
   -I src/helpers/ui

--- a/variants/lilygo_techo/platformio.ini
+++ b/variants/lilygo_techo/platformio.ini
@@ -114,6 +114,7 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
   -D UI_RECENT_LIST_SIZE=9
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+  -D QSPIFLASH=1
 build_src_filter = ${LilyGo_T-Echo.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>

--- a/variants/mesh_pocket/platformio.ini
+++ b/variants/mesh_pocket/platformio.ini
@@ -67,6 +67,8 @@ build_flags =
 
 [env:Mesh_pocket_companion_radio_ble]
 extends = Mesh_pocket
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new
@@ -89,6 +91,8 @@ lib_deps =
 
 [env:Mesh_pocket_companion_radio_usb]
 extends = Mesh_pocket
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/minewsemi_me25ls01/platformio.ini
+++ b/variants/minewsemi_me25ls01/platformio.ini
@@ -50,6 +50,8 @@ lib_deps = ${nrf52840_me25ls01.lib_deps}
 
 [env:Minewsemi_me25ls01_companion_radio_ble]
 extends = me25ls01
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${me25ls01.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
@@ -147,6 +149,8 @@ lib_deps = ${me25ls01.lib_deps}
 
 [env:Minewsemi_me25ls01_companion_radio_usb]
 extends = me25ls01
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${me25ls01.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350

--- a/variants/nano_g2_ultra/platformio.ini
+++ b/variants/nano_g2_ultra/platformio.ini
@@ -31,6 +31,8 @@ upload_protocol = nrfutil
 
 [env:Nano_G2_Ultra_companion_radio_ble]
 extends = Nano_G2_Ultra
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Nano_G2_Ultra.build_flags}
   -I src/helpers/ui
@@ -62,6 +64,8 @@ lib_deps =
 
 [env:Nano_G2_Ultra_companion_radio_usb]
 extends = Nano_G2_Ultra
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${Nano_G2_Ultra.build_flags}
   -I src/helpers/ui

--- a/variants/nano_g2_ultra/platformio.ini
+++ b/variants/nano_g2_ultra/platformio.ini
@@ -72,6 +72,7 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D QSPIFLASH=1
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=SH1106Display
   -D PIN_BUZZER=4

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -86,6 +86,8 @@ lib_deps = ${Faketec.lib_deps}
 
 [env:Faketec_companion_radio_usb]
 extends = Faketec
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags = ${Faketec.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
@@ -104,6 +106,8 @@ lib_deps = ${Faketec.lib_deps}
 
 [env:Faketec_companion_radio_ble]
 extends = Faketec
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags = ${Faketec.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -64,6 +64,8 @@ build_src_filter = ${rak4631.build_src_filter}
 
 [env:RAK_4631_companion_radio_usb]
 extends = rak4631
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${rak4631.build_flags}
   -I examples/companion_radio/ui-new
@@ -83,6 +85,8 @@ lib_deps =
 
 [env:RAK_4631_companion_radio_ble]
 extends = rak4631
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${rak4631.build_flags}
   -I examples/companion_radio/ui-new

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -66,6 +66,8 @@ build_src_filter = ${rak_wismesh_tag.build_src_filter}
 
 [env:RAK_WisMesh_Tag_companion_radio_usb]
 extends = rak_wismesh_tag
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${rak_wismesh_tag.build_flags}
   -I examples/companion_radio/ui-orig
@@ -83,6 +85,8 @@ lib_deps =
 
 [env:RAK_WisMesh_Tag_companion_radio_ble]
 extends = rak_wismesh_tag
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${rak_wismesh_tag.build_flags}
   -I examples/companion_radio/ui-orig

--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -74,6 +74,8 @@ build_src_filter = ${SenseCap_Solar.build_src_filter}
 
 [env:SenseCap_Solar_companion_radio_ble]
 extends = SenseCap_Solar
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${SenseCap_Solar.build_flags}
   -D MAX_CONTACTS=350
@@ -92,6 +94,8 @@ lib_deps =
 
 [env:SenseCap_Solar_companion_radio_usb]
 extends = SenseCap_Solar
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${SenseCap_Solar.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -72,8 +72,8 @@ board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
 board_upload.maximum_size = 708608
 build_flags = ${t1000-e.build_flags}
   -I examples/companion_radio/ui-orig
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
   -D OFFLINE_QUEUE_SIZE=256

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -68,6 +68,8 @@ lib_deps = ${t1000-e.lib_deps}
 
 [env:t1000e_companion_radio_usb]
 extends = t1000-e
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${t1000-e.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=100
@@ -89,6 +91,8 @@ lib_deps = ${t1000-e.lib_deps}
 
 [env:t1000e_companion_radio_ble]
 extends = t1000-e
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${t1000-e.build_flags}
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -67,6 +67,8 @@ lib_deps =
 
 [env:ThinkNode_M1_companion_radio_ble]
 extends = ThinkNode_M1
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${ThinkNode_M1.build_flags}
   -I src/helpers/ui
@@ -99,6 +101,8 @@ lib_deps =
 
 [env:ThinkNode_M1_companion_radio_usb]
 extends = ThinkNode_M1
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
 build_flags =
   ${ThinkNode_M1.build_flags}
   -I src/helpers/ui

--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -59,11 +59,12 @@ board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
 board_upload.maximum_size = 708608
 build_flags = ${WioTrackerL1.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D DISPLAY_CLASS=SH1106Display
   -D OFFLINE_QUEUE_SIZE=256
   -D PIN_BUZZER=12
+  -D QSPIFLASH=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${WioTrackerL1.build_src_filter}

--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -55,6 +55,8 @@ lib_deps = ${WioTrackerL1.lib_deps}
 
 [env:WioTrackerL1_companion_radio_usb]
 extends = WioTrackerL1
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${WioTrackerL1.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=100
@@ -77,6 +79,8 @@ lib_deps = ${WioTrackerL1.lib_deps}
 
 [env:WioTrackerL1_companion_radio_ble]
 extends = WioTrackerL1
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags = ${WioTrackerL1.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -84,6 +84,7 @@ build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D QSPIFLASH=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Xiao_nrf52.build_src_filter}

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -57,6 +57,8 @@ upload_protocol = nrfutil
 
 [env:Xiao_nrf52_companion_radio_ble]
 extends = Xiao_nrf52
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350
@@ -76,6 +78,8 @@ lib_deps =
 
 [env:Xiao_nrf52_companion_radio_usb]
 extends = Xiao_nrf52
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
 build_flags =
   ${Xiao_nrf52.build_flags}
   -D MAX_CONTACTS=350


### PR DESCRIPTION
This PR adds new linker scripts for NRF52 companion envs, so we can't accidentally overwrite the ExtraFS area if the firmware grows too large. I added board_upload.maximum_size for those envs too, so that the platformio build output reflects the true maximum size.

I considered whether the variants with QSPIFLASH enabled should keep the original linker scripts, but given that EXTRAFS is defined at the root platformio.ini level it is probably safer to use the new ldscripts.

It also adds QSPIFLASH for a couple of variants which were missing it for their companion USB targets and fixes the final inconsistencies with max contacts/channels.