### PR TITLE
tidy up xiao nrf52 variant

### DIFF
--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -1,21 +1,19 @@
 #ifdef XIAO_NRF52
 
 #include <Arduino.h>
-#include "XiaoNrf52Board.h"
-
-#include <bluefruit.h>
 #include <Wire.h>
+#include <bluefruit.h>
+
+#include "XiaoNrf52Board.h"
 
 static BLEDfu bledfu;
 
-static void connect_callback(uint16_t conn_handle)
-{
+static void connect_callback(uint16_t conn_handle) {
   (void)conn_handle;
   MESH_DEBUG_PRINTLN("BLE client connected");
 }
 
-static void disconnect_callback(uint16_t conn_handle, uint8_t reason)
-{
+static void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
   (void)conn_handle;
   (void)reason;
 
@@ -41,12 +39,12 @@ void XiaoNrf52Board::begin() {
   digitalWrite(P_LORA_TX_LED, HIGH);
 #endif
 
-//  pinMode(SX126X_POWER_EN, OUTPUT);
-//  digitalWrite(SX126X_POWER_EN, HIGH);
-  delay(10);   // give sx1262 some time to power up
+  //  pinMode(SX126X_POWER_EN, OUTPUT);
+  //  digitalWrite(SX126X_POWER_EN, HIGH);
+  delay(10); // give sx1262 some time to power up
 }
 
-bool XiaoNrf52Board::startOTAUpdate(const char* id, char reply[]) {
+bool XiaoNrf52Board::startOTAUpdate(const char *id, char reply[]) {
   // Config the peripheral connection with maximum bandwidth
   // more SRAM required by SoftDevice
   // Note: All config***() function must be called before begin()
@@ -86,10 +84,8 @@ bool XiaoNrf52Board::startOTAUpdate(const char* id, char reply[]) {
   Bluefruit.Advertising.start(0);             // 0 = Don't stop advertising after n seconds
 
   strcpy(reply, "OK - started");
+
   return true;
-
-
-  return false;
 }
 
 #endif

--- a/variants/xiao_nrf52/XiaoNrf52Board.h
+++ b/variants/xiao_nrf52/XiaoNrf52Board.h
@@ -5,20 +5,6 @@
 
 #ifdef XIAO_NRF52
 
-// redefine lora pins if using the S3 variant of SX1262 board
-#ifdef SX1262_XIAO_S3_VARIANT
-  #undef P_LORA_DIO_1
-  #undef P_LORA_BUSY
-  #undef P_LORA_RESET
-  #undef P_LORA_NSS
-  #undef SX126X_RXEN
-  #define  P_LORA_DIO_1       D0
-  #define  P_LORA_BUSY        D1
-  #define  P_LORA_RESET       D2
-  #define  P_LORA_NSS         D3
-  #define  SX126X_RXEN        D4
-#endif
-
 class XiaoNrf52Board : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;
@@ -40,13 +26,13 @@ public:
     // Please read befor going further ;)
     // https://wiki.seeedstudio.com/XIAO_BLE#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging
 
-    // We can't drive VBAT_ENABLE to HIGH as long 
+    // We can't drive VBAT_ENABLE to HIGH as long
     // as we don't know wether we are charging or not ...
     // this is a 3mA loss (4/1500)
     digitalWrite(VBAT_ENABLE, LOW);
     int adcvalue = 0;
     analogReadResolution(12);
-    analogReference(AR_INTERNAL_3_0);  
+    analogReference(AR_INTERNAL_3_0);
     delay(10);
     adcvalue = analogRead(PIN_VBAT);
     return (adcvalue * ADC_MULTIPLIER * AREF_VOLTAGE) / 4.096;

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -1,37 +1,19 @@
-[nrf52840_xiao]
+[Xiao_nrf52]
 extends = nrf52_base
-platform_packages =
-  toolchain-gccarmnoneeabi@~1.100301.0
-  framework-arduinoadafruitnrf52
 board = seeed-xiao-afruitnrf52-nrf52840
 board_build.ldscript = boards/nrf52840_s140_v7.ld
 build_flags = ${nrf52_base.build_flags}
-  -D NRF52_PLATFORM -D XIAO_NRF52
+  ${sensor_base.build_flags}
   -I lib/nrf52/s140_nrf52_7.3.0_API/include
   -I lib/nrf52/s140_nrf52_7.3.0_API/include/nrf52
-lib_ignore =
-  BluetoothOTA
-  lvgl
-  lib5b4
-lib_deps =
-  ${nrf52_base.lib_deps}
-  rweather/Crypto @ ^0.4.0
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0  
-
-
-[Xiao_nrf52]
-extends = nrf52840_xiao
-;board_build.ldscript = boards/nrf52840_s140_v7.ld
-build_flags = ${nrf52840_xiao.build_flags}
-  -D P_LORA_TX_LED=11
   -I variants/xiao_nrf52
-  -I src/helpers/nrf52
+  -UENV_INCLUDE_GPS
+  -D NRF52_PLATFORM
+  -D XIAO_NRF52
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
+  -D P_LORA_TX_LED=11
   -D P_LORA_DIO_1=D1
   -D P_LORA_RESET=D2
   -D P_LORA_BUSY=D3
@@ -42,18 +24,16 @@ build_flags = ${nrf52840_xiao.build_flags}
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-  -D PIN_WIRE_SCL=6
-  -D PIN_WIRE_SDA=7
-  -D ENV_INCLUDE_AHTX0=1
-  -D ENV_INCLUDE_BME280=1
-  -D ENV_INCLUDE_INA3221=1
-  -D ENV_INCLUDE_INA219=1
-build_src_filter = ${nrf52840_xiao.build_src_filter}
+  -D PIN_WIRE_SCL=D6
+  -D PIN_WIRE_SDA=D7
+build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/sensors>
   +<../variants/xiao_nrf52>
 debug_tool = jlink
 upload_protocol = nrfutil
+lib_deps = ${nrf52_base.lib_deps}
+  ${sensor_base.lib_deps}
 
 [env:Xiao_nrf52_companion_radio_ble]
 extends = Xiao_nrf52
@@ -94,12 +74,6 @@ lib_deps =
   ${Xiao_nrf52.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
-[env:Xiao_nrf52_alt_pinout_companion_radio_ble]
-extends = env:Xiao_nrf52_companion_radio_ble
-build_flags =
-  ${env:Xiao_nrf52_companion_radio_ble.build_flags}
-  -D SX1262_XIAO_S3_VARIANT
-
 [env:Xiao_nrf52_repeater]
 extends = Xiao_nrf52
 build_flags =
@@ -113,12 +87,6 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Xiao_nrf52.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
-
-[env:Xiao_nrf52_alt_pinout_repeater]
-extends = env:Xiao_nrf52_repeater
-build_flags =
-  ${env:Xiao_nrf52_repeater.build_flags}
-  -D SX1262_XIAO_S3_VARIANT
 
 [env:Xiao_nrf52_room_server]
 extends = Xiao_nrf52

--- a/variants/xiao_nrf52/target.cpp
+++ b/variants/xiao_nrf52/target.cpp
@@ -10,12 +10,13 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
 EnvironmentSensorManager sensors;
 
 bool radio_init() {
-    rtc_clock.begin(Wire);
-  
-    return radio.std_init(&SPI);
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&SPI);
 }
 
 uint32_t radio_get_rng_seed() {
@@ -35,5 +36,5 @@ void radio_set_tx_power(uint8_t dbm) {
 
 mesh::LocalIdentity radio_new_identity() {
   RadioNoiseListener rng(radio);
-  return mesh::LocalIdentity(&rng);  // create new random identity
+  return mesh::LocalIdentity(&rng); // create new random identity
 }

--- a/variants/xiao_nrf52/variant.cpp
+++ b/variants/xiao_nrf52/variant.cpp
@@ -1,86 +1,85 @@
 #include "variant.h"
+
+#include "nrf.h"
 #include "wiring_constants.h"
 #include "wiring_digital.h"
-#include "nrf.h"
 
-const uint32_t g_ADigitalPinMap[] =
-{
-    // D0 .. D10
-     2, // D0  is P0.02 (A0)
-     3, // D1  is P0.03 (A1)
-    28, // D2  is P0.28 (A2)
-    29, // D3  is P0.29 (A3)
-     4, // D4  is P0.04 (A4,SDA)
-     5, // D5  is P0.05 (A5,SCL)
-    43, // D6  is P1.11 (TX)
-    44, // D7  is P1.12 (RX)
-    45, // D8  is P1.13 (SCK)
-    46, // D9  is P1.14 (MISO)
-    47, // D10 is P1.15 (MOSI)
+const uint32_t g_ADigitalPinMap[] = {
+  // D0 .. D10
+  2,  // D0  is P0.02 (A0)
+  3,  // D1  is P0.03 (A1)
+  28, // D2  is P0.28 (A2)
+  29, // D3  is P0.29 (A3)
+  4,  // D4  is P0.04 (A4,SDA)
+  5,  // D5  is P0.05 (A5,SCL)
+  43, // D6  is P1.11 (TX)
+  44, // D7  is P1.12 (RX)
+  45, // D8  is P1.13 (SCK)
+  46, // D9  is P1.14 (MISO)
+  47, // D10 is P1.15 (MOSI)
 
-    // LEDs
-    26, // D11 is P0.26 (LED RED)
-     6, // D12 is P0.06 (LED BLUE)
-    30, // D13 is P0.30 (LED GREEN)
-    14, // D14 is P0.14 (READ_BAT)
+  // LEDs
+  26, // D11 is P0.26 (LED RED)
+  6,  // D12 is P0.06 (LED BLUE)
+  30, // D13 is P0.30 (LED GREEN)
+  14, // D14 is P0.14 (READ_BAT)
 
-    // LSM6DS3TR
-    40, // D15 is P1.08 (6D_PWR)
-    27, // D16 is P0.27 (6D_I2C_SCL)
-     7, // D17 is P0.07 (6D_I2C_SDA)
-    11, // D18 is P0.11 (6D_INT1)
+  // LSM6DS3TR
+  40, // D15 is P1.08 (6D_PWR)
+  27, // D16 is P0.27 (6D_I2C_SCL)
+  7,  // D17 is P0.07 (6D_I2C_SDA)
+  11, // D18 is P0.11 (6D_INT1)
 
-    // MIC
-    42, // D19 is P1.10 (MIC_PWR)
-    32, // D20 is P1.00 (PDM_CLK)
-    16, // D21 is P0.16 (PDM_DATA)
+  // MIC
+  42, // D19 is P1.10 (MIC_PWR)
+  32, // D20 is P1.00 (PDM_CLK)
+  16, // D21 is P0.16 (PDM_DATA)
 
-    // BQ25100
-    13, // D22 is P0.13 (HICHG)
-    17, // D23 is P0.17 (~CHG)
+  // BQ25100
+  13, // D22 is P0.13 (HICHG)
+  17, // D23 is P0.17 (~CHG)
 
-    //
-    21, // D24 is P0.21 (QSPI_SCK)
-    25, // D25 is P0.25 (QSPI_CSN)
-    20, // D26 is P0.20 (QSPI_SIO_0 DI)
-    24, // D27 is P0.24 (QSPI_SIO_1 DO)
-    22, // D28 is P0.22 (QSPI_SIO_2 WP)
-    23, // D29 is P0.23 (QSPI_SIO_3 HOLD)
+  //
+  21, // D24 is P0.21 (QSPI_SCK)
+  25, // D25 is P0.25 (QSPI_CSN)
+  20, // D26 is P0.20 (QSPI_SIO_0 DI)
+  24, // D27 is P0.24 (QSPI_SIO_1 DO)
+  22, // D28 is P0.22 (QSPI_SIO_2 WP)
+  23, // D29 is P0.23 (QSPI_SIO_3 HOLD)
 
-    // NFC
-     9, // D30 is P0.09 (NFC1)
-    10, // D31 is P0.10 (NFC2)
+  // NFC
+  9,  // D30 is P0.09 (NFC1)
+  10, // D31 is P0.10 (NFC2)
 
-    // VBAT
-    31, // D32 is P0.31 (VBAT)
+  // VBAT
+  31, // D32 is P0.31 (VBAT)
 };
 
-void initVariant()
-{
-    // Disable reading of the BAT voltage.
-    // https://wiki.seeedstudio.com/XIAO_BLE#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging
-    pinMode(VBAT_ENABLE, OUTPUT);
-    //digitalWrite(VBAT_ENABLE, HIGH); 
-    // This was taken from Seeed github butis not coherent with the doc, 
-    // VBAT_ENABLE should be kept to LOW to protect P0.14, (1500/500)*(4.2-3.3)+3.3 = 3.9V > 3.6V
-    // This induces a 3mA current in the resistors :( but it's better than burning the nrf
-    digitalWrite(VBAT_ENABLE, LOW);
+void initVariant() {
+  // Disable reading of the BAT voltage.
+  // https://wiki.seeedstudio.com/XIAO_BLE#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging
+  pinMode(VBAT_ENABLE, OUTPUT);
+  // digitalWrite(VBAT_ENABLE, HIGH);
+  //  This was taken from Seeed github butis not coherent with the doc,
+  //  VBAT_ENABLE should be kept to LOW to protect P0.14, (1500/500)*(4.2-3.3)+3.3 = 3.9V > 3.6V
+  //  This induces a 3mA current in the resistors :( but it's better than burning the nrf
+  digitalWrite(VBAT_ENABLE, LOW);
 
-    // Low charging current (50mA)
-    // https://wiki.seeedstudio.com/XIAO_BLE#battery-charging-current
-    //pinMode(PIN_CHARGING_CURRENT, INPUT);
+  // Low charging current (50mA)
+  // https://wiki.seeedstudio.com/XIAO_BLE#battery-charging-current
+  // pinMode(PIN_CHARGING_CURRENT, INPUT);
 
-    // High charging current (100mA)
-    pinMode(PIN_CHARGING_CURRENT, OUTPUT);
-    digitalWrite(PIN_CHARGING_CURRENT, LOW);
+  // High charging current (100mA)
+  pinMode(PIN_CHARGING_CURRENT, OUTPUT);
+  digitalWrite(PIN_CHARGING_CURRENT, LOW);
 
-    pinMode(PIN_QSPI_CS, OUTPUT);
-    digitalWrite(PIN_QSPI_CS, HIGH);
+  pinMode(PIN_QSPI_CS, OUTPUT);
+  digitalWrite(PIN_QSPI_CS, HIGH);
 
-    pinMode(LED_RED, OUTPUT);
-    digitalWrite(LED_RED, HIGH);
-    pinMode(LED_GREEN, OUTPUT);
-    digitalWrite(LED_GREEN, HIGH);
-    pinMode(LED_BLUE, OUTPUT);
-    digitalWrite(LED_BLUE, HIGH);
+  pinMode(LED_RED, OUTPUT);
+  digitalWrite(LED_RED, HIGH);
+  pinMode(LED_GREEN, OUTPUT);
+  digitalWrite(LED_GREEN, HIGH);
+  pinMode(LED_BLUE, OUTPUT);
+  digitalWrite(LED_BLUE, HIGH);
 }

--- a/variants/xiao_nrf52/variant.h
+++ b/variants/xiao_nrf52/variant.h
@@ -113,8 +113,8 @@ static const uint8_t A5  = PIN_A5;
 // #define PIN_WIRE_SDA            (17) // 4 and 5 are used for the sx1262 !
 // #define PIN_WIRE_SCL            (16) // use WIRE1_SDA
 
-static const uint8_t SDA = PIN_WIRE_SDA;
-static const uint8_t SCL = PIN_WIRE_SCL;
+// static const uint8_t SDA = PIN_WIRE_SDA;
+// static const uint8_t SCL = PIN_WIRE_SCL;
 
 //#define PIN_WIRE1_SDA           (17)
 //#define PIN_WIRE1_SCL           (16)


### PR DESCRIPTION
- add all sensors supported by env sensor manager(apart from GPS - rx/tx pins are used by i2c)
- remove unnecessary nrf52840_xiao pio def
- remove alternative pinout envs (consulted with @fdlamotte)
- make source formatting in line with `.clang-format`