### PR TITLE
Add CLI Command: board

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -399,6 +399,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       sprintf(reply, "File system erase: %s", s ? "OK" : "Err");
     } else if (memcmp(command, "ver", 3) == 0) {
       sprintf(reply, "%s (Build: %s)", _callbacks->getFirmwareVer(), _callbacks->getBuildDate());
+    } else if (memcmp(command, "board", 5) == 0) {
+      sprintf(reply, "%s", _board->getManufacturerName());
     } else if (memcmp(command, "log start", 9) == 0) {
       _callbacks->setLoggingOn(true);
       strcpy(reply, "   logging on");


### PR DESCRIPTION
This PR adds a new admin CLI command `board`, so users can fetch the board name from remote devices.

<img src="https://github.com/user-attachments/assets/623d40fb-4f8c-45a3-b9de-47aad0063a30" width="300px"/>
