### PR TITLE
RadioLibWrapper: Ensure correct state before processing packets to prevent IRQ ambiguity.

### DIFF
--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -69,7 +69,11 @@ class CustomLR1110 : public LR1110 {
     }
 
     int16_t readData(uint8_t* data, size_t len) override {
-      clearIrqState(0xFFFF);
-      return LR1110::readData(data, len);
+      int16_t res = LR1110::readData(data, len);
+      if (res == RADIOLIB_ERR_NONE) {
+        const uint16_t RX_DONE = (1u << 3);
+        clearIrqState(RX_DONE);
+      }
+      return res;
     }
 };

--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -67,4 +67,9 @@ class CustomLR1110 : public LR1110 {
       bool detected = ((irq & LR1110_IRQ_HEADER_VALID) || (irq & LR1110_IRQ_HAS_PREAMBLE));
       return detected;
     }
+
+    int16_t readData(uint8_t* data, size_t len) override {
+      clearIrqState(0xFFFF);
+      return LR1110::readData(data, len);
+    }
 };

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -12,13 +12,8 @@ public:
   bool canReadPacketNow() override {
     uint16_t irq = ((CustomLR1110 *)_radio)->getIrqStatus();
     const uint16_t RX_DONE = (1u << 3);
-    bool has_packet = (irq & RX_DONE) != 0;
     
-    if (has_packet) {
-      ((CustomLR1110 *)_radio)->clearIrqState(RX_DONE);
-    }
-    
-    return has_packet;
+    return (irq & RX_DONE) != 0;
   }
   float getCurrentRSSI() override {
     float rssi = -110;

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -12,7 +12,13 @@ public:
   bool canReadPacketNow() override {
     uint16_t irq = ((CustomLR1110 *)_radio)->getIrqStatus();
     const uint16_t RX_DONE = (1u << 3);
-    return (irq & RX_DONE) != 0;
+    bool has_packet = (irq & RX_DONE) != 0;
+    
+    if (has_packet) {
+      ((CustomLR1110 *)_radio)->clearIrqState(RX_DONE);
+    }
+    
+    return has_packet;
   }
   float getCurrentRSSI() override {
     float rssi = -110;

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -9,6 +9,11 @@ public:
   bool isReceivingPacket() override { 
     return ((CustomLR1110 *)_radio)->isReceiving();
   }
+  bool canReadPacketNow() override {
+    uint16_t irq = ((CustomLR1110 *)_radio)->getIrqStatus();
+    const uint16_t RX_DONE = (1u << 3);
+    return (irq & RX_DONE) != 0;
+  }
   float getCurrentRSSI() override {
     float rssi = -110;
     ((CustomLR1110 *)_radio)->getRssiInst(&rssi);

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -98,6 +98,10 @@ bool RadioLibWrapper::isInRecvMode() const {
 int RadioLibWrapper::recvRaw(uint8_t* bytes, int sz) {
   int len = 0;
   if ((state & STATE_INT_READY) && ((state & ~STATE_INT_READY) == STATE_RX)) {
+    if (!canReadPacketNow()) {
+      state = STATE_IDLE;
+      return 0;
+    }
     len = _radio->getPacketLength();
     if (len > 0) {
       if (len > sz) { len = sz; }

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -29,7 +29,7 @@ void RadioLibWrapper::begin() {
   state = STATE_IDLE;
 
   if (_board->getStartupReason() == BD_STARTUP_RX_PACKET) {  // received a LoRa packet (while in deep sleep)
-    setFlag(); // LoRa packet is already received
+    state = (STATE_RX | STATE_INT_READY);
   }
 
   _noise_floor = 0;
@@ -97,7 +97,7 @@ bool RadioLibWrapper::isInRecvMode() const {
 
 int RadioLibWrapper::recvRaw(uint8_t* bytes, int sz) {
   int len = 0;
-  if (state & STATE_INT_READY) {
+  if ((state & STATE_INT_READY) && ((state & ~STATE_INT_READY) == STATE_RX)) {
     len = _radio->getPacketLength();
     if (len > 0) {
       if (len > sz) { len = sz; }
@@ -141,7 +141,7 @@ bool RadioLibWrapper::startSendRaw(const uint8_t* bytes, int len) {
 }
 
 bool RadioLibWrapper::isSendComplete() {
-  if (state & STATE_INT_READY) {
+  if ((state & STATE_INT_READY) && ((state & ~STATE_INT_READY) == STATE_TX_WAIT)) {
     state = STATE_IDLE;
     n_sent++;
     return true;

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -16,6 +16,7 @@ protected:
   void startRecv();
   float packetScoreInt(float snr, int sf, int packet_len);
   virtual bool isReceivingPacket() =0;
+  virtual bool canReadPacketNow() { return true; }
 
 public:
   RadioLibWrapper(PhysicalLayer& radio, mesh::MainBoard& board) : _radio(&radio), _board(&board) { n_recv = n_sent = 0; }


### PR DESCRIPTION
A shared interrupt callback set an internal flag for both RxDone and TxDone; recvRaw() treated any interrupt as RX-ready and called `readData()` while not in RX.

This might also be related to the LR1110's problem with the "shifted" packets but testing should confirm that before we can make that claim. Besides that problem; it might be a good improvement to implement this nonetheless, as old RadioLib issue's show that this has been an issue in the past, which we might run into sooner or later.