### PR TITLE
refactor variants to use standard firmware type suffixes

### DIFF
--- a/variants/rak3x72/platformio.ini
+++ b/variants/rak3x72/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ${stm32_base.build_flags}
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/rak3x72>
 
-[env:rak3x72-repeater]
+[env:rak3x72_repeater]
 extends = rak3x72
 build_flags = ${rak3x72.build_flags}
   -D ADVERT_NAME='"RAK3x72 Repeater"'
@@ -21,7 +21,7 @@ build_flags = ${rak3x72.build_flags}
 build_src_filter = ${rak3x72.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 
-[env:rak3x72-sensor]
+[env:rak3x72_sensor]
 extends = rak3x72
 build_flags = ${rak3x72.build_flags}
   -D ADVERT_NAME='"RAK3x72 Sensor"'

--- a/variants/tenstar_c3/platformio.ini
+++ b/variants/tenstar_c3/platformio.ini
@@ -23,7 +23,7 @@ build_flags =
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/tenstar_c3>
 
-[env:Tenstar_C3_repeater_sx1262]
+[env:Tenstar_C3_sx1262_repeater]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -44,7 +44,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:Tenstar_C3_repeater_sx1262_bridge_rs232]
+; [env:Tenstar_C3_sx1262_repeater_bridge_rs232]
 ; extends = Tenstar_esp32_C3
 ; build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
 ;   +<helpers/bridges/RS232Bridge.cpp>
@@ -69,7 +69,7 @@ lib_deps =
 ;   ${Tenstar_esp32_C3.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_repeater_sx1262_bridge_espnow]
+[env:Tenstar_C3_sx1262_repeater_bridge_espnow]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>
@@ -93,7 +93,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_repeater_sx1268]
+[env:Tenstar_C3_sx1268_repeater]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -113,7 +113,7 @@ lib_deps =
   ${Tenstar_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-; [env:Tenstar_C3_repeater_sx1268_bridge_rs232]
+; [env:Tenstar_C3_sx1268_repeater_bridge_rs232]
 ; extends = Tenstar_esp32_C3
 ; build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
 ;   +<helpers/bridges/RS232Bridge.cpp>
@@ -137,7 +137,7 @@ lib_deps =
 ;   ${Tenstar_esp32_C3.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
-[env:Tenstar_C3_repeater_sx1268_bridge_espnow]
+[env:Tenstar_C3_sx1268_repeater_bridge_espnow]
 extends = Tenstar_esp32_C3
 build_src_filter = ${Tenstar_esp32_C3.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>

--- a/variants/tiny_relay/platformio.ini
+++ b/variants/tiny_relay/platformio.ini
@@ -15,7 +15,7 @@ build_flags = ${stm32_base.build_flags}
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/tiny_relay>
 
-[env:Tiny_Relay-repeater]
+[env:Tiny_Relay_repeater]
 extends = Tiny_Relay
 build_flags = ${Tiny_Relay.build_flags}
   -D ADVERT_NAME='"tiny_relay Repeater"'
@@ -23,7 +23,7 @@ build_flags = ${Tiny_Relay.build_flags}
 build_src_filter = ${Tiny_Relay.build_src_filter}
   +<../examples/simple_repeater/main.cpp>
 
-[env:Tiny_Relay-sensor]
+[env:Tiny_Relay_sensor]
 extends = Tiny_Relay
 build_flags = ${Tiny_Relay.build_flags}
   -D ADVERT_NAME='"tiny_relay Sensor"'

--- a/variants/wio-e5-dev/platformio.ini
+++ b/variants/wio-e5-dev/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ${stm32_base.build_flags}
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-dev>
 
-[env:wio-e5-repeater]
+[env:wio-e5_repeater]
 extends = lora_e5
 build_flags = ${lora_e5.build_flags}
   -D LORA_TX_POWER=22

--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -16,7 +16,7 @@ build_src_filter = ${stm32_base.build_src_filter}
 lib_deps = ${stm32_base.lib_deps}
   finitespace/BME280 @ ^3.0.0
 
-[env:wio-e5-mini-repeater]
+[env:wio-e5-mini_repeater]
 extends = lora_e5_mini
 build_flags = ${lora_e5_mini.build_flags}
   -D LORA_TX_POWER=22
@@ -25,7 +25,7 @@ build_flags = ${lora_e5_mini.build_flags}
 build_src_filter = ${lora_e5_mini.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 
-[env:wio-e5-mini-sensor]
+[env:wio-e5-mini_sensor]
 extends = lora_e5_mini
 build_flags = ${lora_e5_mini.build_flags}
   -D LORA_TX_POWER=22

--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -19,7 +19,7 @@ build_flags =
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/xiao_c3>
 
-[env:Xiao_C3_repeater_sx1262]
+[env:Xiao_C3_sx1262_repeater]
 extends = Xiao_esp32_C3
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/*.cpp>


### PR DESCRIPTION
This PR refactors existing variants to use the standard firmware type suffixes:

```
_sensor
_repeater
_repeater_bridge_rs232
_repeater_bridge_espnow
_room_server
_companion_radio_ble
_companion_radio_usb
_companion_radio_wifi
```

A few variants were using dashes, or had radio types mixed in, such as `_repeater_sx1268`.

This is being done, as a follow up change to the build script will require firmware targets to have the expected suffix in order to be automatically built.

The only firmware being renamed in this PR that I could see on the web flasher is:
- `Xiao_C3_repeater_sx1262` which is being renamed to `Xiao_C3_sx1262_repeater`