### PR TITLE
Normalize repeater target names

### DIFF
--- a/variants/lilygo_t3s3/platformio.ini
+++ b/variants/lilygo_t3s3/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
   adafruit/Adafruit SSD1306 @ ^2.5.13
 
 ; === LilyGo T3S3 with SX1262 environments ===
-[env:LilyGo_T3S3_sx1262_Repeater]
+[env:LilyGo_T3S3_sx1262_repeater]
 extends = LilyGo_T3S3_sx1262
 build_flags =
   ${LilyGo_T3S3_sx1262.build_flags}
@@ -52,7 +52,7 @@ lib_deps =
   ${LilyGo_T3S3_sx1262.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:LilyGo_T3S3_sx1262_Repeater_bridge_rs232]
+; [env:LilyGo_T3S3_sx1262_repeater_bridge_rs232]
 ; extends = LilyGo_T3S3_sx1262
 ; build_flags =
 ;   ${LilyGo_T3S3_sx1262.build_flags}
@@ -75,7 +75,7 @@ lib_deps =
 ;   ${LilyGo_T3S3_sx1262.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:LilyGo_T3S3_sx1262_Repeater_bridge_espnow]
+[env:LilyGo_T3S3_sx1262_repeater_bridge_espnow]
 extends = LilyGo_T3S3_sx1262
 build_flags =
   ${LilyGo_T3S3_sx1262.build_flags}

--- a/variants/lilygo_t3s3_sx1276/platformio.ini
+++ b/variants/lilygo_t3s3_sx1276/platformio.ini
@@ -31,7 +31,7 @@ lib_deps =
   adafruit/Adafruit SSD1306 @ ^2.5.13
 
 ; === LilyGo T3S3 with SX1276 environments ===
-[env:LilyGo_T3S3_sx1276_Repeater]
+[env:LilyGo_T3S3_sx1276_repeater]
 extends = LilyGo_T3S3_sx1276
 build_flags =
   ${LilyGo_T3S3_sx1276.build_flags}
@@ -50,7 +50,7 @@ lib_deps =
   ${LilyGo_T3S3_sx1276.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:LilyGo_T3S3_sx1276_Repeater_bridge_rs232]
+; [env:LilyGo_T3S3_sx1276_repeater_bridge_rs232]
 ; extends = LilyGo_T3S3_sx1276
 ; build_flags =
 ;   ${LilyGo_T3S3_sx1276.build_flags}
@@ -73,7 +73,7 @@ lib_deps =
 ;   ${LilyGo_T3S3_sx1276.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:LilyGo_T3S3_sx1276_Repeater_bridge_espnow]
+[env:LilyGo_T3S3_sx1276_repeater_bridge_espnow]
 extends = LilyGo_T3S3_sx1276
 build_flags =
   ${LilyGo_T3S3_sx1276.build_flags}

--- a/variants/lilygo_tlora_v2_1/platformio.ini
+++ b/variants/lilygo_tlora_v2_1/platformio.ini
@@ -45,7 +45,7 @@ lib_deps =
   adafruit/Adafruit BMP280 Library @ ^2.6.8
 
 ; === LILYGO T-LoRa V2.1-1.6 with SX1276 environments ===
-[env:LilyGo_TLora_V2_1_1_6_Repeater]
+[env:LilyGo_TLora_V2_1_1_6_repeater]
 extends = LilyGo_TLora_V2_1_1_6
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
@@ -160,7 +160,7 @@ lib_deps =
 ;
 ; Repeater Bridges
 ;
-[env:LilyGo_TLora_V2_1_1_6_bridge_rs232]
+[env:LilyGo_TLora_V2_1_1_6_repeater_bridge_rs232]
 extends = LilyGo_TLora_V2_1_1_6
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
@@ -183,7 +183,7 @@ lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   ${esp32_ota.lib_deps}
 
-[env:LilyGo_TLora_V2_1_1_6_bridge_espnow]
+[env:LilyGo_TLora_V2_1_1_6_repeater_bridge_espnow]
 extends = LilyGo_TLora_V2_1_1_6
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -34,7 +34,7 @@ lib_deps= ${nrf52_base.lib_deps}
   adafruit/Adafruit BMP280 Library@^2.6.8
   stevemarple/MicroNMEA @ ^2.0.6
 
-[env:Faketec_Repeater]
+[env:Faketec_repeater]
 extends = Faketec
 build_src_filter = ${Faketec.build_src_filter}
   +<../examples/simple_repeater>

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =
   adafruit/Adafruit SSD1306 @ ^2.5.13
   sparkfun/SparkFun u-blox GNSS Arduino Library@^2.2.27
 
-[env:RAK_4631_Repeater]
+[env:RAK_4631_repeater]
 extends = rak4631
 build_flags =
   ${rak4631.build_flags}

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -37,7 +37,7 @@ lib_deps =
   ${sensor_base.lib_deps}
   end2endzone/NonBlockingRTTTL@^1.3.0
 
-[env:RAK_WisMesh_Tag_Repeater]
+[env:RAK_WisMesh_Tag_repeater]
 extends = rak_wismesh_tag
 build_flags =
   ${rak_wismesh_tag.build_flags}

--- a/variants/rpi_picow/platformio.ini
+++ b/variants/rpi_picow/platformio.ini
@@ -27,7 +27,7 @@ build_src_filter = ${rp2040_base.build_src_filter}
   +<../variants/rpi_picow>
 lib_deps = ${rp2040_base.lib_deps}
 
-[env:PicoW_Repeater]
+[env:PicoW_repeater]
 extends = rpi_picow
 build_flags = ${rpi_picow.build_flags}
   -D ADVERT_NAME='"PicoW Repeater"'

--- a/variants/tenstar_c3/platformio.ini
+++ b/variants/tenstar_c3/platformio.ini
@@ -23,7 +23,7 @@ build_flags =
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/tenstar_c3>
 
-[env:Tenstar_C3_Repeater_sx1262]
+[env:Tenstar_C3_repeater_sx1262]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -44,7 +44,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:Tenstar_C3_Repeater_sx1262_bridge_rs232]
+; [env:Tenstar_C3_repeater_sx1262_bridge_rs232]
 ; extends = Tenstar_esp32_C3
 ; build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
 ;   +<helpers/bridges/RS232Bridge.cpp>
@@ -69,7 +69,7 @@ lib_deps =
 ;   ${Tenstar_esp32_C3.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_Repeater_sx1262_bridge_espnow]
+[env:Tenstar_C3_repeater_sx1262_bridge_espnow]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>
@@ -93,7 +93,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_Repeater_sx1268]
+[env:Tenstar_C3_repeater_sx1268]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -113,7 +113,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:Tenstar_C3_Repeater_sx1268_bridge_rs232]
+; [env:Tenstar_C3_repeater_sx1268_bridge_rs232]
 ; extends = Tenstar_esp32_C3
 ; build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
 ;   +<helpers/bridges/RS232Bridge.cpp>
@@ -137,7 +137,7 @@ lib_deps =
 ;   ${Tenstar_esp32_C3.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_Repeater_sx1268_bridge_espnow]
+[env:Tenstar_C3_repeater_sx1268_bridge_espnow]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>

--- a/variants/waveshare_rp2040_lora/platformio.ini
+++ b/variants/waveshare_rp2040_lora/platformio.ini
@@ -33,7 +33,7 @@ build_src_filter = ${rp2040_base.build_src_filter}
   +<../variants/waveshare_rp2040_lora>
 lib_deps = ${rp2040_base.lib_deps}
 
-[env:waveshare_rp2040_lora_Repeater]
+[env:waveshare_rp2040_lora_repeater]
 extends = waveshare_rp2040_lora
 build_flags = ${waveshare_rp2040_lora.build_flags}
   -D ADVERT_NAME='"RP2040-LoRa Repeater"'

--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -24,7 +24,7 @@ lib_deps= ${nrf52_base.lib_deps}
   adafruit/Adafruit GFX Library @ ^1.12.1
   stevemarple/MicroNMEA @ ^2.0.6
 
-[env:WioTrackerL1_Repeater]
+[env:WioTrackerL1_repeater]
 extends = WioTrackerL1
 build_src_filter = ${WioTrackerL1.build_src_filter}
   +<../examples/simple_repeater>

--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -19,7 +19,7 @@ build_flags =
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/xiao_c3>
 
-[env:Xiao_C3_Repeater_sx1262]
+[env:Xiao_C3_repeater_sx1262]
 extends = Xiao_esp32_C3
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -30,7 +30,7 @@ build_src_filter = ${esp32c6_base.build_src_filter}
   +<../variants/xiao_c6>
   +<XiaoC6Board.cpp>
 
-[env:Xiao_C6_Repeater]
+[env:Xiao_C6_repeater]
 extends = Xiao_C6
 build_src_filter = ${Xiao_C6.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -90,7 +90,7 @@ build_flags =
   -D SX126X_RX_BOOSTED_GAIN=1
   -D USE_XIAO_ESP32C6_EXTERNAL_ANTENNA=1
 
-[env:Meshimi_Repeater]
+[env:Meshimi_repeater]
 extends = Meshimi
 build_src_filter = ${Meshimi.build_src_filter}
                    +<../examples/simple_repeater/*.cpp>
@@ -147,7 +147,7 @@ build_flags =
   -USX126X_DIO2_AS_RF_SWITCH
   -USX126X_DIO3_TCXO_VOLTAGE
 
-[env:WHY2025_badge_Repeater]
+[env:WHY2025_badge_repeater]
 extends = WHY2025_badge
 build_src_filter = ${WHY2025_badge.build_src_filter}
   +<../examples/simple_repeater/*.cpp>

--- a/variants/xiao_rp2040/platformio.ini
+++ b/variants/xiao_rp2040/platformio.ini
@@ -29,7 +29,7 @@ build_src_filter = ${rp2040_base.build_src_filter}
   +<../variants/xiao_rp2040>
 lib_deps = ${rp2040_base.lib_deps}
 
-[env:Xiao_rp2040_Repeater]
+[env:Xiao_rp2040_repeater]
 extends = Xiao_rp2040
 build_flags = ${Xiao_rp2040.build_flags}
   -D ADVERT_NAME='"Xiao Repeater"'

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -27,7 +27,7 @@ build_flags = ${esp32_base.build_flags}
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/xiao_s3_wio>
 
-[env:Xiao_S3_WIO_Repeater]
+[env:Xiao_S3_WIO_repeater]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -44,7 +44,7 @@ lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:Xiao_S3_WIO_Repeater_bridge_rs232]
+; [env:Xiao_S3_WIO_repeater_bridge_rs232]
 ; extends = Xiao_S3_WIO
 ; build_src_filter = ${Xiao_S3_WIO.build_src_filter}
 ;   +<helpers/bridges/RS232Bridge.cpp>
@@ -65,7 +65,7 @@ lib_deps =
 ;   ${Xiao_S3_WIO.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:Xiao_S3_WIO_Repeater_bridge_espnow]
+[env:Xiao_S3_WIO_repeater_bridge_espnow]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>


### PR DESCRIPTION
Fix a typo with `variants/lilygo_tlora_v2_1` and take the opportunity to normalize all targets to lower case.