### PR TITLE
Unify nRF & ESP BLE interface - Phase 1

### DIFF
--- a/src/helpers/SerialBLECommon.h
+++ b/src/helpers/SerialBLECommon.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "BaseSerialInterface.h"
+#include <string.h>
+
+// Units: interval=1.25ms, timeout=10ms
+#define BLE_MIN_CONN_INTERVAL      12
+#define BLE_MAX_CONN_INTERVAL      36
+#define BLE_SLAVE_LATENCY          3
+#define BLE_CONN_SUP_TIMEOUT       500
+
+// Sync mode: higher throughput (min 15ms for Apple compliance)
+#define BLE_SYNC_MIN_CONN_INTERVAL   12
+#define BLE_SYNC_MAX_CONN_INTERVAL   24
+#define BLE_SYNC_SLAVE_LATENCY       0
+#define BLE_SYNC_CONN_SUP_TIMEOUT    300
+
+#define BLE_SYNC_INACTIVITY_TIMEOUT_MS  5000
+
+// Units: advertising interval=0.625ms
+// ESP randomly chooses between 32 and 338
+// max seems slow, but we can wait a few seconds for it to connect, worth the battery
+#define BLE_ADV_INTERVAL_MIN       32
+#define BLE_ADV_INTERVAL_MAX       338
+#define BLE_ADV_FAST_TIMEOUT       30
+
+#define BLE_HEALTH_CHECK_INTERVAL  10000
+#define BLE_RETRY_THROTTLE_MS      250
+#define BLE_MIN_SEND_INTERVAL_MS   8
+#define BLE_RX_DRAIN_BUF_SIZE      32
+
+#define SERVICE_UUID           "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
+#define CHARACTERISTIC_UUID_RX "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+#define CHARACTERISTIC_UUID_TX "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+
+#define BLE_SYNC_FRAME_SIZE_THRESHOLD  40
+#define BLE_SYNC_LARGE_FRAME_COUNT_THRESHOLD  3
+#define BLE_SYNC_LARGE_FRAME_WINDOW_MS  1500
+
+#define BLE_CONN_HANDLE_INVALID  0xFFFF
+
+// BLE specific MTU target, ESP can do more, but we don't need it, so stay at max nRF52
+#define BLE_MAX_MTU              247
+
+// ESP needs this to set manually, nRF52 handles it automatically
+#define BLE_DLE_MAX_TX_OCTETS    251
+#define BLE_DLE_MAX_TX_TIME_US   2120  // Not used by Bluedroid, only needed if we migrate to NimBLE
+
+// nRF only now, keeping this to preserver current settings
+#ifndef BLE_TX_POWER
+#define BLE_TX_POWER 4
+#endif
+
+struct SerialBLEFrame {
+  uint8_t len;
+  uint8_t buf[MAX_FRAME_SIZE];
+};
+
+// Queue size: NRF52 event-driven TX drains greedily, so smaller queue works.
+// ESP32 polling still benefits from buffering. 4 slots = ~700 bytes per queue.
+#define FRAME_QUEUE_SIZE  4
+
+struct CircularFrameQueue {
+  SerialBLEFrame frames[FRAME_QUEUE_SIZE];
+  uint8_t head;
+  uint8_t tail;
+  uint8_t count;
+
+  void init() {
+    head = 0;
+    tail = 0;
+    count = 0;
+  }
+
+  bool isEmpty() const {
+    return count == 0;
+  }
+
+  bool isFull() const {
+    return count >= FRAME_QUEUE_SIZE;
+  }
+
+  SerialBLEFrame* peekFront() {
+    if (isEmpty()) return nullptr;
+    return &frames[tail];
+  }
+
+  SerialBLEFrame* getWriteSlot() {
+    if (isFull()) return nullptr;
+    return &frames[head];
+  }
+
+  void push() {
+    if (!isFull()) {
+      head = (head + 1) % FRAME_QUEUE_SIZE;
+      count++;
+    }
+  }
+
+  void pop() {
+    if (!isEmpty()) {
+      tail = (tail + 1) % FRAME_QUEUE_SIZE;
+      count--;
+    }
+  }
+
+  uint8_t size() const {
+    return count;
+  }
+};
+
+#if BLE_DEBUG_LOGGING && ARDUINO
+  #include <Arduino.h>
+  #define BLE_DEBUG_PRINT(F, ...) Serial.printf("BLE: " F, ##__VA_ARGS__)
+  #define BLE_DEBUG_PRINTLN(F, ...) Serial.printf("BLE: " F "\n", ##__VA_ARGS__)
+#else
+  #define BLE_DEBUG_PRINT(...) {}
+  #define BLE_DEBUG_PRINTLN(...) {}
+#endif
+
+class SerialBLEInterfaceBase : public BaseSerialInterface {
+protected:
+  bool _isEnabled;
+  bool _isDeviceConnected;
+  uint16_t _conn_handle;
+  unsigned long _last_health_check;
+  unsigned long _last_retry_attempt;
+  unsigned long _last_send_time;
+  unsigned long _last_activity_time;
+  bool _sync_mode;
+  bool _conn_param_update_pending;
+  uint8_t _large_frame_count;
+  unsigned long _large_frame_window_start;
+
+  CircularFrameQueue send_queue;
+  CircularFrameQueue recv_queue;
+
+  void clearTransferState() {
+    send_queue.init();
+    recv_queue.init();
+    _last_retry_attempt = 0;
+    _last_send_time = 0;
+    _last_activity_time = 0;
+    _sync_mode = false;
+    _conn_param_update_pending = false;
+    _large_frame_count = 0;
+    _large_frame_window_start = 0;
+  }
+
+  void popSendQueue() {
+    send_queue.pop();
+  }
+
+  void popRecvQueue() {
+    recv_queue.pop();
+  }
+
+  bool noteFrameActivity(unsigned long now, size_t frame_len) {
+    if (frame_len < BLE_SYNC_FRAME_SIZE_THRESHOLD) {
+      return false;
+    }
+
+    _last_activity_time = now;
+
+    if (_large_frame_window_start == 0 ||
+        (now - _large_frame_window_start) > BLE_SYNC_LARGE_FRAME_WINDOW_MS) {
+      _large_frame_count = 1;
+      _large_frame_window_start = now;
+    } else if (_large_frame_count < 255) {
+      _large_frame_count++;
+    }
+
+    return (!_sync_mode && _large_frame_count >= BLE_SYNC_LARGE_FRAME_COUNT_THRESHOLD);
+  }
+
+  bool isWriteBusyCommon() const {
+    return send_queue.size() >= (FRAME_QUEUE_SIZE * 2 / 3);
+  }
+
+  void initCommonState() {
+    _isEnabled = false;
+    _isDeviceConnected = false;
+    _conn_handle = BLE_CONN_HANDLE_INVALID;
+    _last_health_check = 0;
+    _last_retry_attempt = 0;
+    _last_send_time = 0;
+    _last_activity_time = 0;
+    _sync_mode = false;
+    _conn_param_update_pending = false;
+    _large_frame_count = 0;
+    _large_frame_window_start = 0;
+    send_queue.init();
+    recv_queue.init();
+  }
+};
+

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -1,15 +1,95 @@
 #include "SerialBLEInterface.h"
+#include <string.h>
+#include <esp_gap_ble_api.h>
 
-// See the following for generating UUIDs:
-// https://www.uuidgenerator.net/
+// ESP32 TX Model: Bluedroid's notify() has no async TX complete event for
+// notifications (only indications get ESP_GATTS_CONF_EVT). The onStatus()
+// callback fires synchronously within notify(), detecting immediate errors
+// but not when transmission actually completes. This polling model with
+// rate limiting is optimal for this constraint. See NRF52 implementation
+// for event-driven TX using BLE_GATTS_EVT_HVN_TX_COMPLETE.
 
-#define SERVICE_UUID           "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" // UART service UUID
-#define CHARACTERISTIC_UUID_RX "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
-#define CHARACTERISTIC_UUID_TX "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+SerialBLEInterface* SerialBLEInterface::instance = nullptr;
 
-#define ADVERT_RESTART_DELAY  1000   // millis
+void SerialBLEInterface::gapEventHandler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t* param) {
+  if (!instance) return;
+
+  switch (event) {
+    case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT:
+      instance->onConnParamsUpdate(param);
+      break;
+    case ESP_GAP_BLE_ADV_START_COMPLETE_EVT:
+      instance->onAdvStartComplete(param);
+      break;
+    case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT:
+      instance->onAdvStopComplete(param);
+      break;
+    default:
+      break;
+  }
+}
+
+void SerialBLEInterface::onConnParamsUpdate(esp_ble_gap_cb_param_t* param) {
+  if (param->update_conn_params.status != ESP_BT_STATUS_SUCCESS) {
+    BLE_DEBUG_PRINTLN("Failed to request connection parameter update: %d", param->update_conn_params.status);
+    _conn_param_update_pending = false;
+    return;
+  }
+
+  // Check if this update matches our peer address
+  if (memcmp(param->update_conn_params.bda, _peer_addr, sizeof(esp_bd_addr_t)) != 0) {
+    return;
+  }
+
+  uint16_t interval = param->update_conn_params.conn_int;  // Actual connection interval applied
+  uint16_t latency = param->update_conn_params.latency;
+  uint16_t timeout = param->update_conn_params.timeout;
+
+  BLE_DEBUG_PRINTLN("CONN_PARAM_UPDATE: interval=%u, latency=%u, timeout=%u",
+                   interval, latency, timeout);
+
+  // Check if sync mode parameters were applied (matching nRF52 logic)
+  if (latency == BLE_SYNC_SLAVE_LATENCY &&
+      timeout == BLE_SYNC_CONN_SUP_TIMEOUT &&
+      interval >= BLE_SYNC_MIN_CONN_INTERVAL &&
+      interval <= BLE_SYNC_MAX_CONN_INTERVAL) {
+    if (!_sync_mode) {
+      BLE_DEBUG_PRINTLN("Sync mode confirmed by connection parameters");
+      _sync_mode = true;
+      _last_activity_time = millis();
+    }
+  } else if (latency == BLE_SLAVE_LATENCY &&
+             timeout == BLE_CONN_SUP_TIMEOUT &&
+             interval >= BLE_MIN_CONN_INTERVAL &&
+             interval <= BLE_MAX_CONN_INTERVAL) {
+    if (_sync_mode) {
+      BLE_DEBUG_PRINTLN("Default mode confirmed by connection parameters");
+      _sync_mode = false;
+    }
+  }
+
+  _conn_param_update_pending = false;
+}
+
+void SerialBLEInterface::onAdvStartComplete(esp_ble_gap_cb_param_t* param) {
+  if (param->adv_start_cmpl.status == ESP_BT_STATUS_SUCCESS) {
+    _isAdvertising = true;
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising started (GAP event confirmed)");
+  } else {
+    _isAdvertising = false;
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising start failed, status=%d", param->adv_start_cmpl.status);
+  }
+}
+
+void SerialBLEInterface::onAdvStopComplete(esp_ble_gap_cb_param_t* param) {
+  if (param->adv_stop_cmpl.status == ESP_BT_STATUS_SUCCESS || param->adv_stop_cmpl.status == ESP_BT_STATUS_UNSUPPORTED) {
+    _isAdvertising = false;
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising stopped (GAP event confirmed)");
+  }
+}
 
 void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code) {
+  instance = this;
   _pin_code = pin_code;
 
   if (strcmp(name, "@@MAC") == 0) {
@@ -25,228 +105,569 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   // Create the BLE Device
   BLEDevice::init(dev_name);
   BLEDevice::setSecurityCallbacks(this);
-  BLEDevice::setMTU(MAX_FRAME_SIZE);
+  BLEDevice::setMTU(BLE_MAX_MTU);
 
-  BLESecurity  sec;
+  BLESecurity sec;
   sec.setStaticPIN(pin_code);
   sec.setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
 
-  //BLEDevice::setPower(ESP_PWR_LVL_N8);
-
   // Create the BLE Server
   pServer = BLEDevice::createServer();
+  if (!pServer) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: failed to create BLE server");
+    return;
+  }
   pServer->setCallbacks(this);
 
   // Create the BLE Service
   pService = pServer->createService(SERVICE_UUID);
+  if (!pService) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: failed to create BLE service");
+    return;
+  }
 
-  // Create a BLE Characteristic
-  pTxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_TX, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
+  // Create TX Characteristic (notify to client)
+  pTxCharacteristic = pService->createCharacteristic(
+    CHARACTERISTIC_UUID_TX,
+    BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY
+  );
+  if (!pTxCharacteristic) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: failed to create TX characteristic");
+    return;
+  }
   pTxCharacteristic->setAccessPermissions(ESP_GATT_PERM_READ_ENC_MITM);
   pTxCharacteristic->addDescriptor(new BLE2902());
 
-  BLECharacteristic * pRxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_RX, BLECharacteristic::PROPERTY_WRITE);
+  // Create RX Characteristic (write from client)
+  // Support both WRITE (with response) and WRITE_NR (without response) for flexibility
+  BLECharacteristic* pRxCharacteristic = pService->createCharacteristic(
+    CHARACTERISTIC_UUID_RX,
+    BLECharacteristic::PROPERTY_WRITE | BLECharacteristic::PROPERTY_WRITE_NR
+  );
+  if (!pRxCharacteristic) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: failed to create RX characteristic");
+    return;
+  }
   pRxCharacteristic->setAccessPermissions(ESP_GATT_PERM_WRITE_ENC_MITM);
   pRxCharacteristic->setCallbacks(this);
 
-  pServer->getAdvertising()->addServiceUUID(SERVICE_UUID);
+  // Configure advertising
+  BLEAdvertising* pAdvertising = pServer->getAdvertising();
+  pAdvertising->addServiceUUID(SERVICE_UUID);
+  pAdvertising->setMinInterval(BLE_ADV_INTERVAL_MIN);
+  pAdvertising->setMaxInterval(BLE_ADV_INTERVAL_MAX);
+  pAdvertising->setScanResponse(true);
+
+  // Register custom GAP handler to receive connection parameter update events
+  BLEDevice::setCustomGapHandler(gapEventHandler);
 }
 
 // -------- BLESecurityCallbacks methods
 
 uint32_t SerialBLEInterface::onPassKeyRequest() {
-  BLE_DEBUG_PRINTLN("onPassKeyRequest()");
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: passkey request");
   return _pin_code;
 }
 
 void SerialBLEInterface::onPassKeyNotify(uint32_t pass_key) {
-  BLE_DEBUG_PRINTLN("onPassKeyNotify(%u)", pass_key);
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: passkey notify: %u", pass_key);
 }
 
 bool SerialBLEInterface::onConfirmPIN(uint32_t pass_key) {
-  BLE_DEBUG_PRINTLN("onConfirmPIN(%u)", pass_key);
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: confirm PIN: %u", pass_key);
   return true;
 }
 
 bool SerialBLEInterface::onSecurityRequest() {
-  BLE_DEBUG_PRINTLN("onSecurityRequest()");
-  return true;  // allow
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: security request");
+  return true;
 }
 
 void SerialBLEInterface::onAuthenticationComplete(esp_ble_auth_cmpl_t cmpl) {
-  if (cmpl.success) {
-    BLE_DEBUG_PRINTLN(" - SecurityCallback - Authentication Success");
-    deviceConnected = true;
-  } else {
-    BLE_DEBUG_PRINTLN(" - SecurityCallback - Authentication Failure*");
+  if (_conn_handle == BLE_CONN_HANDLE_INVALID) {
+    // Windows can deliver auth complete before onConnect gives us conn_id.
+    BLE_DEBUG_PRINTLN("onAuthenticationComplete: deferring result until onConnect");
+    _authPending = true;
+    _authPendingSuccess = cmpl.success;
+    memcpy(_authPendingAddr, cmpl.bd_addr, sizeof(_authPendingAddr));
+    return;
+  }
 
-    //pServer->removePeerDevice(pServer->getConnId(), true);
-    pServer->disconnect(pServer->getConnId());
-    adv_restart_time = millis() + ADVERT_RESTART_DELAY;
+  if (!isValidConnection(_conn_handle, true)) {
+    BLE_DEBUG_PRINTLN("onAuthenticationComplete: ignoring stale/duplicate callback");
+    return;
+  }
+
+  if (cmpl.success) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: authentication successful");
+    _isDeviceConnected = true;
+
+    // We've just connected, there will be data sync, so enable sync mode immediately
+    _sync_mode = true;
+    _last_activity_time = millis();
+    _conn_param_update_pending = true;
+
+    // Request sync mode connection parameters
+    if (pServer) {
+      pServer->updateConnParams(_peer_addr,
+                                BLE_SYNC_MIN_CONN_INTERVAL,
+                                BLE_SYNC_MAX_CONN_INTERVAL,
+                                BLE_SYNC_SLAVE_LATENCY,
+                                BLE_SYNC_CONN_SUP_TIMEOUT);
+      BLE_DEBUG_PRINTLN(
+        "Sync mode requested on secure: %u-%ums interval, latency=%u, %ums timeout",
+        BLE_SYNC_MIN_CONN_INTERVAL * 5 / 4,
+        BLE_SYNC_MAX_CONN_INTERVAL * 5 / 4,
+        BLE_SYNC_SLAVE_LATENCY,
+        BLE_SYNC_CONN_SUP_TIMEOUT * 10
+      );
+      // We now have a custom GAP handler that will receive ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT
+      // The pending flag will be cleared by onConnParamsUpdate callback when update completes
+      // Keep _conn_param_update_pending = true until callback confirms
+
+      // Request Data Length Extension (DLE) - ESP needs this set manually, nRF52 handles automatically
+      // Bluedroid API only sets tx_data_length (octets), time component is auto-negotiated
+      esp_err_t err_code = esp_ble_gap_set_pkt_data_len(_peer_addr, BLE_DLE_MAX_TX_OCTETS);
+      if (err_code == ESP_OK) {
+        BLE_DEBUG_PRINTLN("Data Length Extension requested: max_tx_octets=%u", BLE_DLE_MAX_TX_OCTETS);
+      } else {
+        BLE_DEBUG_PRINTLN("Failed to request Data Length Extension: %d", err_code);
+      }
+    }
+  } else {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: authentication failed, disconnecting");
+    if (pServer && _conn_handle != BLE_CONN_HANDLE_INVALID) {
+      pServer->disconnect(_conn_handle);
+    }
+    _last_health_check = millis();
   }
 }
 
 // -------- BLEServerCallbacks methods
 
-void SerialBLEInterface::onConnect(BLEServer* pServer) {
+void SerialBLEInterface::onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t* param) {
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: connected conn_id=%d", param->connect.conn_id);
+
+  // Reject additional connections (single connection only)
+  if (pServer->getConnectedCount() > 1) {
+    pServer->disconnect(param->connect.conn_id);
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: rejecting second connection, already have %d connection", pServer->getConnectedCount() - 1);
+    return;
+  }
+
+  _conn_handle = param->connect.conn_id;
+  memcpy(_peer_addr, param->connect.remote_bda, sizeof(esp_bd_addr_t));
+  _sync_mode = false;
+  _conn_param_update_pending = false;
+  _isDeviceConnected = false;  // Wait for authentication
+  _isAdvertising = false;  // Advertising stops automatically when connection is established
+  clearBuffers();
+
+  if (_authPending && memcmp(_authPendingAddr, _peer_addr, sizeof(_peer_addr)) == 0) {
+    _authPending = false;
+    if (_authPendingSuccess) {
+      BLE_DEBUG_PRINTLN("SerialBLEInterface: applying deferred auth result");
+      _isDeviceConnected = true;
+      _sync_mode = true;
+      _last_activity_time = millis();
+      _conn_param_update_pending = true;
+
+      if (pServer) {
+        pServer->updateConnParams(_peer_addr,
+                                  BLE_SYNC_MIN_CONN_INTERVAL,
+                                  BLE_SYNC_MAX_CONN_INTERVAL,
+                                  BLE_SYNC_SLAVE_LATENCY,
+                                  BLE_SYNC_CONN_SUP_TIMEOUT);
+        BLE_DEBUG_PRINTLN(
+          "Sync mode requested on secure: %u-%ums interval, latency=%u, %ums timeout",
+          BLE_SYNC_MIN_CONN_INTERVAL * 5 / 4,
+          BLE_SYNC_MAX_CONN_INTERVAL * 5 / 4,
+          BLE_SYNC_SLAVE_LATENCY,
+          BLE_SYNC_CONN_SUP_TIMEOUT * 10
+        );
+
+        esp_err_t err_code = esp_ble_gap_set_pkt_data_len(_peer_addr, BLE_DLE_MAX_TX_OCTETS);
+        if (err_code == ESP_OK) {
+          BLE_DEBUG_PRINTLN("Data Length Extension requested: max_tx_octets=%u", BLE_DLE_MAX_TX_OCTETS);
+        } else {
+          BLE_DEBUG_PRINTLN("Failed to request Data Length Extension: %d", err_code);
+        }
+      }
+    } else {
+      BLE_DEBUG_PRINTLN("SerialBLEInterface: deferred auth failed, disconnecting");
+      if (pServer && _conn_handle != BLE_CONN_HANDLE_INVALID) {
+        pServer->disconnect(_conn_handle);
+      }
+      _last_health_check = millis();
+    }
+  } else if (_authPending) {
+    // Different peer connected; drop stale pending state.
+    _authPending = false;
+  }
 }
 
-void SerialBLEInterface::onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param) {
-  BLE_DEBUG_PRINTLN("onConnect(), conn_id=%d, mtu=%d", param->connect.conn_id, pServer->getPeerMTU(param->connect.conn_id));
-  last_conn_id = param->connect.conn_id;
-}
+void SerialBLEInterface::onDisconnect(BLEServer* pServer, esp_ble_gatts_cb_param_t* param) {
+#if BLE_DEBUG_LOGGING
+  const char* initiator;
+  uint8_t reason = param->disconnect.reason;
+  if (reason == 0x16) {
+    initiator = "local";
+  } else if (reason == 0x08) {
+    initiator = "timeout";
+  } else {
+    initiator = "remote";
+  }
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: disconnected conn_handle=%d reason=0x%02X (initiated by %s)", 
+                    param->disconnect.conn_id, reason, initiator);
+#endif
 
-void SerialBLEInterface::onMtuChanged(BLEServer* pServer, esp_ble_gatts_cb_param_t* param) {
-  BLE_DEBUG_PRINTLN("onMtuChanged(), mtu=%d", pServer->getPeerMTU(param->mtu.conn_id));
-}
+  if (_conn_handle == param->disconnect.conn_id) {
+    _conn_handle = BLE_CONN_HANDLE_INVALID;
+    _sync_mode = false;
+    _conn_param_update_pending = false;
+    _isDeviceConnected = false;
+    _authPending = false;
+    memset(_peer_addr, 0, sizeof(_peer_addr));
+    clearBuffers();
+    _last_health_check = millis();
 
-void SerialBLEInterface::onDisconnect(BLEServer* pServer) {
-  BLE_DEBUG_PRINTLN("onDisconnect()");
-  if (_isEnabled) {
-    adv_restart_time = millis() + ADVERT_RESTART_DELAY;
-
-    // loop() will detect this on next loop, and set deviceConnected to false
+    if (_isEnabled) {
+      BLEAdvertising* pAdvertising = pServer->getAdvertising();
+      if (pAdvertising) {
+        pAdvertising->start();
+        // State will be updated by ESP_GAP_BLE_ADV_START_COMPLETE_EVT event
+        // Optimistically set flag - GAP event will confirm
+        _isAdvertising = true;
+        BLE_DEBUG_PRINTLN("SerialBLEInterface: restarting advertising on disconnect");
+      }
+    }
   }
 }
 
 // -------- BLECharacteristicCallbacks methods
 
 void SerialBLEInterface::onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param) {
+  if (!isConnected()) {
+    return;
+  }
+
+  // Check connection handle matches (like NimBLE test)
+  if (param->write.conn_id != _conn_handle) {
+    BLE_DEBUG_PRINTLN("onWrite: ignoring write from stale connection handle %d (expected %d)", 
+                     param->write.conn_id, _conn_handle);
+    return;
+  }
+
   uint8_t* rxValue = pCharacteristic->getData();
-  int len = pCharacteristic->getLength();
+  size_t len = pCharacteristic->getLength();
+
+  BLE_DEBUG_PRINTLN("onWrite: len=%u, queue=%u", (unsigned)len, (unsigned)recv_queue.size());
 
   if (len > MAX_FRAME_SIZE) {
-    BLE_DEBUG_PRINTLN("ERROR: onWrite(), frame too big, len=%d", len);
-  } else if (recv_queue_len >= FRAME_QUEUE_SIZE) {
-    BLE_DEBUG_PRINTLN("ERROR: onWrite(), recv_queue is full!");
-  } else {
-    recv_queue[recv_queue_len].len = len;
-    memcpy(recv_queue[recv_queue_len].buf, rxValue, len);
-    recv_queue_len++;
+    BLE_DEBUG_PRINTLN("onWrite: frame too big, len=%u", (unsigned)len);
+    return;
+  }
+
+  if (recv_queue.isFull()) {
+    BLE_DEBUG_PRINTLN("onWrite: recv queue full, dropping data");
+    return;
+  }
+
+  if (rxValue == nullptr && len > 0) {
+    BLE_DEBUG_PRINTLN("onWrite: invalid data pointer");
+    return;
+  }
+
+  SerialBLEFrame* frame = recv_queue.getWriteSlot();
+  if (frame) {
+    frame->len = len;
+    memcpy(frame->buf, rxValue, len);
+    recv_queue.push();
+  }
+
+  unsigned long now = millis();
+  if (noteFrameActivity(now, len)) {
+    requestSyncModeConnection();
   }
 }
 
-// ---------- public methods
+void SerialBLEInterface::onStatus(BLECharacteristic* pCharacteristic, Status s, uint32_t code) {
+  // Handle notification/indication status (called synchronously by BLECharacteristic::notify())
+  // For notifications, onStatus is called immediately with SUCCESS_NOTIFY or error codes
+  // This allows us to detect immediate failures from esp_ble_gatts_send_indicate()
+  // Unlike nRF52's synchronous write() which returns bytes written, Bluedroid's notify() is async
+  // but calls onStatus synchronously, so we can detect immediate API errors
+  if (pCharacteristic == pTxCharacteristic) {
+    if (s == ERROR_GATT || s == ERROR_NO_CLIENT || s == ERROR_NOTIFY_DISABLED) {
+      // Set flag so checkRecvFrame can detect failure after notify() returns
+      _notify_failed = true;
+      BLE_DEBUG_PRINTLN("onStatus: notify failed, status=%d, code=%lu", s, (unsigned long)code);
+    }
+    // For SUCCESS_NOTIFY, _notify_failed remains false, frame will be popped in checkRecvFrame
+  }
+}
 
-void SerialBLEInterface::enable() { 
+// ---------- Helper methods
+
+void SerialBLEInterface::clearBuffers() {
+  clearTransferState();
+}
+
+bool SerialBLEInterface::isValidConnection(uint16_t conn_handle, bool requireWaitingForSecurity) const {
+  if (_conn_handle != conn_handle) {
+    return false;
+  }
+  if (_conn_handle == BLE_CONN_HANDLE_INVALID) {
+    return false;
+  }
+  if (requireWaitingForSecurity && _isDeviceConnected) {
+    return false;
+  }
+  return true;
+}
+
+bool SerialBLEInterface::isAdvertising() const {
+  // Track advertising state via GAP events (ESP_GAP_BLE_ADV_START_COMPLETE_EVT / ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT)
+  // This is more reliable than checking object existence - it reflects actual BLE stack state
+  return _isAdvertising;
+}
+
+void SerialBLEInterface::requestSyncModeConnection() {
+  if (!pServer || !isConnected()) {
+    return;
+  }
+
+  if (_sync_mode) {
+    return;
+  }
+
+  if (_conn_param_update_pending) {
+    return;
+  }
+  _conn_param_update_pending = true;
+
+  BLE_DEBUG_PRINTLN("Requesting sync mode connection: %u-%ums interval, latency=%u, %ums timeout",
+                    BLE_SYNC_MIN_CONN_INTERVAL * 5 / 4,
+                    BLE_SYNC_MAX_CONN_INTERVAL * 5 / 4,
+                    BLE_SYNC_SLAVE_LATENCY,
+                    BLE_SYNC_CONN_SUP_TIMEOUT * 10);
+
+  pServer->updateConnParams(_peer_addr,
+                            BLE_SYNC_MIN_CONN_INTERVAL,
+                            BLE_SYNC_MAX_CONN_INTERVAL,
+                            BLE_SYNC_SLAVE_LATENCY,
+                            BLE_SYNC_CONN_SUP_TIMEOUT);
+
+  // We now have a custom GAP handler that will receive ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT
+  // Unlike nRF52 which can detect NRF_ERROR_BUSY and retry, Bluedroid's updateConnParams is void
+  // We can't detect errors immediately, but we can detect success via callback
+  // Don't set _sync_mode here - wait for callback to confirm (matching nRF52 behavior)
+  // Keep _conn_param_update_pending = true until callback confirms or times out
+}
+
+void SerialBLEInterface::requestDefaultConnection() {
+  if (!pServer || !isConnected()) {
+    return;
+  }
+
+  if (!_sync_mode) {
+    return;
+  }
+
+  if (!send_queue.isEmpty() || !recv_queue.isEmpty()) {
+    return;
+  }
+
+  if (_conn_param_update_pending) {
+    return;
+  }
+  _conn_param_update_pending = true;
+
+  BLE_DEBUG_PRINTLN("Requesting default connection: %u-%ums interval, latency=%u, %ums timeout",
+                    BLE_MIN_CONN_INTERVAL * 5 / 4,
+                    BLE_MAX_CONN_INTERVAL * 5 / 4,
+                    BLE_SLAVE_LATENCY,
+                    BLE_CONN_SUP_TIMEOUT * 10);
+
+  pServer->updateConnParams(_peer_addr,
+                            BLE_MIN_CONN_INTERVAL,
+                            BLE_MAX_CONN_INTERVAL,
+                            BLE_SLAVE_LATENCY,
+                            BLE_CONN_SUP_TIMEOUT);
+
+  // We now have a custom GAP handler that will receive ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT
+  // Unlike nRF52 which can detect NRF_ERROR_BUSY and retry, Bluedroid's updateConnParams is void
+  // We can't detect errors immediately, but we can detect success via callback
+  // Don't set _sync_mode here - wait for callback to confirm (matching nRF52 behavior)
+  // Keep _conn_param_update_pending = true until callback confirms or times out
+}
+
+// ---------- Public methods
+
+void SerialBLEInterface::enable() {
   if (_isEnabled) return;
+
+  if (!pServer) {
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: enable() failed - pServer is null");
+    return;
+  }
 
   _isEnabled = true;
   clearBuffers();
+  _last_health_check = millis();
 
   // Start the service
   pService->start();
 
   // Start advertising
+  // State will be updated by ESP_GAP_BLE_ADV_START_COMPLETE_EVT event
+  BLEAdvertising* pAdvertising = pServer->getAdvertising();
+  if (pAdvertising) {
+    pAdvertising->start();
+    // Optimistically set flag - GAP event will confirm
+    _isAdvertising = true;
+    BLE_DEBUG_PRINTLN("SerialBLEInterface: enable() - advertising started");
+  }
+}
 
-  //pServer->getAdvertising()->setMinInterval(500);
-  //pServer->getAdvertising()->setMaxInterval(1000);
-
-  pServer->getAdvertising()->start();
-  adv_restart_time = 0;
+void SerialBLEInterface::disconnect() {
+  if (_conn_handle != BLE_CONN_HANDLE_INVALID && pServer) {
+    pServer->disconnect(_conn_handle);
+  }
 }
 
 void SerialBLEInterface::disable() {
   _isEnabled = false;
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: disable");
 
-  BLE_DEBUG_PRINTLN("SerialBLEInterface::disable");
-
-  pServer->getAdvertising()->stop();
-  pServer->disconnect(last_conn_id);
+  disconnect();
+  BLEAdvertising* pAdvertising = pServer->getAdvertising();
+  if (pAdvertising) {
+    pAdvertising->stop();
+    // State will be updated by ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT event
+    _isAdvertising = false;
+  }
   pService->stop();
-  oldDeviceConnected = deviceConnected = false;
-  adv_restart_time = 0;
+  _isDeviceConnected = false;
+  memset(_peer_addr, 0, sizeof(_peer_addr));
+  _last_health_check = 0;
 }
 
 size_t SerialBLEInterface::writeFrame(const uint8_t src[], size_t len) {
   if (len > MAX_FRAME_SIZE) {
-    BLE_DEBUG_PRINTLN("writeFrame(), frame too big, len=%d", len);
+    BLE_DEBUG_PRINTLN("writeFrame(), frame too big, len=%u", (unsigned)len);
     return 0;
   }
 
-  if (deviceConnected && len > 0) {
-    if (send_queue_len >= FRAME_QUEUE_SIZE) {
+  bool connected = isConnected();
+  if (connected && len > 0) {
+    if (send_queue.isFull()) {
       BLE_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
       return 0;
     }
 
-    send_queue[send_queue_len].len = len;  // add to send queue
-    memcpy(send_queue[send_queue_len].buf, src, len);
-    send_queue_len++;
-
-    return len;
+    SerialBLEFrame* frame = send_queue.getWriteSlot();
+    if (frame) {
+      frame->len = len;
+      memcpy(frame->buf, src, len);
+      send_queue.push();
+      return len;
+    }
   }
   return 0;
 }
 
-#define  BLE_WRITE_MIN_INTERVAL   60
-
-bool SerialBLEInterface::isWriteBusy() const {
-  return millis() < _last_write + BLE_WRITE_MIN_INTERVAL;   // still too soon to start another write?
-}
-
 size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
-  if (send_queue_len > 0   // first, check send queue
-    && millis() >= _last_write + BLE_WRITE_MIN_INTERVAL    // space the writes apart
-  ) {
-    _last_write = millis();
-    pTxCharacteristic->setValue(send_queue[0].buf, send_queue[0].len);
-    pTxCharacteristic->notify();
-
-    BLE_DEBUG_PRINTLN("writeBytes: sz=%d, hdr=%d", (uint32_t)send_queue[0].len, (uint32_t) send_queue[0].buf[0]);
-
-    send_queue_len--;
-    for (int i = 0; i < send_queue_len; i++) {   // delete top item from queue
-      send_queue[i] = send_queue[i + 1];
-    }
-  }
-
-  if (recv_queue_len > 0) {   // check recv queue
-    size_t len = recv_queue[0].len;   // take from top of queue
-    memcpy(dest, recv_queue[0].buf, len);
-
-    BLE_DEBUG_PRINTLN("readBytes: sz=%d, hdr=%d", len, (uint32_t) dest[0]);
-
-    recv_queue_len--;
-    for (int i = 0; i < recv_queue_len; i++) {   // delete top item from queue
-      recv_queue[i] = recv_queue[i + 1];
-    }
-    return len;
-  }
-
-  if (pServer->getConnectedCount() == 0)  deviceConnected = false;
-
-  if (deviceConnected != oldDeviceConnected) {
-    if (!deviceConnected) {    // disconnecting
-      clearBuffers();
-
-      BLE_DEBUG_PRINTLN("SerialBLEInterface -> disconnecting...");
-
-      //pServer->getAdvertising()->setMinInterval(500);
-      //pServer->getAdvertising()->setMaxInterval(1000);
-
-      adv_restart_time = millis() + ADVERT_RESTART_DELAY;
+  // Process send queue
+  if (!send_queue.isEmpty()) {
+    if (!isConnected()) {
+      BLE_DEBUG_PRINTLN("writeBytes: connection invalid, clearing send queue");
+      send_queue.init();
     } else {
-      BLE_DEBUG_PRINTLN("SerialBLEInterface -> stopping advertising");
-      BLE_DEBUG_PRINTLN("SerialBLEInterface -> connecting...");
-      // connecting
-      // do stuff here on connecting
-      pServer->getAdvertising()->stop();
-      adv_restart_time = 0;
+      unsigned long now = millis();
+      bool throttle_active = (_last_retry_attempt > 0 && (now - _last_retry_attempt) < BLE_RETRY_THROTTLE_MS);
+      bool send_interval_ok = (_last_send_time == 0 || (now - _last_send_time) >= BLE_MIN_SEND_INTERVAL_MS);
+
+      if (!throttle_active && send_interval_ok && pTxCharacteristic) {
+        SerialBLEFrame* frame_to_send = send_queue.peekFront();
+        if (frame_to_send) {
+          _notify_failed = false;  // Reset flag before notify
+          pTxCharacteristic->setValue(frame_to_send->buf, frame_to_send->len);
+          pTxCharacteristic->notify();
+
+          // onStatus() is called synchronously within notify(), so check flag now
+          if (_notify_failed) {
+            if (!isConnected()) {
+              BLE_DEBUG_PRINTLN("writeBytes failed: connection lost, dropping frame");
+              _last_retry_attempt = 0;
+              _last_send_time = 0;
+              popSendQueue();
+            } else {
+              BLE_DEBUG_PRINTLN("writeBytes failed (buffer full), keeping frame for retry");
+              _last_retry_attempt = now;
+            }
+          } else {
+            BLE_DEBUG_PRINTLN("writeBytes: sz=%u, hdr=%u", (unsigned)frame_to_send->len, (unsigned)frame_to_send->buf[0]);
+            _last_retry_attempt = 0;
+            _last_send_time = now;
+            if (noteFrameActivity(now, frame_to_send->len)) {
+              requestSyncModeConnection();
+            }
+            popSendQueue();
+          }
+        }
+      }
     }
-    oldDeviceConnected = deviceConnected;
   }
 
-  if (adv_restart_time && millis() >= adv_restart_time) {
-    if (pServer->getConnectedCount() == 0) {
-      BLE_DEBUG_PRINTLN("SerialBLEInterface -> re-starting advertising");
-      pServer->getAdvertising()->start();  // re-Start advertising
+  // Process receive queue
+  if (!recv_queue.isEmpty()) {
+    SerialBLEFrame* frame = recv_queue.peekFront();
+    if (frame) {
+      size_t len = frame->len;
+      memcpy(dest, frame->buf, len);
+
+      BLE_DEBUG_PRINTLN("readBytes: sz=%u, hdr=%u", (unsigned)len, (unsigned)dest[0]);
+
+      popRecvQueue();
+      return len;
     }
-    adv_restart_time = 0;
   }
+
+  // Check for sync mode timeout
+  unsigned long now = millis();
+  if (isConnected() && _sync_mode && _last_activity_time > 0 &&
+      send_queue.isEmpty() && recv_queue.isEmpty()) {
+    if (now - _last_activity_time >= BLE_SYNC_INACTIVITY_TIMEOUT_MS) {
+      requestDefaultConnection();
+    }
+  }
+
+  // Advertising watchdog - restart if stopped unexpectedly
+  if (_isEnabled && !isConnected() && _conn_handle == BLE_CONN_HANDLE_INVALID) {
+    if (now - _last_health_check >= BLE_HEALTH_CHECK_INTERVAL) {
+      _last_health_check = now;
+
+      if (!isAdvertising()) {
+        BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising watchdog - advertising stopped, restarting");
+        BLEAdvertising* pAdvertising = pServer->getAdvertising();
+        if (pAdvertising) {
+          pAdvertising->start();
+          // State will be updated by ESP_GAP_BLE_ADV_START_COMPLETE_EVT event
+          // Optimistically set flag - GAP event will confirm
+          _isAdvertising = true;
+        }
+      }
+    }
+  }
+
   return 0;
 }
 
 bool SerialBLEInterface::isConnected() const {
-  return deviceConnected;  //pServer != NULL && pServer->getConnectedCount() > 0;
+  return _isDeviceConnected && _conn_handle != BLE_CONN_HANDLE_INVALID && pServer && pServer->getConnectedCount() > 0;
+}
+
+bool SerialBLEInterface::isWriteBusy() const {
+  return isWriteBusyCommon();
 }

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -1,79 +1,99 @@
 #include "SerialBLEInterface.h"
+#include "../SerialBLECommon.h"
 #include <stdio.h>
 #include <string.h>
 #include "ble_gap.h"
 #include "ble_hci.h"
 
-// Magic numbers came from actual testing
-#define BLE_HEALTH_CHECK_INTERVAL  10000  // Advertising watchdog check every 10 seconds
-#define BLE_RETRY_THROTTLE_MS      250    // Throttle retries to 250ms when queue buildup detected
-
-// Connection parameters (units: interval=1.25ms, timeout=10ms)
-#define BLE_MIN_CONN_INTERVAL      12     // 15ms
-#define BLE_MAX_CONN_INTERVAL      24     // 30ms
-#define BLE_SLAVE_LATENCY          4
-#define BLE_CONN_SUP_TIMEOUT       200    // 2000ms
-
-// Advertising parameters
-#define BLE_ADV_INTERVAL_MIN       32     // 20ms (units: 0.625ms)
-#define BLE_ADV_INTERVAL_MAX       244    // 152.5ms (units: 0.625ms)
-#define BLE_ADV_FAST_TIMEOUT       30     // seconds
-
-// RX drain buffer size for overflow protection
-#define BLE_RX_DRAIN_BUF_SIZE      32
-
-static SerialBLEInterface* instance = nullptr;
+SerialBLEInterface* SerialBLEInterface::instance = nullptr;
 
 void SerialBLEInterface::onConnect(uint16_t connection_handle) {
   BLE_DEBUG_PRINTLN("SerialBLEInterface: connected handle=0x%04X", connection_handle);
   if (instance) {
+    if (Bluefruit.connected() > 1) {
+      uint32_t err_code = sd_ble_gap_disconnect(connection_handle, BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION);
+      if (err_code != NRF_SUCCESS) {
+        BLE_DEBUG_PRINTLN("SerialBLEInterface: failed to disconnect second connection: 0x%08lX", err_code);
+      } else {
+        BLE_DEBUG_PRINTLN("SerialBLEInterface: rejecting second connection, already have %d connection", Bluefruit.connected() - 1);
+      }
+      return;
+    }
+    instance->_sync_mode = false;
+    instance->_conn_param_update_pending = false;
     instance->_conn_handle = connection_handle;
     instance->_isDeviceConnected = false;
-    instance->clearBuffers();
+    instance->_tx_pending = 0;
+    instance->_tx_in_progress = false;
+    instance->clearBuffers(); // this seems redundant, but there were edge cases where stuff stuck in the buffers on rapid disconnect-connects
   }
 }
 
 void SerialBLEInterface::onDisconnect(uint16_t connection_handle, uint8_t reason) {
-  BLE_DEBUG_PRINTLN("SerialBLEInterface: disconnected handle=0x%04X reason=%u", connection_handle, reason);
+#if BLE_DEBUG_LOGGING
+  const char* initiator;
+  if (reason == BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION) {
+    initiator = "local";
+  } else if (reason == BLE_HCI_CONNECTION_TIMEOUT) {
+    initiator = "timeout";
+  } else {
+    initiator = "remote";
+  }
+  BLE_DEBUG_PRINTLN("SerialBLEInterface: disconnected handle=0x%04X reason=0x%02X (initiated by %s)", 
+                    connection_handle, reason, initiator);
+#endif
   if (instance) {
     if (instance->_conn_handle == connection_handle) {
       instance->_conn_handle = BLE_CONN_HANDLE_INVALID;
+      instance->_sync_mode = false;
+      instance->_conn_param_update_pending = false;
       instance->_isDeviceConnected = false;
+      instance->_tx_pending = 0;
+      instance->_tx_in_progress = false;
       instance->clearBuffers();
+      instance->_last_health_check = millis();
     }
   }
 }
 
 void SerialBLEInterface::onSecured(uint16_t connection_handle) {
   BLE_DEBUG_PRINTLN("SerialBLEInterface: onSecured handle=0x%04X", connection_handle);
+
   if (instance) {
     if (instance->isValidConnection(connection_handle, true)) {
       instance->_isDeviceConnected = true;
-      
-      // Connection interval units: 1.25ms, supervision timeout units: 10ms
-      // Apple: "The product will not read or use the parameters in the Peripheral Preferred Connection Parameters characteristic."
-      // So we explicitly set it here to make Android & Apple match
+
+      // We've just connected, there will be data sync, so enable sync mode immediately
+      instance->_sync_mode = true;
+      instance->_last_activity_time = millis();
+      instance->_conn_param_update_pending = true;
+
       ble_gap_conn_params_t conn_params;
-      conn_params.min_conn_interval = BLE_MIN_CONN_INTERVAL;
-      conn_params.max_conn_interval = BLE_MAX_CONN_INTERVAL;
-      conn_params.slave_latency = BLE_SLAVE_LATENCY;
-      conn_params.conn_sup_timeout = BLE_CONN_SUP_TIMEOUT;
-      
+      conn_params.min_conn_interval = BLE_SYNC_MIN_CONN_INTERVAL;
+      conn_params.max_conn_interval = BLE_SYNC_MAX_CONN_INTERVAL;
+      conn_params.slave_latency     = BLE_SYNC_SLAVE_LATENCY;
+      conn_params.conn_sup_timeout  = BLE_SYNC_CONN_SUP_TIMEOUT;
+
       uint32_t err_code = sd_ble_gap_conn_param_update(connection_handle, &conn_params);
       if (err_code == NRF_SUCCESS) {
-        BLE_DEBUG_PRINTLN("Connection parameter update requested: %u-%ums interval, latency=%u, %ums timeout",
-                         conn_params.min_conn_interval * 5 / 4,  // convert to ms (1.25ms units)
-                         conn_params.max_conn_interval * 5 / 4,
-                         conn_params.slave_latency,
-                         conn_params.conn_sup_timeout * 10);  // convert to ms (10ms units)
+        BLE_DEBUG_PRINTLN(
+          "Sync mode requested on secure: %u-%ums interval, latency=%u, %ums timeout",
+          conn_params.min_conn_interval * 5 / 4,
+          conn_params.max_conn_interval * 5 / 4,
+          conn_params.slave_latency,
+          conn_params.conn_sup_timeout * 10
+        );
+      } else if (err_code == NRF_ERROR_BUSY) {
+        BLE_DEBUG_PRINTLN("Sync mode request deferred (NRF_ERROR_BUSY)");
       } else {
-        BLE_DEBUG_PRINTLN("Failed to request connection parameter update: %lu", err_code);
+        instance->_conn_param_update_pending = false;
+        BLE_DEBUG_PRINTLN("Failed to request sync mode on secure: %lu", err_code);
       }
-    } else {
-      BLE_DEBUG_PRINTLN("onSecured: ignoring stale/duplicate callback");
     }
   }
 }
+
+
 
 bool SerialBLEInterface::onPairingPasskey(uint16_t connection_handle, uint8_t const passkey[6], bool match_request) {
   (void)connection_handle;
@@ -101,16 +121,68 @@ void SerialBLEInterface::onPairingComplete(uint16_t connection_handle, uint8_t a
 void SerialBLEInterface::onBLEEvent(ble_evt_t* evt) {
   if (!instance) return;
   
-  if (evt->header.evt_id == BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST) {
+  if (evt->header.evt_id == BLE_GAP_EVT_CONN_PARAM_UPDATE) {
     uint16_t conn_handle = evt->evt.gap_evt.conn_handle;
     if (instance->isValidConnection(conn_handle)) {
-      BLE_DEBUG_PRINTLN("CONN_PARAM_UPDATE_REQUEST: handle=0x%04X, min_interval=%u, max_interval=%u, latency=%u, timeout=%u",
-                       conn_handle,
-                       evt->evt.gap_evt.params.conn_param_update_request.conn_params.min_conn_interval,
-                       evt->evt.gap_evt.params.conn_param_update_request.conn_params.max_conn_interval,
-                       evt->evt.gap_evt.params.conn_param_update_request.conn_params.slave_latency,
-                       evt->evt.gap_evt.params.conn_param_update_request.conn_params.conn_sup_timeout);
+      ble_gap_conn_params_t* params = &evt->evt.gap_evt.params.conn_param_update.conn_params;
+      uint16_t min_interval = params->min_conn_interval;
+      uint16_t max_interval = params->max_conn_interval;
+      uint16_t latency = params->slave_latency;
+      uint16_t timeout = params->conn_sup_timeout;
       
+      BLE_DEBUG_PRINTLN("CONN_PARAM_UPDATE: handle=0x%04X, min_interval=%u, max_interval=%u, latency=%u, timeout=%u",
+                       conn_handle, min_interval, max_interval, latency, timeout);
+      
+      if (latency == BLE_SYNC_SLAVE_LATENCY &&
+          timeout == BLE_SYNC_CONN_SUP_TIMEOUT &&
+          min_interval >= BLE_SYNC_MIN_CONN_INTERVAL &&
+          max_interval <= BLE_SYNC_MAX_CONN_INTERVAL) {
+        if (!instance->_sync_mode) {
+          BLE_DEBUG_PRINTLN("Sync mode confirmed by connection parameters");
+          instance->_sync_mode = true;
+          instance->_last_activity_time = millis();
+        }
+      } else if (latency == BLE_SLAVE_LATENCY &&
+                 timeout == BLE_CONN_SUP_TIMEOUT &&
+                 min_interval >= BLE_MIN_CONN_INTERVAL &&
+                 max_interval <= BLE_MAX_CONN_INTERVAL) {
+        if (instance->_sync_mode) {
+          BLE_DEBUG_PRINTLN("Default mode confirmed by connection parameters");
+          instance->_sync_mode = false;
+        }
+      }
+      instance->_conn_param_update_pending = false;
+    }
+  } else if (evt->header.evt_id == BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST) {
+    uint16_t conn_handle = evt->evt.gap_evt.conn_handle;
+  
+    if (instance->isValidConnection(conn_handle)) {
+      BLE_DEBUG_PRINTLN(
+        "CONN_PARAM_UPDATE_REQUEST: handle=0x%04X, min=%u, max=%u, lat=%u, timeout=%u",
+        conn_handle,
+        evt->evt.gap_evt.params.conn_param_update_request.conn_params.min_conn_interval,
+        evt->evt.gap_evt.params.conn_param_update_request.conn_params.max_conn_interval,
+        evt->evt.gap_evt.params.conn_param_update_request.conn_params.slave_latency,
+        evt->evt.gap_evt.params.conn_param_update_request.conn_params.conn_sup_timeout
+      );
+  
+    // Reject central-initiated downgrade while in sync mode
+    const ble_gap_conn_params_t& req =
+      evt->evt.gap_evt.params.conn_param_update_request.conn_params;
+    bool downgrade =
+      req.slave_latency     > BLE_SYNC_SLAVE_LATENCY ||
+      req.conn_sup_timeout  > BLE_SYNC_CONN_SUP_TIMEOUT ||
+      req.max_conn_interval > BLE_SYNC_MAX_CONN_INTERVAL;
+    
+    if (instance->_sync_mode && downgrade) {
+      BLE_DEBUG_PRINTLN("Rejecting central downgrade while in sync mode");
+      return;
+    }
+    if (instance->_conn_param_update_pending) {
+      BLE_DEBUG_PRINTLN("Deferring CONN_PARAM_UPDATE_REQUEST (update pending)");
+      return;
+    }
+      // Accept request (use PPCP)
       uint32_t err_code = sd_ble_gap_conn_param_update(conn_handle, NULL);
       if (err_code == NRF_SUCCESS) {
         BLE_DEBUG_PRINTLN("Accepted CONN_PARAM_UPDATE_REQUEST (using PPCP)");
@@ -120,7 +192,63 @@ void SerialBLEInterface::onBLEEvent(ble_evt_t* evt) {
     } else {
       BLE_DEBUG_PRINTLN("CONN_PARAM_UPDATE_REQUEST: ignoring stale callback for handle=0x%04X", conn_handle);
     }
+  } else if (evt->header.evt_id == BLE_GATTS_EVT_HVN_TX_COMPLETE) {
+    uint16_t conn_handle = evt->evt.gatts_evt.conn_handle;
+    if (instance->isValidConnection(conn_handle)) {
+      uint8_t count = evt->evt.gatts_evt.params.hvn_tx_complete.count;
+      instance->onTxComplete(count);
+    }
   }
+}
+
+void SerialBLEInterface::onTxComplete(uint8_t count) {
+  if (_tx_pending >= count) {
+    _tx_pending -= count;
+  } else {
+    _tx_pending = 0;
+  }
+
+  BLE_DEBUG_PRINTLN("HVN_TX_COMPLETE: count=%u, pending=%u, queue=%u", count, _tx_pending, send_queue.size());
+
+  // Event-driven chain: immediately try to send next frame
+  trySendNextFrame();
+}
+
+void SerialBLEInterface::trySendNextFrame() {
+  // Guard against re-entry from HVN_TX_COMPLETE ISR during bleuart.write()
+  if (_tx_in_progress) {
+    return;
+  }
+  _tx_in_progress = true;
+
+  while (isConnected() && !send_queue.isEmpty()) {
+    SerialBLEFrame* frame = send_queue.peekFront();
+    if (!frame) {
+      break;
+    }
+
+    size_t written = bleuart.write(frame->buf, frame->len);
+
+    if (written == frame->len) {
+      BLE_DEBUG_PRINTLN("TX: sz=%u, hdr=%u", (unsigned)frame->len, (unsigned)frame->buf[0]);
+      _tx_pending++;
+
+      if (noteFrameActivity(millis(), frame->len)) {
+        requestSyncModeConnection();
+      }
+      popSendQueue();
+      // Continue loop to greedily drain while HVN queue has space
+    } else if (written > 0) {
+      BLE_DEBUG_PRINTLN("TX: partial write %u/%u, dropping frame", (unsigned)written, (unsigned)frame->len);
+      popSendQueue();
+    } else {
+      // Buffer full - wait for HVN_TX_COMPLETE event (no polling retry needed)
+      BLE_DEBUG_PRINTLN("TX: buffer full, waiting for HVN_TX_COMPLETE");
+      break;
+    }
+  }
+
+  _tx_in_progress = false;
 }
 
 void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code) {
@@ -129,11 +257,9 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   char charpin[20];
   snprintf(charpin, sizeof(charpin), "%lu", (unsigned long)pin_code);
   
-  // If we want to control BLE LED ourselves, uncomment this:
-  // Bluefruit.autoConnLed(false);
   Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
   Bluefruit.begin();
- 
+
   char dev_name[32+16];
   if (strcmp(name, "@@MAC") == 0) {
     ble_gap_addr_t addr;
@@ -154,10 +280,10 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   uint32_t err_code = sd_ble_gap_ppcp_set(&ppcp_params);
   if (err_code == NRF_SUCCESS) {
     BLE_DEBUG_PRINTLN("PPCP set: %u-%ums interval, latency=%u, %ums timeout",
-                     ppcp_params.min_conn_interval * 5 / 4,  // convert to ms (1.25ms units)
+                     ppcp_params.min_conn_interval * 5 / 4,
                      ppcp_params.max_conn_interval * 5 / 4,
                      ppcp_params.slave_latency,
-                     ppcp_params.conn_sup_timeout * 10);  // convert to ms (10ms units)
+                     ppcp_params.conn_sup_timeout * 10);
   } else {
     BLE_DEBUG_PRINTLN("Failed to set PPCP: %lu", err_code);
   }
@@ -195,28 +321,8 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
 }
 
 void SerialBLEInterface::clearBuffers() {
-  send_queue_len = 0;
-  recv_queue_len = 0;
-  _last_retry_attempt = 0;
+  clearTransferState();
   bleuart.flush();
-}
-
-void SerialBLEInterface::shiftSendQueueLeft() {
-  if (send_queue_len > 0) {
-    send_queue_len--;
-    for (uint8_t i = 0; i < send_queue_len; i++) {
-      send_queue[i] = send_queue[i + 1];
-    }
-  }
-}
-
-void SerialBLEInterface::shiftRecvQueueLeft() {
-  if (recv_queue_len > 0) {
-    recv_queue_len--;
-    for (uint8_t i = 0; i < recv_queue_len; i++) {
-      recv_queue[i] = recv_queue[i + 1];
-    }
-  }
 }
 
 bool SerialBLEInterface::isValidConnection(uint16_t handle, bool requireWaitingForSecurity) const {
@@ -236,6 +342,7 @@ bool SerialBLEInterface::isValidConnection(uint16_t handle, bool requireWaitingF
 bool SerialBLEInterface::isAdvertising() const {
   ble_gap_addr_t adv_addr;
   uint32_t err_code = sd_ble_gap_adv_addr_get(0, &adv_addr);
+  (void)adv_addr;  // address not needed, only return code
   return (err_code == NRF_SUCCESS);
 }
 
@@ -251,7 +358,7 @@ void SerialBLEInterface::enable() {
 
 void SerialBLEInterface::disconnect() {
   if (_conn_handle != BLE_CONN_HANDLE_INVALID) {
-    sd_ble_gap_disconnect(_conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+    sd_ble_gap_disconnect(_conn_handle, BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION);
   }
 }
 
@@ -272,68 +379,59 @@ size_t SerialBLEInterface::writeFrame(const uint8_t src[], size_t len) {
 
   bool connected = isConnected();
   if (connected && len > 0) {
-    if (send_queue_len >= FRAME_QUEUE_SIZE) {
+    if (send_queue.isFull()) {
       BLE_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
       return 0;
     }
 
-    send_queue[send_queue_len].len = len;
-    memcpy(send_queue[send_queue_len].buf, src, len);
-    send_queue_len++;
-    
-    return len;
+    bool was_empty = send_queue.isEmpty();
+
+    SerialBLEFrame* frame = send_queue.getWriteSlot();
+    if (frame) {
+      frame->len = len;
+      memcpy(frame->buf, src, len);
+      send_queue.push();
+
+      // Kickstart event-driven TX chain if this is the first frame
+      if (was_empty) {
+        trySendNextFrame();
+      }
+
+      return len;
+    }
   }
   return 0;
 }
 
 size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
-  if (send_queue_len > 0) {
-    if (!isConnected()) {
-      BLE_DEBUG_PRINTLN("writeBytes: connection invalid, clearing send queue");
-      send_queue_len = 0;
-    } else {
-      unsigned long now = millis();
-      bool throttle_active = (_last_retry_attempt > 0 && (now - _last_retry_attempt) < BLE_RETRY_THROTTLE_MS);
+  // TX is now event-driven via HVN_TX_COMPLETE - just clear queue if disconnected
+  if (!send_queue.isEmpty() && !isConnected()) {
+    BLE_DEBUG_PRINTLN("checkRecvFrame: connection invalid, clearing send queue");
+    send_queue.init();
+  }
 
-      if (!throttle_active) {
-        Frame frame_to_send = send_queue[0];
-
-        size_t written = bleuart.write(frame_to_send.buf, frame_to_send.len);
-        if (written == frame_to_send.len) {
-          BLE_DEBUG_PRINTLN("writeBytes: sz=%u, hdr=%u", (unsigned)frame_to_send.len, (unsigned)frame_to_send.buf[0]);
-          _last_retry_attempt = 0;
-          shiftSendQueueLeft();
-        } else if (written > 0) {
-          BLE_DEBUG_PRINTLN("writeBytes: partial write, sent=%u of %u, dropping corrupted frame", (unsigned)written, (unsigned)frame_to_send.len);
-          _last_retry_attempt = 0;
-          shiftSendQueueLeft();
-        } else {
-          if (!isConnected()) {
-            BLE_DEBUG_PRINTLN("writeBytes failed: connection lost, dropping frame");
-            _last_retry_attempt = 0;
-            shiftSendQueueLeft();
-          } else {
-            BLE_DEBUG_PRINTLN("writeBytes failed (buffer full), keeping frame for retry");
-            _last_retry_attempt = now;
-          }
-        }
-      }
+  // Process receive queue
+  if (!recv_queue.isEmpty()) {
+    SerialBLEFrame* frame = recv_queue.peekFront();
+    if (frame) {
+      size_t len = frame->len;
+      memcpy(dest, frame->buf, len);
+      
+      BLE_DEBUG_PRINTLN("readBytes: sz=%u, hdr=%u", (unsigned)len, (unsigned)dest[0]);
+      
+      popRecvQueue();
+      return len;
     }
   }
   
-  if (recv_queue_len > 0) {
-    size_t len = recv_queue[0].len;
-    memcpy(dest, recv_queue[0].buf, len);
-    
-    BLE_DEBUG_PRINTLN("readBytes: sz=%u, hdr=%u", (unsigned)len, (unsigned)dest[0]);
-    
-    shiftRecvQueueLeft();
-    return len;
+  unsigned long now = millis();
+  if (isConnected() && _sync_mode && _last_activity_time > 0 && 
+      send_queue.isEmpty() && recv_queue.isEmpty()) {
+    if (now - _last_activity_time >= BLE_SYNC_INACTIVITY_TIMEOUT_MS) {
+      requestDefaultConnection();
+    }
   }
   
-  // Advertising watchdog: periodically check if advertising is running, restart if not
-  // Only run when truly disconnected (no connection handle), not during connection establishment
-  unsigned long now = millis();
   if (_isEnabled && !isConnected() && _conn_handle == BLE_CONN_HANDLE_INVALID) {
     if (now - _last_health_check >= BLE_HEALTH_CHECK_INTERVAL) {
       _last_health_check = now;
@@ -361,7 +459,7 @@ void SerialBLEInterface::onBleUartRX(uint16_t conn_handle) {
   }
   
   while (instance->bleuart.available() > 0) {
-    if (instance->recv_queue_len >= FRAME_QUEUE_SIZE) {
+    if (instance->recv_queue.isFull()) {
       while (instance->bleuart.available() > 0) {
         instance->bleuart.read();
       }
@@ -382,16 +480,90 @@ void SerialBLEInterface::onBleUartRX(uint16_t conn_handle) {
     }
     
     int read_len = avail;
-    instance->recv_queue[instance->recv_queue_len].len = read_len;
-    instance->bleuart.readBytes(instance->recv_queue[instance->recv_queue_len].buf, read_len);
-    instance->recv_queue_len++;
+    SerialBLEFrame* frame = instance->recv_queue.getWriteSlot();
+    if (frame) {
+      frame->len = read_len;
+      instance->bleuart.readBytes(frame->buf, read_len);
+      instance->recv_queue.push();
+
+      unsigned long now = millis();
+      if (instance->noteFrameActivity(now, read_len)) {
+        instance->requestSyncModeConnection();
+      }
+    }
   }
 }
 
 bool SerialBLEInterface::isConnected() const {
-  return _isDeviceConnected && Bluefruit.connected() > 0;
+  return _isDeviceConnected && _conn_handle != BLE_CONN_HANDLE_INVALID && Bluefruit.connected() > 0;
 }
 
 bool SerialBLEInterface::isWriteBusy() const {
-  return send_queue_len >= (FRAME_QUEUE_SIZE * 2 / 3);
+  return isWriteBusyCommon();
+}
+
+void SerialBLEInterface::requestSyncModeConnection() {
+  if (!isConnected()) return;
+  if (_sync_mode) return;
+  if (_conn_param_update_pending) return;
+
+  _conn_param_update_pending = true;
+
+  BLE_DEBUG_PRINTLN("Requesting sync mode connection: %u-%ums interval, latency=%u, %ums timeout",
+                    BLE_SYNC_MIN_CONN_INTERVAL * 5 / 4,
+                    BLE_SYNC_MAX_CONN_INTERVAL * 5 / 4,
+                    BLE_SYNC_SLAVE_LATENCY,
+                    BLE_SYNC_CONN_SUP_TIMEOUT * 10);
+
+  ble_gap_conn_params_t conn_params;
+  conn_params.min_conn_interval = BLE_SYNC_MIN_CONN_INTERVAL;
+  conn_params.max_conn_interval = BLE_SYNC_MAX_CONN_INTERVAL;
+  conn_params.slave_latency     = BLE_SYNC_SLAVE_LATENCY;
+  conn_params.conn_sup_timeout  = BLE_SYNC_CONN_SUP_TIMEOUT;
+
+  uint32_t err_code = sd_ble_gap_conn_param_update(_conn_handle, &conn_params);
+
+  if (err_code == NRF_SUCCESS) {
+      BLE_DEBUG_PRINTLN("Sync mode connection parameter update requested successfully");
+  } else if (err_code != NRF_ERROR_BUSY) {
+      _conn_param_update_pending = false;
+      BLE_DEBUG_PRINTLN("Failed to request sync mode connection: %lu", err_code);
+  } else {
+      BLE_DEBUG_PRINTLN("Sync mode request deferred (NRF_ERROR_BUSY)");
+      // _conn_param_update_pending remains true, retry happens later
+  }
+}
+
+
+void SerialBLEInterface::requestDefaultConnection() {
+  if (!isConnected()) return;
+  if (!_sync_mode) return;
+  if (!send_queue.isEmpty() || !recv_queue.isEmpty()) return;
+  if (_conn_param_update_pending) return;
+
+  _conn_param_update_pending = true;
+
+  BLE_DEBUG_PRINTLN("Requesting default connection: %u-%ums interval, latency=%u, %ums timeout",
+                    BLE_MIN_CONN_INTERVAL * 5 / 4,
+                    BLE_MAX_CONN_INTERVAL * 5 / 4,
+                    BLE_SLAVE_LATENCY,
+                    BLE_CONN_SUP_TIMEOUT * 10);
+
+  ble_gap_conn_params_t conn_params;
+  conn_params.min_conn_interval = BLE_MIN_CONN_INTERVAL;
+  conn_params.max_conn_interval = BLE_MAX_CONN_INTERVAL;
+  conn_params.slave_latency     = BLE_SLAVE_LATENCY;
+  conn_params.conn_sup_timeout  = BLE_CONN_SUP_TIMEOUT;
+
+  uint32_t err_code = sd_ble_gap_conn_param_update(_conn_handle, &conn_params);
+
+  if (err_code == NRF_SUCCESS) {
+      BLE_DEBUG_PRINTLN("Default connection parameter update requested successfully");
+  } else if (err_code != NRF_ERROR_BUSY) {
+      _conn_param_update_pending = false;
+      BLE_DEBUG_PRINTLN("Failed to request default connection: %lu", err_code);
+  } else {
+      BLE_DEBUG_PRINTLN("Default connection request deferred (NRF_ERROR_BUSY)");
+      // _conn_param_update_pending remains true, retry happens later
+  }
 }


### PR DESCRIPTION
Core Stuff
- Unified common code into SerialBLECommon.h base class
(it should reside in a helpers/bluetooth folder with all the nrf/esp files, but this PR is not for tidying up)

<strike>- ESP32: Migrated from ESP32 BLE library to NimBLE - Re-pair could be needed! Full erase would be preferable for updating to clear out old BT library stuff from the flash. Factory reset does not clear that.
	- this also resolves xiao c3 bootloops because of too much sensors (-~500k from flash)</strike>
UPDATE: NimBLE migration will need much more testing to be seamless, so only the already used Bluedroid code is unified with nRF interface!

Connection
- Reject second connection attempts (single connection only) (edge case!)
- Improved disconnect handling with reason codes and initiator tracking (for debugging who is to blame for disconnects)

Dynamic connection parameters
- Added sync mode: switches to low-latency params (0 latency, 12-24ms interval) for high throughput
- Sync mode when the fw auto-detects large frame activity (40+ bytes, 3+ frames in 1.5s window)
- Falls back to default mode (3 latency, 12-36ms interval) after 5s inactivity
- Tracks connection parameter updates via BLE events

Queue & Transfer Improvements
- Circular queue implementation replaces linear array shifts - less RAM/CPU
- Added send interval throttling (8ms minimum) - undetectable by user, but helps stabilize the ble stack, on ESP this is mandatory!
- Improved retry logic with throttle window (250ms) - throttle sending when we detect spotty BT connection

ESP32 Specific:
Well... everything that nRF had already are now in ESP's interface :) even "turbo mode"

The two platform's BLE interface is now more or less the same (with library dependent differences of course)