### PR TITLE
BUGFIX: Companion packet timestamp mismatch trips replay protection

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -903,6 +903,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       int result;
       uint32_t expected_ack;
       if (txt_type == TXT_TYPE_CLI_DATA) {
+        msg_timestamp = getRTCClock()->getCurrentTimeUnique(); // Use node's RTC instead of app timestamp to avoid tripping replay protection
         result = sendCommandData(*recipient, msg_timestamp, attempt, text, est_timeout);
         expected_ack = 0; // no Ack expected
       } else {


### PR DESCRIPTION
Initial login packet and REQ packets use the timestamp from the companion node's RTC. Most subsequent text packets using the timestamp from the companion node's mobile app. Drift between these timestamps can trip the replay protection and cause timeouts after login on the client side. 

Fix changes this logic to send the node's RTC timestamp for TXT_TYPE_CLI_DATA messages instead of the timestamp from the app (matches the sendRequest() code logic).

Ideally we would use the same timestamp everywhere and this does work in my testing, however it breaks the "Heard <n> repeats" in the mobile app (presumably because the timestamp is part of the packet hash and the heard packet doesn't match the one the app thinks was sent). 