### PR TITLE
Build Script Improvements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,8 @@ build_firmware() {
   # e.g: RAK_4631_Repeater-v1.0.0-SHA
   FIRMWARE_FILENAME="$1-${FIRMWARE_VERSION_STRING}"
 
-  # export build flags for pio so we can inject firmware version info
-  export PLATFORMIO_BUILD_FLAGS="-DFIRMWARE_BUILD_DATE='\"${FIRMWARE_BUILD_DATE}\"' -DFIRMWARE_VERSION='\"${FIRMWARE_VERSION_STRING}\"'"
+  # add firmware version info to end of existing platformio build flags in environment vars
+  export PLATFORMIO_BUILD_FLAGS="${PLATFORMIO_BUILD_FLAGS} -DFIRMWARE_BUILD_DATE='\"${FIRMWARE_BUILD_DATE}\"' -DFIRMWARE_VERSION='\"${FIRMWARE_VERSION_STRING}\"'"
 
   # build firmware target
   pio run -e $1

--- a/build.sh
+++ b/build.sh
@@ -143,8 +143,11 @@ mkdir -p out
 
 # handle script args
 if [[ $1 == "build-firmware" ]]; then
-  if [ "$2" ]; then
-    build_firmware $2
+  TARGETS=${@:2}
+  if [ "$TARGETS" ]; then
+    for env in $TARGETS; do
+      build_firmware $env
+    done
   else
     echo "usage: $0 build-firmware <target>"
     exit 1


### PR DESCRIPTION
This PR improves the build script.

- It appends the firmware version info to the `PLATFORMIO_BUILD_FLAGS` env var instead of overwriting it entirely.
- It allows users to provide multiple firmware targets to the `build-firmware` command.

These changes allow users to build multiple firmwares at the same time, with custom platformio build flags, without needing to change any project files.

For example:

- The following commands build companion firmware for `Heltec v3` and `WioTrackerL1`.
- Using `v1.9.0-NZ` as the firmware version.
- Using the New Zealand radio preset by default.

```
FIRMWARE_VERSION=v1.9.0-NZ
PLATFORMIO_BUILD_FLAGS="-D LORA_FREQ=917.375 -D LORA_BW=250 -D LORA_SF=11"
./build.sh build-firmware Heltec_v3_companion_radio_ble WioTrackerL1_companion_radio_ble
```

- The following commands build WiFi companion firmware for `Heltec v3`.
- Using a custom WiFi SSID and Password.

```
FIRMWARE_VERSION=v1.9.0
PLATFORMIO_BUILD_FLAGS="-D WIFI_SSID='\"myssid\"' -D WIFI_PWD='\"mypwd\"'"
./build.sh build-firmware Heltec_v3_companion_radio_wifi
```

- The following commands build the companion firmware for `Wio Tracker L1` with the buzzer disabled.

```
FIRMWARE_VERSION=v1.9.0
PLATFORMIO_BUILD_FLAGS="-D PIN_BUZZER=0"
./build.sh build-firmware WioTrackerL1_companion_radio_ble
```