### PR TITLE
Fix: WisMeshTag power off and wake up

### DIFF
--- a/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
+++ b/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
@@ -62,7 +62,8 @@ public:
     digitalWrite(LED_PIN, HIGH);
     #endif
     #ifdef BUTTON_PIN
-    while(digitalRead(BUTTON_PIN));
+    // wismesh tag uses LOW to indicate button is pressed, wait until it goes HIGH to indicate it was released
+    while(digitalRead(BUTTON_PIN) == LOW);
     #endif
     #ifdef LED_GREEN
     digitalWrite(LED_GREEN, LOW);
@@ -72,7 +73,8 @@ public:
     #endif
 
     #ifdef BUTTON_PIN
-    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_HIGH);
+    // configure button press to wake up when in powered off state
+    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
     #endif
 
     sd_power_system_off();


### PR DESCRIPTION
This PR fixes the issue where holding the user button to power off, will not fully power off until the user releases the button, and then presses it once more.

The power off logic was expecting HIGH to indicate button press, however this board uses LOW to indicate button press.

Additionally, pressing the button to wake the board when it was in powered off state was not working. This has also been adjusted to use a pull up, and sense for low state to trigger power on.

Requesting review/test by @recrof as I believe you have this board :)