### PR TITLE
Implement binary request/response for Repeater Neighbours

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -515,6 +515,7 @@ void MyMesh::onContactResponse(const ContactInfo &contact, const uint8_t *data, 
       memcpy(&out_frame[i], &tag, 4);
       i += 4; // NEW: include server timestamp
       out_frame[i++] = data[7]; // NEW (v7): ACL permissions
+      out_frame[i++] = data[12]; // FIRMWARE_VER_LEVEL
     } else {
       out_frame[i++] = PUSH_CODE_LOGIN_FAIL;
       out_frame[i++] = 0; // reserved

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -197,11 +197,12 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
       int reply_offset = 4;
 
       // get request params
-      uint8_t count = payload[2]; // how many neighbours to fetch
-      uint8_t offset = payload[3]; // offset from start of neighbours list
-      uint8_t order_by = payload[4]; // how to order neighbours. 0=newest_to_oldest, 1=oldest_to_newest, 2=strongest_to_weakest, 3=weakest_to_strongest
-      uint8_t pubkey_prefix_length = payload[5]; // how many bytes of neighbour pub key we want
-      // we also send a 4 byte random blob in payload[6...9] to help packet uniqueness
+      uint8_t count = payload[2]; // how many neighbours to fetch (0-255)
+      uint16_t offset;
+      memcpy(&offset, &payload[3], 2); // offset from start of neighbours list (0-65535)
+      uint8_t order_by = payload[5]; // how to order neighbours. 0=newest_to_oldest, 1=oldest_to_newest, 2=strongest_to_weakest, 3=weakest_to_strongest
+      uint8_t pubkey_prefix_length = payload[6]; // how many bytes of neighbour pub key we want
+      // we also send a 4 byte random blob in payload[7...10] to help packet uniqueness
 
       MESH_DEBUG_PRINTLN("REQ_TYPE_GET_NEIGHBOURS count=%d, offset=%d, order_by=%d, pubkey_prefix_length=%d", count, offset, order_by, pubkey_prefix_length);
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -214,11 +214,11 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
 
       // create copy of neighbours list, skipping empty entries so we can sort it separately from main list
       int16_t neighbours_count = 0;
-      NeighbourInfo sorted_neighbours[MAX_NEIGHBOURS];
+      NeighbourInfo* sorted_neighbours[MAX_NEIGHBOURS];
       for (int i = 0; i < MAX_NEIGHBOURS; i++) {
         auto neighbour = &neighbours[i];
         if (neighbour->heard_timestamp > 0) {
-          sorted_neighbours[neighbours_count] = *neighbour;
+          sorted_neighbours[neighbours_count] = neighbour;
           neighbours_count++;
         }
       }
@@ -227,26 +227,26 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
       if (order_by == 0) {
         // sort by newest to oldest
         MESH_DEBUG_PRINTLN("REQ_TYPE_GET_NEIGHBOURS sorting newest to oldest");
-        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo &a, const NeighbourInfo &b) {
-          return a.heard_timestamp > b.heard_timestamp; // desc
+        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo* a, const NeighbourInfo* b) {
+          return a->heard_timestamp > b->heard_timestamp; // desc
         });
       } else if (order_by == 1) {
         // sort by oldest to newest
         MESH_DEBUG_PRINTLN("REQ_TYPE_GET_NEIGHBOURS sorting oldest to newest");
-        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo &a, const NeighbourInfo &b) {
-          return a.heard_timestamp < b.heard_timestamp; // asc
+        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo* a, const NeighbourInfo* b) {
+          return a->heard_timestamp < b->heard_timestamp; // asc
         });
       } else if (order_by == 2) {
         // sort by strongest to weakest
         MESH_DEBUG_PRINTLN("REQ_TYPE_GET_NEIGHBOURS sorting strongest to weakest");
-        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo &a, const NeighbourInfo &b) {
-          return a.snr > b.snr; // desc
+        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo* a, const NeighbourInfo* b) {
+          return a->snr > b->snr; // desc
         });
       } else if (order_by == 3) {
         // sort by weakest to strongest
         MESH_DEBUG_PRINTLN("REQ_TYPE_GET_NEIGHBOURS sorting weakest to strongest");
-        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo &a, const NeighbourInfo &b) {
-          return a.snr < b.snr; // asc
+        std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo* a, const NeighbourInfo* b) {
+          return a->snr < b->snr; // asc
         });
       }
 
@@ -264,7 +264,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
         }
 
         // add next neighbour to results
-        auto neighbour = &sorted_neighbours[index + offset];
+        auto neighbour = sorted_neighbours[index + offset];
         uint32_t heard_seconds_ago = getRTCClock()->getCurrentTime() - neighbour->heard_timestamp;
         memcpy(&results_buffer[results_offset], neighbour->id.pub_key, pubkey_prefix_length); results_offset += pubkey_prefix_length;
         memcpy(&results_buffer[results_offset], &heard_seconds_ago, 4); results_offset += 4;


### PR DESCRIPTION
This PR introduces a new binary request/response for fetching a paginated list of neighbours from a repeater.

The request supports the following parameters:
- `uint8_t count` how many neighbours to fetch (0-255)
- `uint16_t offset` offset from start of neighbours list (0-65535)
- `uint8_t order_by` how to order neighbours
  - `0` newest to oldest
  - `1` oldest to newest
  - `2` strongest to weakest
  - `3` weakest to strongest
- `uint8_t pubkey_prefix_length` how many bytes of the neighbours public key we want (0-32)

To use this new feature, users will need to:
- update their repeater firmware, to add support for the request/response.
- update their companion firmware, as we need to check the new `FIRMWARE_VER_LEVEL` added to the `PUSH_CODE_LOGIN_SUCCESS` to know if the repeater supports this new request
- update the companion app which will automatically use the new binary request if the `FIRMWARE_VER_LEVEL` is `>= 1`

This PR does not increase the `MAX_NEIGHBOURS` build flag for the repeater firmwares. This will need to be increased if you want to be able to remember more than 8 neighbours (the current default).