### PR TITLE
revert unexpected change to ble advertising interval on nrf52

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -86,7 +86,7 @@ void SerialBLEInterface::startAdv() {
    * https://developer.apple.com/library/content/qa/qa1931/_index.html   
    */
   Bluefruit.Advertising.restartOnDisconnect(false); // don't restart automatically as we handle it in onDisconnect
-  Bluefruit.Advertising.setInterval(32, 1600);
+  Bluefruit.Advertising.setInterval(32, 244);
   Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
   Bluefruit.Advertising.start(0);                // 0 = Don't stop advertising after n seconds
 


### PR DESCRIPTION
This PR reverts the slow advertising interval for our nrf52 SerialBLEInterface.

Copy pasting the information in my comment here: https://github.com/meshcore-dev/MeshCore/pull/736/files#r2347702632

This one slipped through code review, and should be rolled back to `244` which is `0.625 * 244 = 152.5 ms`.

The value of `1600` which is `0.625 * 1600 = 1000 ms` isn't listed in the Apple recommended discovery intervals:
https://developer.apple.com/library/archive/qa/qa1931/_index.html so I'm not too sure why this was changed to 1600.

I've noticed connecting to devices (after being disconnected for 30 seconds, which is the fast interval timeout) is significantly slower due to this change. Sometimes waiting up to 20 seconds for the Android app to connect. Reverting this change, the app is able to reconnect within 2 seconds.

> The recommended advertising pattern and advertising intervals are:
> First, advertise at 20 ms intervals for at least 30 seconds
> If not discovered after 30 seconds, you may change to one of the following longer intervals: 152.5 ms, 211.25 ms, 318.75 ms, 417.5 ms, 546.25 ms, 760 ms, 852.5 ms, 1022.5 ms, 1285 ms
> **Important:** These specific intervals are the ones to be used exactly! Even the slightest deviation from these actual intervals may dramatically increase your time to discovery.

Our esp32 SerialBLEInterface implementation is using the defaults of 32/244, so reverting this back ensures a consistent setup for our nrf52 implementation.

```
# BLEAdvertising.h (used on es32)
#define BLE_ADV_INTERVAL_FAST_DFLT       32  // 20    ms (in 0.625 ms unit)
#define BLE_ADV_INTERVAL_SLOW_DFLT       244 // 152.5 ms (in 0.625 ms unit)
#define BLE_ADV_FAST_TIMEOUT_DFLT        30  // in seconds
```

Any changes to the advertising intervals should probably be put behind a power saving flag, with a note documenting that things will take far longer to connect in this mode.

It should be noted that the advertising interval change here only saves power when you're not connected. If you're connected to the device, it won't be advertising anyway.