### PR TITLE
make offline queue channel messages mutable

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -177,13 +177,29 @@ void MyMesh::updateContactFromFrame(ContactInfo &contact, uint32_t& last_mod, co
 
 void MyMesh::addToOfflineQueue(const uint8_t frame[], int len) {
   if (offline_queue_len >= OFFLINE_QUEUE_SIZE) {
-    MESH_DEBUG_PRINTLN("ERROR: offline_queue is full!");
+    MESH_DEBUG_PRINTLN("WARN: offline_queue is full!");
+    int pos = 0;
+    while (pos < offline_queue_len) {
+      if ((offline_queue[pos].buf[0] == RESP_CODE_CHANNEL_MSG_RECV) ||
+          offline_queue[pos].buf[0] == RESP_CODE_CHANNEL_MSG_RECV_V3) {
+        for (int i = pos; i < offline_queue_len; i++) { // delete oldest channel msg from queue
+          offline_queue[i] = offline_queue[i + 1];
+        }
+        MESH_DEBUG_PRINTLN("INFO: removed oldest channel message from queue.");
+        offline_queue[offline_queue_len - 1].len = len;
+        memcpy(offline_queue[offline_queue_len - 1].buf, frame, len);
+        return;
+      }
+      pos++;
+    }
+    MESH_DEBUG_PRINTLN("INFO: no channel messages to remove from queue.");
   } else {
     offline_queue[offline_queue_len].len = len;
     memcpy(offline_queue[offline_queue_len].buf, frame, len);
     offline_queue_len++;
   }
 }
+
 int MyMesh::getFromOfflineQueue(uint8_t frame[]) {
   if (offline_queue_len > 0) {         // check offline queue
     size_t len = offline_queue[0].len; // take from top of queue


### PR DESCRIPTION
older channel messages can be overwritten, keeping other mssagage types

this allows a user to be away for a long time and still get the most recent channel messages without losing any direct messages for exampe