### PR TITLE
Make NodePrefs globally accessible

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -72,6 +72,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->multi_acks = constrain(_prefs->multi_acks, 0, 1);
 
     file.close();
+
+    g_nodePrefs = _prefs; 
   }
 }
 
@@ -116,6 +118,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *) &_prefs->interference_threshold, sizeof(_prefs->interference_threshold));  // 126
 
     file.close();
+    g_nodePrefs = _prefs; 
+
   }
 }
 

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -2,6 +2,7 @@
 
 #include "Mesh.h"
 #include <helpers/IdentityStore.h>
+#include "GlobalPrefs.h"
 
 struct NodePrefs {  // persisted to file
     float airtime_factor;

--- a/src/helpers/GlobalPrefs.cpp
+++ b/src/helpers/GlobalPrefs.cpp
@@ -1,0 +1,4 @@
+#include "GlobalPrefs.h"
+
+// Einzige Definition des Symbols:
+NodePrefs* g_nodePrefs = nullptr;

--- a/src/helpers/GlobalPrefs.cpp
+++ b/src/helpers/GlobalPrefs.cpp
@@ -1,4 +1,4 @@
 #include "GlobalPrefs.h"
 
-// Einzige Definition des Symbols:
+// Single Definition of Symbol:
 NodePrefs* g_nodePrefs = nullptr;

--- a/src/helpers/GlobalPrefs.h
+++ b/src/helpers/GlobalPrefs.h
@@ -1,11 +1,11 @@
 #pragma once
 
-// Vorwärtsdeklaration – kein Include-Rattenschwanz.
+// Forward declaration – prevents include cascades.
 struct NodePrefs;
 
-// Globaler Zeiger auf DEINE eine NodePrefs-Instanz.
+// Global pointer to YOUR single NodePrefs instance.
 extern NodePrefs* g_nodePrefs;
 
-// Bequeme Getter:
+// Convenient getters:
 inline NodePrefs& prefs()       { return *g_nodePrefs; }
 inline const NodePrefs& cprefs(){ return *g_nodePrefs; }

--- a/src/helpers/GlobalPrefs.h
+++ b/src/helpers/GlobalPrefs.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Vorwärtsdeklaration – kein Include-Rattenschwanz.
+struct NodePrefs;
+
+// Globaler Zeiger auf DEINE eine NodePrefs-Instanz.
+extern NodePrefs* g_nodePrefs;
+
+// Bequeme Getter:
+inline NodePrefs& prefs()       { return *g_nodePrefs; }
+inline const NodePrefs& cprefs(){ return *g_nodePrefs; }


### PR DESCRIPTION
Added a helper to make NodePrefs globally accessible to read.