### PR TITLE
Add display invert setting for e-paper displays

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -222,6 +222,7 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     file.read(pad, 2);                                                                     // 78
     file.read((uint8_t *)&_prefs.ble_pin, sizeof(_prefs.ble_pin));                         // 80
     file.read((uint8_t *)&_prefs.buzzer_quiet, sizeof(_prefs.buzzer_quiet));               // 84
+    file.read((uint8_t *)&_prefs.invert_display, sizeof(_prefs.invert_display));           // 85
 
     file.close();
   }
@@ -254,6 +255,7 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write(pad, 2);                                                                     // 78
     file.write((uint8_t *)&_prefs.ble_pin, sizeof(_prefs.ble_pin));                         // 80
     file.write((uint8_t *)&_prefs.buzzer_quiet, sizeof(_prefs.buzzer_quiet));               // 84
+    file.write((uint8_t *)&_prefs.invert_display, sizeof(_prefs.invert_display));           // 85
 
     file.close();
   }

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -25,4 +25,5 @@ struct NodePrefs {  // persisted to file
   uint32_t ble_pin;
   uint8_t  advert_loc_policy;
   uint8_t  buzzer_quiet;
+  uint8_t  invert_display;   // 0 = normal (black on white), 1 = inverted (white on black)
 };

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -28,6 +28,7 @@ public:
   uint32_t ble_pin = 0;
   uint8_t  advert_loc_policy = 0;
   uint8_t  buzzer_quiet = 0;
+  uint8_t  invert_display = 0;  // 0 = normal (black on white), 1 = inverted (white on black)
   uint8_t  gps_enabled = 0;      // GPS enabled flag (0=disabled, 1=enabled)
   uint32_t gps_interval = 0;     // GPS read interval in seconds
   uint8_t autoadd_config = 0;    // bitmask for auto-add contacts config
@@ -101,6 +102,7 @@ private:
       def("defs_key", (void *) _parent->default_scope_key, sizeof(_parent->default_scope_key));
       def("pin", _parent->ble_pin);
       def("buzz_q", _parent->buzzer_quiet);
+      def("disp_inv", _parent->invert_display);
       def("auto_add", _parent->autoadd_config);    // bitmask for auto-add contacts config
       def("man_add", _parent->manual_add_contacts);
       def("tel_base", _parent->telemetry_mode_base);

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -91,6 +91,7 @@ class HomeScreen : public UIScreen {
     RADIO,
     BLUETOOTH,
     ADVERT,
+    INVERT,
 #if ENV_INCLUDE_GPS == 1
     GPS,
 #endif
@@ -299,6 +300,14 @@ public:
       display.drawXbm((display.width() - 32) / 2, 18, advert_icon, 32, 32);
       display.setColor(UIColor::secondary_txt);
       display.drawTextCentered(display.width() / 2, 64 - 11, "advert: " PRESS_LABEL);
+    } else if (_page == HomePage::INVERT) {
+      display.setColor(UIColor::primary_txt);
+      display.setTextSize(1);
+      char buf[24];
+      sprintf(buf, "Invert: %s", _node_prefs->invert_display ? "ON" : "OFF");
+      display.drawTextCentered(display.width() / 2, 32, buf);
+      display.setColor(UIColor::secondary_txt);
+      display.drawTextCentered(display.width() / 2, 64 - 11, "toggle: " PRESS_LABEL);
 #if ENV_INCLUDE_GPS == 1
     } else if (_page == HomePage::GPS) {
       LocationProvider* nmea = sensors.getLocationProvider();
@@ -478,6 +487,10 @@ public:
       return true;
     }
 #endif
+    if (c == KEY_ENTER && _page == HomePage::INVERT) {
+      _task->toggleInvertDisplay();
+      return true;
+    }
     if (c == KEY_ENTER && _page == HomePage::SHUTDOWN) {
       _shutdown_init = true;  // need to wait for button to be released
       return true;
@@ -592,6 +605,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _node_prefs = node_prefs;
 
   if (_display != NULL) {
+    _display->setInverted(_node_prefs->invert_display);  // apply saved inversion state
     _display->turnOn();
   }
 
@@ -966,4 +980,15 @@ void UITask::toggleBuzzer() {
     showAlert(buzzer.isQuiet() ? "Buzzer: OFF" : "Buzzer: ON", 800);
     _next_refresh = 0;  // trigger refresh
   #endif
+}
+
+void UITask::toggleInvertDisplay() {
+  _node_prefs->invert_display = !_node_prefs->invert_display;
+  if (_display != NULL) {
+    _display->setInverted(_node_prefs->invert_display);
+  }
+  notify(UIEventType::ack);
+  showAlert(_node_prefs->invert_display ? "Invert: ON" : "Invert: OFF", 800);
+  the_mesh.savePrefs();
+  _next_refresh = 0;  // trigger refresh
 }

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -77,6 +77,7 @@ public:
   void toggleBuzzer();
   bool getGPSState();
   void toggleGPS();
+  void toggleInvertDisplay();
 
 
   // from AbstractUITask

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -87,6 +87,7 @@ public:
   }
 
   void toggleBuzzer();
+  void toggleInvertDisplay();
   bool getGPSState();
   void toggleGPS();
 

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -6,12 +6,15 @@
 class DisplayDriver {
   int _w, _h;
 protected:
+  bool _inverted = false;  // display inversion state
   DisplayDriver(int w, int h) { _w = w; _h = h; }
 public:
   enum Color { DARK=0, LIGHT, RED, GREEN, BLUE, YELLOW, ORANGE }; // on b/w screen, colors will be !=0 synonym of light
 
   int width() const { return _w; }
   int height() const { return _h; }
+  bool isInverted() const { return _inverted; }
+  virtual void setInverted(bool inv) { _inverted = inv; }
 
   virtual bool isOn() = 0;
   virtual void turnOn() = 0;

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -14,12 +14,15 @@ public:
 class DisplayDriver {
   int _w, _h;
 protected:
+  bool _inverted = false;  // display inversion state
   DisplayDriver(int w, int h) { _w = w; _h = h; }
 public:
   //enum Color { DARK=0, LIGHT, RED, GREEN, BLUE, YELLOW, ORANGE }; // on b/w screen, colors will be !=0 synonym of light
 
   int width() const { return _w; }
   int height() const { return _h; }
+  bool isInverted() const { return _inverted; }
+  virtual void setInverted(bool inv) { _inverted = inv; }
 
   virtual bool isOn() = 0;
   virtual bool isEink() { return false; } // default to non-eink, override in eink drivers

--- a/src/helpers/ui/GxEPDDisplay.cpp
+++ b/src/helpers/ui/GxEPDDisplay.cpp
@@ -68,8 +68,8 @@ void GxEPDDisplay::turnOff() {
 }
 
 void GxEPDDisplay::clear() {
-  display.fillScreen(GxEPD_WHITE);
-  display.setTextColor(GxEPD_BLACK);
+  display.fillScreen(UIColor::window_bkg);
+  display.setTextColor(UIColor::primary_txt);
   display_crc.reset();
 }
 
@@ -183,4 +183,21 @@ void GxEPDDisplay::endFrame() {
     display.display(true);
     last_display_crc_value = crc;
   }
+}
+
+void GxEPDDisplay::setInverted(bool inv) {
+  if (inv == _inverted) return;
+  _inverted = inv;
+
+  UIColor::window_bkg = inv ? GxEPD_BLACK : GxEPD_WHITE;
+  UIColor::title_bkg = UIColor::window_bkg;
+  UIColor::popup_bkg = UIColor::window_bkg;
+  UIColor::title_txt = inv ? GxEPD_WHITE : GxEPD_BLACK;
+  UIColor::primary_txt = UIColor::title_txt;
+  UIColor::secondary_txt = UIColor::title_txt;
+  UIColor::warning_txt = UIColor::title_txt;
+  UIColor::popup_txt = UIColor::title_txt;
+  UIColor::corp_blue = UIColor::title_txt;
+
+  last_display_crc_value = 0;  // force full redraw on next frame
 }

--- a/src/helpers/ui/GxEPDDisplay.h
+++ b/src/helpers/ui/GxEPDDisplay.h
@@ -60,4 +60,5 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  void setInverted(bool inv) override;
 };

--- a/src/helpers/ui/GxEPDDisplay.h
+++ b/src/helpers/ui/GxEPDDisplay.h
@@ -61,4 +61,5 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  void setInverted(bool inv) override;
 };


### PR DESCRIPTION
## Summary
- Adds a toggle to invert the display colors (white on black instead of black on white)
- The setting persists across reboots
- Adds `invert_display` preference to NodePrefs
- Adds INVERT page to home screen (after ADVERT) with toggle
- Updates GxEPDDisplay to respect inversion state for colors and background

## Test plan
- [x] Tested on LilyGo T-Echo with companion_radio_ble firmware
- [x] Verified display inverts correctly when toggled
- [x] Verified setting persists after reboot
- [x] Verified logo and text render correctly in both modes