### PR TITLE
fix multiple candidates warning

### DIFF
--- a/src/Identity.h
+++ b/src/Identity.h
@@ -64,7 +64,7 @@ public:
    * \param  secret OUT - the 'shared secret' (must be PUB_KEY_SIZE bytes)
    * \param  other IN - the second party in the exchange.
   */
-  void calcSharedSecret(uint8_t* secret, const Identity& other) { calcSharedSecret(secret, other.pub_key); }
+  void calcSharedSecret(uint8_t* secret, const Identity& other) const { calcSharedSecret(secret, other.pub_key); }
 
   /**
    * \brief  the ECDH key exhange, with Ed25519 public key transposed to Ex25519.


### PR DESCRIPTION
This PR adds `const` to the `calcSharedSecret` method to avoid the multiple candidates warning during compilation.

<img width="856" height="620" alt="Screenshot 2025-09-28 at 6 17 05 PM" src="https://github.com/user-attachments/assets/d0ed716a-bf16-40e5-b387-e45d66128a35" />
