### PR TITLE
build script should check for firmware type suffix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,17 @@ get_pio_envs_containing_string() {
   done
 }
 
+# $1 should be the string to find (case insensitive)
+get_pio_envs_ending_with_string() {
+  shopt -s nocasematch
+  envs=($(get_pio_envs))
+  for env in "${envs[@]}"; do
+    if [[ "$env" == *${1} ]]; then
+      echo $env
+    fi
+  done
+}
+
 # build firmware for the provided pio env in $1
 build_firmware() {
 
@@ -85,6 +96,14 @@ build_all_firmwares_matching() {
   done
 }
 
+# firmwares ending with $1 will be built
+build_all_firmwares_by_suffix() {
+  envs=($(get_pio_envs_ending_with_string "$1"))
+  for env in "${envs[@]}"; do
+    build_firmware $env
+  done
+}
+
 build_repeater_firmwares() {
 
 #  # build specific repeater firmwares
@@ -96,7 +115,7 @@ build_repeater_firmwares() {
 #  build_firmware "RAK_4631_Repeater"
 
   # build all repeater firmwares
-  build_all_firmwares_matching "repeater"
+  build_all_firmwares_by_suffix "_repeater"
 
 }
 
@@ -115,8 +134,8 @@ build_companion_firmwares() {
 #  build_firmware "t1000e_companion_radio_ble"
 
   # build all companion firmwares
-  build_all_firmwares_matching "companion_radio_usb"
-  build_all_firmwares_matching "companion_radio_ble"
+  build_all_firmwares_by_suffix "_companion_radio_usb"
+  build_all_firmwares_by_suffix "_companion_radio_ble"
 
 }
 
@@ -127,7 +146,7 @@ build_room_server_firmwares() {
 #  build_firmware "RAK_4631_room_server"
 
   # build all room server firmwares
-  build_all_firmwares_matching "room_server"
+  build_all_firmwares_by_suffix "_room_server"
 
 }
 


### PR DESCRIPTION
This PR updates our build script to ensure we are only building firmwares where the suffix matches the expected firmware type.

Previously, we were building all firmwares that contained the text `repeater`, when building repeater firmwares. This would mean the `repeater_bridge` firmwares would also be built when we release v1.9.0

We don't need to build the bridge firmwares for the web flasher at this time.