### PR TITLE
Fix: add missing build flags for tiny_relay

### DIFF
--- a/variants/tiny_relay/platformio.ini
+++ b/variants/tiny_relay/platformio.ini
@@ -19,15 +19,21 @@ build_src_filter = ${stm32_base.build_src_filter}
 extends = Tiny_Relay
 build_flags = ${Tiny_Relay.build_flags}
   -D ADVERT_NAME='"tiny_relay Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
 build_src_filter = ${Tiny_Relay.build_src_filter}
-  +<../examples/simple_repeater/main.cpp>
+  +<../examples/simple_repeater>
 
 [env:Tiny_Relay_sensor]
 extends = Tiny_Relay
 build_flags = ${Tiny_Relay.build_flags}
   -D ADVERT_NAME='"tiny_relay Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
 build_src_filter = ${Tiny_Relay.build_src_filter}
   +<../examples/simple_sensor>
 


### PR DESCRIPTION
- Add ADVERT_LAT and ADVERT_LON definitions for both repeater and sensor variants
- Set MAX_NEIGHBOURS to 50 for improved network capacity