### PR TITLE
Removed halt and replaced it with a delay and reboot

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -101,8 +101,18 @@ MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables, store
 
 /* END GLOBAL OBJECTS */
 
-void halt() {
-  delay(10000);
+void delayedReboot(const char *msg, const uint32_t delayms) {
+  char tmp[32];
+  sprintf(tmp, "Rebooting in %3.1fs", delayms/1000.0);
+  #ifdef DISPLAY_CLASS
+    display.startFrame();
+    display.drawTextCentered(display.width() / 2, 24, msg);
+    display.drawTextCentered(display.width() / 2, 32, tmp);
+    display.endFrame();
+  #endif
+  MESH_DEBUG_PRINTLN(msg);
+  MESH_DEBUG_PRINTLN(tmp);
+  delay(delayms);
   board.reboot();
 }
 
@@ -123,7 +133,8 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  if (!radio_init())
+    delayedReboot("Radio Init Failed!", 5000);
 
   fast_rng.begin(radio_get_rng_seed());
 

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -102,14 +102,14 @@ MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables, store
 /* END GLOBAL OBJECTS */
 
 void halt() {
-  while (1) ;
+  delay(10000);
+  board.reboot();
 }
 
 void setup() {
   Serial.begin(115200);
 
   board.begin();
-
 #ifdef DISPLAY_CLASS
   DisplayDriver* disp = NULL;
   if (display.begin()) {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -14,7 +14,8 @@ SimpleMeshTables tables;
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
 void halt() {
-  while (1) ;
+  delay(10000);
+  board.reboot();
 }
 
 static char command[160];

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -13,8 +13,18 @@ SimpleMeshTables tables;
 
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
-void halt() {
-  delay(10000);
+void delayedReboot(const char *msg, const uint32_t delayms) {
+  char tmp[32];
+  sprintf(tmp, "Rebooting in %3.1fs", delayms/1000.0);
+  #ifdef DISPLAY_CLASS
+    display.startFrame();
+    display.drawTextCentered(display.width() / 2, 24, msg);
+    display.drawTextCentered(display.width() / 2, 32, tmp);
+    display.endFrame();
+  #endif
+  MESH_DEBUG_PRINTLN(msg);
+  MESH_DEBUG_PRINTLN(tmp);
+  delay(delayms);
   board.reboot();
 }
 
@@ -35,9 +45,8 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) {
-    halt();
-  }
+  if (!radio_init())
+    delayedReboot("Radio Init Failed!", 5000);
 
   fast_rng.begin(radio_get_rng_seed());
 

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -13,7 +13,8 @@ SimpleMeshTables tables;
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
 void halt() {
-  while (1) ;
+  delay(10000);
+  board.reboot();
 }
 
 static char command[MAX_POST_TEXT_LEN+1];

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -12,8 +12,18 @@ StdRNG fast_rng;
 SimpleMeshTables tables;
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
-void halt() {
-  delay(10000);
+void delayedReboot(const char *msg, const uint32_t delayms) {
+  char tmp[32];
+  sprintf(tmp, "Rebooting in %3.1fs", delayms/1000.0);
+  #ifdef DISPLAY_CLASS
+    display.startFrame();
+    display.drawTextCentered(display.width() / 2, 24, msg);
+    display.drawTextCentered(display.width() / 2, 32, tmp);
+    display.endFrame();
+  #endif
+  MESH_DEBUG_PRINTLN(msg);
+  MESH_DEBUG_PRINTLN(tmp);
+  delay(delayms);
   board.reboot();
 }
 
@@ -34,7 +44,9 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+    
+  if (!radio_init())
+    delayedReboot("Radio Init Failed!", 5000);
 
   fast_rng.begin(radio_get_rng_seed());
 

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -550,8 +550,18 @@ StdRNG fast_rng;
 SimpleMeshTables tables;
 MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables);
 
-void halt() {
-  delay(10000);
+void delayedReboot(const char *msg, const uint32_t delayms) {
+  char tmp[32];
+  sprintf(tmp, "Rebooting in %3.1fs", delayms/1000.0);
+  #ifdef DISPLAY_CLASS
+    display.startFrame();
+    display.drawTextCentered(display.width() / 2, 24, msg);
+    display.drawTextCentered(display.width() / 2, 32, tmp);
+    display.endFrame();
+  #endif
+  MESH_DEBUG_PRINTLN(msg);
+  MESH_DEBUG_PRINTLN(tmp);
+  delay(delayms);
   board.reboot();
 }
 
@@ -560,7 +570,8 @@ void setup() {
   
   board.begin();
 
-  if (!radio_init()) { halt(); }
+  if (!radio_init())
+    delayedReboot("Radio Init Failed!", 5000);
 
   fast_rng.begin(radio_get_rng_seed());
 

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -551,12 +551,13 @@ SimpleMeshTables tables;
 MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables);
 
 void halt() {
-  while (1) ;
+  delay(10000);
+  board.reboot();
 }
 
 void setup() {
   Serial.begin(115200);
-
+  
   board.begin();
 
   if (!radio_init()) { halt(); }

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -47,7 +47,8 @@ SimpleMeshTables tables;
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
 void halt() {
-  while (1) ;
+  delay(10000);
+  board.reboot();
 }
 
 static char command[160];

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -46,8 +46,18 @@ SimpleMeshTables tables;
 
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
-void halt() {
-  delay(10000);
+void delayedReboot(const char *msg, const uint32_t delayms) {
+  char tmp[32];
+  sprintf(tmp, "Rebooting in %3.1fs", delayms/1000.0);
+  #ifdef DISPLAY_CLASS
+    display.startFrame();
+    display.drawTextCentered(display.width() / 2, 24, msg);
+    display.drawTextCentered(display.width() / 2, 32, tmp);
+    display.endFrame();
+  #endif
+  MESH_DEBUG_PRINTLN(msg);
+  MESH_DEBUG_PRINTLN(tmp);
+  delay(delayms);
   board.reboot();
 }
 
@@ -67,7 +77,8 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  if (!radio_init())
+    delayedReboot("Radio Init Failed!", 5000);
 
   fast_rng.begin(radio_get_rng_seed());
 


### PR DESCRIPTION
Replaced the halt function with a delay and reboot, instead of an infinite loop. This removes an edge case were there's a bad brown out and the radio fails to initialize properly.

As @liamcottle suggested I have added an error message that is customizable to other failure cases. I also added debug output for nodes without a screen attached.