### PR TITLE
feat: ignore supplied password for passwordless room servers

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -303,7 +303,7 @@ void MyMesh::onAnonDataRecv(mesh::Packet *packet, const uint8_t *secret, const m
       if (strcmp((char *)&data[8], _prefs.password) == 0) { // check for valid admin password
         perm = PERM_ACL_ADMIN;
       } else {
-        if (strcmp((char *)&data[8], _prefs.guest_password) == 0) {   // check the room/public password
+        if (strlen(_prefs.guest_password) == 0 || strcmp((char *)&data[8], _prefs.guest_password) == 0) {   // check the room/public password
           perm = PERM_ACL_READ_WRITE;
         } else if (_prefs.allow_read_only) {
           perm = PERM_ACL_GUEST;


### PR DESCRIPTION
If the password is intentionally left empty, we can assume the operator wants this room server to be public. In such cases it's less frustrating for users to simply accept any password.

A neater solution might be introducing a separate build flag that explicitly enables password-less public room servers, but the downside is that it requires a separate firmware image or custom build, whereas this solution works for any room server that's already configured without a password. We could think about adding a special case for the "hello" password as well.

Just thinking out loud: we could introduce a separate type indicator (chat, repeater, room, public room) for password-less servers that skips the login procedure altogether to further improve the user experience. Another alternative to that might be a quick status request that indicates if the room server is up and whether it requires authentication.