### PR TITLE
Sx1262 Improvements - LoRa Radio reset

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -80,6 +80,7 @@ void Dispatcher::loop() {
       MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): WARNING: outbound packed send timed out!", getLogDateTime());
 
       _radio->onSendFinished();
+      _radio->onTXRXFault();
       logTxFail(outbound, 2 + outbound->path_len + outbound->payload_len);
 
       releasePacket(outbound);  // return to pool

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -57,6 +57,11 @@ public:
   virtual void onSendFinished() = 0;
 
   /**
+   * \brief  optional hook for handling radio TX/RX fault recovery
+  */
+  virtual void onTXRXFault() { }
+
+  /**
    * \brief  do any processing needed on each loop cycle
    */
   virtual void loop() { }

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -19,6 +19,21 @@ public:
     int sf = ((CustomSX1262 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);
   }
+  void onTXRXFault() override {
+    auto radio = static_cast<CustomSX1262 *>(_radio);
+    int16_t result = radio->reset();
+    if (result != RADIOLIB_ERR_NONE) {
+      MESH_DEBUG_PRINTLN("CustomSX1262Wrapper: reset failed (%d)", result);
+      return;
+    }
+    if (!radio->std_init()) {
+      MESH_DEBUG_PRINTLN("CustomSX1262Wrapper: re-init failed");
+      return;
+    }
+    // Rebind ISR and restart receive after reset.
+    RadioLibWrapper::begin();
+    startRecv();
+  }
   virtual void powerOff() override {
     ((CustomSX1262 *)_radio)->sleep(false);
   }

--- a/variants/rak4631/RAK4631Board.h
+++ b/variants/rak4631/RAK4631Board.h
@@ -7,7 +7,7 @@
 // LoRa radio module pins for RAK4631
 #define  P_LORA_DIO_1   47
 #define  P_LORA_NSS     42
-#define  P_LORA_RESET  RADIOLIB_NC   // 38
+#define  P_LORA_RESET  38
 #define  P_LORA_BUSY    46
 #define  P_LORA_SCLK    43
 #define  P_LORA_MISO    45


### PR DESCRIPTION
Several fixes/improvements for SX1262 radios:

1. Implemented radio resets for some TX and RX fault conditions. Radio will reset, then re-init and go back to receive state. Fault codes that will trigger reset:
RADIOLIB_ERR_TX_TIMEOUT
RADIOLIB_ERR_SPI_CMD_FAILED
RADIOLIB_ERR_SPI_CMD_INVALID
RADIOLIB_ERR_SPI_WRITE_FAILED
RADIOLIB_ERR_SPI_READ_FAILED
RADIOLIB_ERR_CHIP_NOT_FOUND
RADIOLIB_ERR_DEVICE_BUSY

On SX1262-based variants without the P_LORA_RESET pin configured, this *should* NO-OP.

2. Added SX1262 DC-DC enable code (separate to the board's DC-DC) and platform.ini flag to enable it on supported nodes. Enabled on RAK4631 as this is confirmed supported.