### PR TITLE
Add battery mapping for more accurate battery levels

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -1,5 +1,6 @@
 #include "UITask.h"
 #include <helpers/TxtDataHelpers.h>
+#include <helpers/Battery.h>
 #include "../MyMesh.h"
 #include "target.h"
 #ifdef WIFI_SSID
@@ -111,17 +112,7 @@ class HomeScreen : public UIScreen {
 
   void renderBatteryIndicator(DisplayDriver& display, uint16_t batteryMilliVolts) {
     // Convert millivolts to percentage
-#ifndef BATT_MIN_MILLIVOLTS
-  #define BATT_MIN_MILLIVOLTS 3000
-#endif
-#ifndef BATT_MAX_MILLIVOLTS
-  #define BATT_MAX_MILLIVOLTS 4200
-#endif
-    const int minMilliVolts = BATT_MIN_MILLIVOLTS;
-    const int maxMilliVolts = BATT_MAX_MILLIVOLTS;
-    int batteryPercentage = ((batteryMilliVolts - minMilliVolts) * 100) / (maxMilliVolts - minMilliVolts);
-    if (batteryPercentage < 0) batteryPercentage = 0; // Clamp to 0%
-    if (batteryPercentage > 100) batteryPercentage = 100; // Clamp to 100%
+    int batteryPercentage = batteryPercentFromMilliVolts(batteryMilliVolts);
 
     // battery icon
     int iconWidth = 24;
@@ -358,8 +349,20 @@ public:
             strcpy(name, "gps"); sprintf(buf, "%.4f %.4f", lat, lon);
             break;
           case LPP_VOLTAGE:
-            r.readVoltage(v);
-            strcpy(name, "voltage"); sprintf(buf, "%6.2f", v);
+            r.readVoltage(v);  // v is in volts
+
+            if (channel == TELEM_CHANNEL_SELF) {
+              // This is our own battery voltage
+              uint16_t batteryMilliVolts = (uint16_t)(v * 1000.0f + 0.5f); // convert V -> mV
+              int pct = batteryPercentFromMilliVolts(batteryMilliVolts);
+
+              strcpy(name, "battery");
+              sprintf(buf, "%4.2fV %3d%%", v, pct);
+            } else {
+              // Other voltage sensor
+              strcpy(name, "voltage");
+              sprintf(buf, "%6.2f", v);
+            }
             break;
           case LPP_CURRENT:
             r.readCurrent(v);

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -1,6 +1,7 @@
 #include "UITask.h"
 #include <Arduino.h>
 #include <helpers/TxtDataHelpers.h>
+#include <helpers/Battery.h>
 #include "../MyMesh.h"
 
 #define AUTO_OFF_MILLIS     15000   // 15 seconds
@@ -149,17 +150,7 @@ void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, i
 
 void UITask::renderBatteryIndicator(uint16_t batteryMilliVolts) {
   // Convert millivolts to percentage
-#ifndef BATT_MIN_MILLIVOLTS
-  #define BATT_MIN_MILLIVOLTS 3000
-#endif
-#ifndef BATT_MAX_MILLIVOLTS
-  #define BATT_MAX_MILLIVOLTS 4200
-#endif
-  const int minMilliVolts = BATT_MIN_MILLIVOLTS;
-  const int maxMilliVolts = BATT_MAX_MILLIVOLTS;
-  int batteryPercentage = ((batteryMilliVolts - minMilliVolts) * 100) / (maxMilliVolts - minMilliVolts);
-  if (batteryPercentage < 0) batteryPercentage = 0; // Clamp to 0%
-  if (batteryPercentage > 100) batteryPercentage = 100; // Clamp to 100%
+  int batteryPercentage = batteryPercentFromMilliVolts(batteryMilliVolts);
 
   // battery icon
   int iconWidth = 24;

--- a/src/helpers/Battery.cpp
+++ b/src/helpers/Battery.cpp
@@ -15,6 +15,11 @@ int batteryPercentFromMilliVolts(uint16_t batteryMilliVolts) {
   const uint8_t stepPct = 10;         // distance between table entries (100 → 90 → ... → 0)
   const size_t n = kOcvTableSize;     // should be 11
 
+  if (NUM_CELLS_IN_SERIES > 1) {
+    // Adjust the input voltage to per-cell basis
+    batteryMilliVolts /= NUM_CELLS_IN_SERIES;
+  }
+
   if (n != 11 || batteryMilliVolts <= 0) {
     // Error: invalid OCV_ARRAY table size or voltage
     return -1;

--- a/src/helpers/Battery.cpp
+++ b/src/helpers/Battery.cpp
@@ -1,0 +1,65 @@
+#include <stddef.h>
+#include "Battery.h"
+
+// Build the OCV table from the configured macro.
+// 11 entries: 100%, 90%, ..., 0%.
+static const uint16_t kOcvTable[] = { OCV_ARRAY };
+static const size_t kOcvTableSize = sizeof(kOcvTable) / sizeof(kOcvTable[0]);
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+static_assert(kOcvTableSize == 11,
+              "OCV_ARRAY must contain exactly 11 entries: 100%, 90%, ..., 0%.");
+#endif
+
+int batteryPercentFromMilliVolts(uint16_t batteryMilliVolts) {
+  const uint8_t stepPct = 10;         // distance between table entries (100 → 90 → ... → 0)
+  const size_t n = kOcvTableSize;     // should be 11
+
+  if (n != 11 || batteryMilliVolts <= 0) {
+    // Error: invalid OCV_ARRAY table size or voltage
+    return -1;
+  }
+
+  // Above or equal to "full" voltage → clamp to 100%
+  if (batteryMilliVolts >= kOcvTable[0]) {
+    return 100;
+  }
+
+  // Below or equal to "empty" voltage → clamp to 0%
+  if (batteryMilliVolts <= kOcvTable[n - 1]) {
+    return 0;
+  }
+
+  // Find the segment [i, i+1] where:
+  //   vHigh >= batteryMilliVolts >= vLow
+  // and map that to [pctHigh, pctLow] = [100 - 10*i, 100 - 10*(i+1)]
+  for (size_t i = 0; i < n - 1; ++i) {
+    uint16_t vHigh = kOcvTable[i];       // higher voltage, higher %
+    uint16_t vLow  = kOcvTable[i + 1];   // lower voltage, lower %
+
+    if (batteryMilliVolts <= vHigh && batteryMilliVolts >= vLow) {
+      uint8_t pctHigh = 100 - i * stepPct;
+      uint8_t pctLow  = 100 - (i + 1) * stepPct;
+
+      uint16_t dv = vHigh - vLow;
+      if (dv == 0) {
+        return pctLow;
+      }
+
+      // How far are we from the low voltage towards the high, as a fraction of the segment?
+      uint16_t pv = batteryMilliVolts - vLow;  // in [0, dv]
+
+      // Interpolate percentage within this 10% band.
+      uint8_t deltaPct = (uint32_t)pv * stepPct / dv;
+      int pct = pctLow + deltaPct;
+
+      // Clamp to [0, 100]
+      if (pct < 0)   pct = 0;
+      if (pct > 100) pct = 100;
+      return pct;
+    }
+  }
+
+  // Should be unreachable if the table is monotonic and cases above are handled.
+  return -1;
+}

--- a/src/helpers/Battery.h
+++ b/src/helpers/Battery.h
@@ -31,6 +31,14 @@
   #endif
 #endif
 
+/**
+ * Number of cells in series (for multi-cell battery packs)
+ * Default to 1 if not defined.
+ */
+#ifndef NUM_CELLS_IN_SERIES
+  #define NUM_CELLS_IN_SERIES 1
+#endif
+
 
 /**
  * Convert a battery voltage (in millivolts) to approximate state-of-charge (%),

--- a/src/helpers/Battery.h
+++ b/src/helpers/Battery.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+// -----------------------------------------------------------------------------
+// Open Circuit Voltage (OCV) map configuration
+//
+// OCV_ARRAY must expand to 11 integer millivolt values, corresponding to:
+//
+//   100%, 90%, 80%, 70%, 60%, 50%, 40%, 30%, 20%, 10%, 0%
+//
+// in *descending* voltage order.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef OCV_ARRAY
+  #ifdef CELL_TYPE_LIFEPO4
+    #define OCV_ARRAY 3400, 3350, 3320, 3290, 3270, 3260, 3250, 3230, 3200, 3120, 3000
+  #elif defined(CELL_TYPE_LEADACID)
+    #define OCV_ARRAY 2120, 2090, 2070, 2050, 2030, 2010, 1990, 1980, 1970, 1960, 1950
+  #elif defined(CELL_TYPE_ALKALINE)
+    #define OCV_ARRAY 1580, 1400, 1350, 1300, 1280, 1250, 1230, 1190, 1150, 1100, 1000
+  #elif defined(CELL_TYPE_NIMH)
+    #define OCV_ARRAY 1400, 1300, 1280, 1270, 1260, 1250, 1240, 1230, 1210, 1150, 1000
+  #elif defined(CELL_TYPE_LTO)
+    #define OCV_ARRAY 2700, 2560, 2540, 2520, 2500, 2460, 2420, 2400, 2380, 2320, 1500
+  #else 
+    // Default Li-Ion / Li-Po
+    #define OCV_ARRAY 4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100
+  #endif
+#endif
+
+
+/**
+ * Convert a battery voltage (in millivolts) to approximate state-of-charge (%),
+ * using the OCV curve defined by OCV_ARRAY.
+ *
+ * Assumes:
+ *  - OCV_ARRAY has 11 entries, in descending order.
+ *  - These correspond to 100, 90, 80, ..., 0 percent.
+ *  - The input batteryMilliVolts is in the same scale as the OCV values.
+ *
+ * Returns an integer percentage in [0, 100] or -1 on error.
+ */
+int batteryPercentFromMilliVolts(uint16_t batteryMilliVolts);

--- a/variants/lilygo_tbeam_1w/platformio.ini
+++ b/variants/lilygo_tbeam_1w/platformio.ini
@@ -32,8 +32,7 @@ build_flags =
   -D LORA_TX_POWER=22
 
   ; Battery - 2S 7.4V LiPo (6.0V min, 8.4V max)
-  -D BATT_MIN_MILLIVOLTS=6000
-  -D BATT_MAX_MILLIVOLTS=8400
+  -D NUM_CELLS_IN_SERIES=2
 
   ; Display - SH1106 OLED at 0x3C
   -D DISPLAY_CLASS=SH1106Display


### PR DESCRIPTION
This adds battery chemistry type mapping for more accurate battery percentage to be calculated for companion devices. It also adds in the battery percentage as a number in the sensor screen on the companion ui-new. 

This is similar to the approach used by meshtastic and i think its one of the easy ways to handle this without bloating the memory usage as only a single OCV table needs to be loaded in at a time, li-ion is used by default since most devices use that. Using a similar approach to meshtastic and using the same table definition should also allow for easy collaboration down the line for these curves, say a new device is released and its got a new battery chemistry or a funky curve, either meshtastic or meshcore can do the initial implementation and the OCV_ARRAY should be able to be copied over between the two projects. 

It can be changed in the variants.h file for devices in case some devices come from the factory with a different chemistry type by setting
-D CELL_TYPE_LIFEPO4=1

It should also allow variants to define their own curve with the OCV_ARRAY build flag with their own 11 values map.

This will not impact the percentages displayed from the mobile app side as that uses its own calculations for it from my understanding and that probably always maps over to li-ion curve so it either needs to be updated to pull battery percentage from the device that way it uses the correct chemistry curve automatically or meshcore needs to broadcast the chemistry type externally so the app can chose the correct curve.

For now i left it out of the main meshcore code and only used it in the ui but it should hopefully be easy to add in everywhere else and use it instead voltages so it does certain tasks when percentage thresholds are reached such as shutting down at X percentage.

This also adds a NUM_CELLS_IN_SERIES build flag that defaults to 1 that way it brings the pack voltage down to an averaged cell value to be used for the mapping. This is untested though as i only have the t-echo with the single cell.

I only have t-echo devices for now so this was only tested two t-echos to compare the before and after % so it probably needs to be tested by other devices and other chemistry types to see if its calculating the percentages correctly.

Inspired by #413 
Fixes #1124 #398 