### PR TITLE
CommonCLI: gps management commands

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -758,6 +758,44 @@ void MyMesh::removeNeighbor(const uint8_t *pubkey, int key_len) {
 #endif
 }
 
+void MyMesh::gpsGetStatus(char * reply) {
+  LocationProvider * l = sensors.getLocationProvider();
+  if (l != NULL) {
+    bool status = l->isActive();
+    bool sync = l->isValid();
+    int sats = l->satellitesCount();
+    if (status) {
+      sprintf(reply, "on, %s, %d sats", sync?"fix":"no fix", sats);
+    } else {
+      strcpy(reply, "off");
+    }
+  } else {
+    strcpy(reply, "Can't find GPS");
+  }
+}
+
+void MyMesh::gpsStart() {
+  LocationProvider * l = sensors.getLocationProvider();
+  if (l != NULL) {
+    l->begin();
+    l->reset();
+  }
+}
+ 
+void MyMesh::gpsStop() {
+  LocationProvider * l = sensors.getLocationProvider();
+  if (l != NULL) {
+    l->stop();
+  }
+}
+
+void MyMesh::gpsSyncTime() {
+  LocationProvider * l = sensors.getLocationProvider();
+  if (l != NULL) {
+    l->syncTime();
+  }
+}
+
 void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
   self_id = new_id;
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -176,6 +176,12 @@ public:
   void formatNeighborsReply(char *reply) override;
   void removeNeighbor(const uint8_t* pubkey, int key_len) override;
 
+  // Gps mgmt cli callbacks
+  void gpsGetStatus(char * reply) override;
+  void gpsStart() override;
+  void gpsStop() override;
+  void gpsSyncTime() override;
+
   mesh::LocalIdentity& getSelfId() override { return self_id; }
 
   void saveIdentity(const mesh::LocalIdentity& new_id) override;

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -401,6 +401,19 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       sprintf(reply, "%s (Build: %s)", _callbacks->getFirmwareVer(), _callbacks->getBuildDate());
     } else if (memcmp(command, "board", 5) == 0) {
       sprintf(reply, "%s", _board->getManufacturerName());
+#if ENV_INCLUDE_GPS == 1
+    } else if (memcmp(command, "gps on", 6) == 0) {
+      _callbacks->gpsStart();
+      strcpy(reply, "ok");
+    } else if (memcmp(command, "gps off", 7) == 0) {
+      _callbacks->gpsStop();
+      strcpy(reply, "ok");
+    } else if (memcmp(command, "gps sync", 8) == 0) {
+      _callbacks->gpsSyncTime();
+      strcpy(reply, "Waiting fix ...");
+    } else if (memcmp(command, "gps", 3) == 0) {
+      _callbacks->gpsGetStatus(reply);
+#endif
     } else if (memcmp(command, "log start", 9) == 0) {
       _callbacks->setLoggingOn(true);
       strcpy(reply, "   logging on");

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -50,6 +50,10 @@ public:
   virtual void saveIdentity(const mesh::LocalIdentity& new_id) = 0;
   virtual void clearStats() = 0;
   virtual void applyTempRadioParams(float freq, float bw, uint8_t sf, uint8_t cr, int timeout_mins) = 0;
+  virtual void gpsGetStatus(char * reply) {}
+  virtual void gpsStart() {}
+  virtual void gpsStop() {}
+  virtual void gpsSyncTime() {}
 };
 
 class CommonCLI {

--- a/src/helpers/sensors/LocationProvider.h
+++ b/src/helpers/sensors/LocationProvider.h
@@ -21,4 +21,5 @@ public:
     virtual void begin() = 0;
     virtual void stop() = 0;
     virtual void loop() = 0;
+    virtual bool isActive() = 0;
 };

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -78,6 +78,16 @@ public :
         }        
     }
 
+    bool isActive() override {
+        // directly read the enable pin if present as gps can be
+        // activated/deactivated outside of here ...
+        if (_pin_en != -1) {
+            return digitalRead(_pin_en) == PIN_GPS_EN_ACTIVE;
+        } else {
+            return true; // no enable so must be active
+        }
+    }
+
     void syncTime() override { nmea.clear(); LocationProvider::syncTime(); }
     long getLatitude() override { return nmea.getLatitude(); }
     long getLongitude() override { return nmea.getLongitude(); }


### PR DESCRIPTION
Some commands to manage GPS (on repeaters for the moment)

* gps : prints gps status (on/off, fix/no fix, sat nb)
* gps on
* gps off
* gps sync : will sync time at next fix

This will be enhanced with parameters when #831 is in (because it adds parameters ;))
* get/set gps.onboot

and possibly parameters for pwm functionality #778 that is currently under review 

Tested on Techo repeater