### PR TITLE
Use python3 not python in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ build_firmware() {
 
   # build .uf2 for nrf52 boards
   if [[ -f .pio/build/$1/firmware.zip && -f .pio/build/$1/firmware.hex ]]; then
-    python bin/uf2conv/uf2conv.py .pio/build/$1/firmware.hex -c -o .pio/build/$1/firmware.uf2 -f 0xADA52840
+    python3 bin/uf2conv/uf2conv.py .pio/build/$1/firmware.hex -c -o .pio/build/$1/firmware.uf2 -f 0xADA52840
   fi
 
   # copy .bin, .uf2, and .zip to out folder


### PR DESCRIPTION
Since the bin/uf2conv/uf2conf.py script uses python3, use python3 as the command instead of python. On my ubuntu 24.04 machine, I don't have a python command in my path by default