### PR TITLE
Include battery voltage as feature 1 in adverts

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -164,16 +164,20 @@ void CommonCLI::savePrefs() {
 }
 
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
-  if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
-    AdvertDataBuilder builder(node_type, _prefs->node_name);
-    return builder.encodeTo(app_data);
-  } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
-    AdvertDataBuilder builder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
-    return builder.encodeTo(app_data);
-  } else {
-    AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
-    return builder.encodeTo(app_data);
+  AdvertDataBuilder builder(node_type, _prefs->node_name);
+
+  if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
+    builder = AdvertDataBuilder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
+  } else if (_prefs->advert_loc_policy == ADVERT_LOC_PREFS) {
+    builder = AdvertDataBuilder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
   }
+
+  uint16_t batt_mv = _board->getBattMilliVolts();
+  if (batt_mv > 0) {
+    builder.setFeat1(batt_mv);
+  }
+
+  return builder.encodeTo(app_data);
 }
 
 void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, char* reply) {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -164,12 +164,12 @@ void CommonCLI::savePrefs() {
 }
 
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
-  AdvertDataBuilder builder(node_type, _prefs->node_name);
+  AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
 
-  if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
+  if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
+    builder = AdvertDataBuilder(node_type, _prefs->node_name);
+  } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
     builder = AdvertDataBuilder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
-  } else if (_prefs->advert_loc_policy == ADVERT_LOC_PREFS) {
-    builder = AdvertDataBuilder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
   }
 
   uint16_t batt_mv = _board->getBattMilliVolts();


### PR DESCRIPTION
Using the board's battery voltage, include it as feature 1 in AdvertDataBuilder. Instead of trying to log in and then trying to request repeater stats, which may fail, would be nice to have the battery voltage included in adverts. 