### PR TITLE
Fix debug log: use c->extra.room.push_failures instead of c->push_failures

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -784,7 +784,7 @@ void MyMesh::loop() {
       if (c->extra.room.pending_ack && millisHasNowPassed(c->extra.room.ack_timeout)) {
         c->extra.room.push_failures++;
         c->extra.room.pending_ack = 0; // reset  (TODO: keep prev expected_ack's in a list, incase they arrive LATER, after we retry)
-        MESH_DEBUG_PRINTLN("pending ACK timed out: push_failures: %d", (uint32_t)c->push_failures);
+        MESH_DEBUG_PRINTLN("pending ACK timed out: push_failures: %d", (uint32_t)c->extra.room.push_failures);
       }
     }
     // check next Round-Robin client, and sync next new post


### PR DESCRIPTION
This PR fixes a bug in the debug log of `examples/simple_room_server/MyMesh.cpp` around line 787.  
The code was incorrectly using `c->push_failures` (which does not exist) instead of `c->extra.room.push_failures`.