### PR TITLE
ESM: delegate gps management to LocationProvider

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -438,6 +438,7 @@ void EnvironmentSensorManager::initBasicGPS() {
 
   // Try to detect if GPS is physically connected to determine if we should expose the setting
   _location->begin();
+  _location->reset();
 
   #ifndef PIN_GPS_EN
     MESH_DEBUG_PRINTLN("No GPS wake/reset pin found for this board. Continuing on...");
@@ -545,6 +546,7 @@ void EnvironmentSensorManager::start_gps() {
   #endif
 
   _location->begin();
+  _location->reset();
 
 #ifndef PIN_GPS_RESET
   MESH_DEBUG_PRINTLN("Start GPS is N/A on this board. Actual GPS state unchanged");

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -437,21 +437,7 @@ void EnvironmentSensorManager::initBasicGPS() {
   #endif
 
   // Try to detect if GPS is physically connected to determine if we should expose the setting
-  #ifdef PIN_GPS_EN
-    pinMode(PIN_GPS_EN, OUTPUT);
-  #ifdef PIN_GPS_EN_ACTIVE
-    digitalWrite(PIN_GPS_EN, PIN_GPS_EN_ACTIVE);   // Power on GPS
-  #else
-    digitalWrite(PIN_GPS_EN, HIGH);   // Power on GPS
-  #endif
-  #endif
-
-#ifdef PIN_GPS_RESET
-    pinMode(PIN_GPS_RESET, OUTPUT);
-    digitalWrite(PIN_GPS_RESET, PIN_GPS_RESET_ACTIVE); // assert for 10ms
-    delay(10);
-    digitalWrite(PIN_GPS_RESET, !PIN_GPS_RESET_ACTIVE);
-#endif
+  _location->begin();
 
   #ifndef PIN_GPS_EN
     MESH_DEBUG_PRINTLN("No GPS wake/reset pin found for this board. Continuing on...");
@@ -472,16 +458,12 @@ void EnvironmentSensorManager::initBasicGPS() {
   } else {
     MESH_DEBUG_PRINTLN("No GPS detected");
   }
-  #ifdef PIN_GPS_EN
-  #ifdef PIN_GPS_EN_ACTIVE
-    digitalWrite(PIN_GPS_EN, !PIN_GPS_EN_ACTIVE);  
-  #else
-    digitalWrite(PIN_GPS_EN, LOW);  // Power off GPS until the setting is changed
-  #endif
-  #endif
+  _location->stop();
   gps_active = false; //Set GPS visibility off until setting is changed
 }
 
+// gps code for rak might be moved to MicroNMEALoactionProvider 
+// or make a new location provider ...
 #ifdef RAK_WISBLOCK_GPS
 void EnvironmentSensorManager::rakGPSInit(){
 
@@ -561,27 +543,12 @@ void EnvironmentSensorManager::start_gps() {
     digitalWrite(gpsResetPin, HIGH);
     return;
   #endif
-  #ifdef PIN_GPS_EN
-    pinMode(PIN_GPS_EN, OUTPUT);
-  #ifdef PIN_GPS_EN_ACTIVE
-    digitalWrite(PIN_GPS_EN, PIN_GPS_EN_ACTIVE);  
-  #else
-    digitalWrite(PIN_GPS_EN, HIGH);
-  #endif
-  #ifndef PIN_GPS_RESET
-    return;
-  #endif
-  #endif
 
-#ifdef PIN_GPS_RESET
-    pinMode(PIN_GPS_RESET, OUTPUT);
-    digitalWrite(PIN_GPS_RESET, PIN_GPS_RESET_ACTIVE); // assert for 10ms
-    delay(10);
-    digitalWrite(PIN_GPS_RESET, !PIN_GPS_RESET_ACTIVE);
-    return;
-#endif
+  _location->begin();
 
+#ifndef PIN_GPS_RESET
   MESH_DEBUG_PRINTLN("Start GPS is N/A on this board. Actual GPS state unchanged");
+#endif
 }
 
 void EnvironmentSensorManager::stop_gps() {
@@ -591,17 +558,12 @@ void EnvironmentSensorManager::stop_gps() {
     digitalWrite(gpsResetPin, LOW);
     return;
   #endif
-  #ifdef PIN_GPS_EN
-    pinMode(PIN_GPS_EN, OUTPUT);
-  #ifdef PIN_GPS_EN_ACTIVE
-    digitalWrite(PIN_GPS_EN, !PIN_GPS_EN_ACTIVE);  
-  #else
-    digitalWrite(PIN_GPS_EN, LOW);
-  #endif   
-  return;
-  #endif
 
+  _location->stop();
+
+  #ifndef PIN_GPS_EN
   MESH_DEBUG_PRINTLN("Stop GPS is N/A on this board. Actual GPS state unchanged");
+  #endif
 }
 
 void EnvironmentSensorManager::loop() {

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -5,15 +5,31 @@
 #include <RTClib.h>
 
 #ifndef GPS_EN
-#define GPS_EN (-1)
+    #ifdef PIN_GPS_EN
+        #define GPS_EN PIN_GPS_EN
+    #else
+        #define GPS_EN (-1)
+    #endif
+#endif
+
+#ifndef PIN_GPS_EN_ACTIVE
+    #define PIN_GPS_EN_ACTIVE HIGH
 #endif
 
 #ifndef GPS_RESET
-#define GPS_RESET (-1)
+    #ifdef PIN_GPS_RESET
+        #define GPS_RESET PIN_GPS_RESET
+    #else
+        #define GPS_RESET (-1)
+    #endif
 #endif
 
 #ifndef GPS_RESET_FORCE
-#define GPS_RESET_FORCE LOW
+    #ifdef PIN_GPS_RESET_ACTIVE
+        #define GPS_RESET_FORCE PIN_GPS_RESET_ACTIVE
+    #else
+        #define GPS_RESET_FORCE LOW
+    #endif
 #endif
 
 class MicroNMEALocationProvider : public LocationProvider {
@@ -40,11 +56,11 @@ public :
     }
 
     void begin() override {
+        if (_pin_en != -1) {
+            digitalWrite(_pin_en, PIN_GPS_EN_ACTIVE);
+        }
         if (_pin_reset != -1) {
             digitalWrite(_pin_reset, !GPS_RESET_FORCE);
-        }
-        if (_pin_en != -1) {
-            digitalWrite(_pin_en, HIGH);
         }
     }
 
@@ -58,7 +74,7 @@ public :
 
     void stop() override {
         if (_pin_en != -1) {
-            digitalWrite(_pin_en, LOW);
+            digitalWrite(_pin_en, !PIN_GPS_EN_ACTIVE);
         }        
     }
 

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -67,7 +67,7 @@ public :
     void reset() override {
         if (_pin_reset != -1) {
             digitalWrite(_pin_reset, GPS_RESET_FORCE);
-            delay(100);
+            delay(10);
             digitalWrite(_pin_reset, !GPS_RESET_FORCE);
         }
     }


### PR DESCRIPTION
There was duplicate code (and duplicate symbols) that led to lots of confusion

Tried to use gps init routines from LocationProvider in ESM, instead of having the same code (with different symbol names)
