### PR TITLE
Fix: BLE pin disappearing too quickly on nrf52 devices

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -4,10 +4,7 @@ static SerialBLEInterface* instance;
 
 void SerialBLEInterface::onConnect(uint16_t connection_handle) {
   BLE_DEBUG_PRINTLN("SerialBLEInterface: connected");
-  if(instance){
-    instance->_isDeviceConnected = true;
-    // no need to stop advertising on connect, as the ble stack does this automatically
-  }
+  // we now set _isDeviceConnected=true in onSecured callback instead
 }
 
 void SerialBLEInterface::onDisconnect(uint16_t connection_handle, uint8_t reason) {
@@ -15,6 +12,14 @@ void SerialBLEInterface::onDisconnect(uint16_t connection_handle, uint8_t reason
   if(instance){
     instance->_isDeviceConnected = false;
     instance->startAdv();
+  }
+}
+
+void SerialBLEInterface::onSecured(uint16_t connection_handle) {
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: onSecured");
+  if(instance){
+    instance->_isDeviceConnected = true;
+    // no need to stop advertising on connect, as the ble stack does this automatically
   }
 }
 
@@ -36,6 +41,7 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
 
   Bluefruit.Periph.setConnectCallback(onConnect);
   Bluefruit.Periph.setDisconnectCallback(onDisconnect);
+  Bluefruit.Security.setSecuredCallback(onSecured);
 
   // To be consistent OTA DFU should be added first if it exists
   //bledfu.begin();

--- a/src/helpers/nrf52/SerialBLEInterface.h
+++ b/src/helpers/nrf52/SerialBLEInterface.h
@@ -25,6 +25,7 @@ class SerialBLEInterface : public BaseSerialInterface {
   void clearBuffers() { send_queue_len = 0; }
   static void onConnect(uint16_t connection_handle);
   static void onDisconnect(uint16_t connection_handle, uint8_t reason);
+  static void onSecured(uint16_t connection_handle);
 
 public:
   SerialBLEInterface() {


### PR DESCRIPTION
This PR fixes the issue where the BLE pin displayed on screen disappears very quickly after connecting, even if you haven't typed the pin in yet. The UI shows `< Connected >` and the user has a bad time unless they memorised the pin quick enough before it disappears.

I've switched to using the `onSecured` callback, instead of the `onConnected` callback, to mark the device as connected. This callback is fired when pairing has been successful, or when an app reconnects when already previously paired.

The BLE pin now stays on screen until the user has successfully paired.

This has been tested, and working on the following devices:
- ThinkNode M1
- Heltec T114
- RAK4631 WisMesh Pocket

The PR only makes the change on nrf52, as the esp32 `SerialBLEInterface` appears to mark devices as connected in the `onMtuChanged` callback, which seems to only happen after pairing is complete.

I do note that the esp32 class is still using the `checkRecvFrame` to update device connection state, and this should really be refactored to use the callbacks as well, however it has been left as is to keep this PR simple.