### PR TITLE
Configurable packet forwarding for repeaters (types and hops)

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -318,15 +318,13 @@ File MyMesh::openAppend(const char *fname) {
 }
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
-  if (packet->isRouteFlood() && packet->path_len >= _prefs.flood_max) return false;
-  if (packet->isRouteFlood() && recv_pkt_region == NULL) {
-    MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
+  if (_prefs.disable_fwd) {
     return false;
   }
 
-  // Check global disable_fwd switch first
-  if (_prefs.disable_fwd) {
-    MESH_DEBUG_PRINTLN("allowPacketForward: forwarding globally disabled");
+  if (packet->isRouteFlood() && packet->path_len >= _prefs.flood_max) return false;
+  if (packet->isRouteFlood() && recv_pkt_region == NULL) {
+    MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
     return false;
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -356,8 +356,9 @@ bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
       }
     }
 
-    // Check max hops for advert packets (0 = no limit)
-    if (_prefs.advert_max_hops > 0 && packet->path_len > _prefs.advert_max_hops) {
+    // Check max hops for flood-mode advert packets (0 = no limit)
+    // path_len is only meaningful for flood packets, not direct-mode packets
+    if (packet->isRouteFlood() && _prefs.advert_max_hops > 0 && packet->path_len > _prefs.advert_max_hops) {
       MESH_DEBUG_PRINTLN("allowPacketForward: advert exceeded max hops (%d > %d)",
                         packet->path_len, _prefs.advert_max_hops);
       return false;

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -324,6 +324,12 @@ bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
     return false;
   }
 
+  // Check global disable_fwd switch first
+  if (_prefs.disable_fwd) {
+    MESH_DEBUG_PRINTLN("allowPacketForward: forwarding globally disabled");
+    return false;
+  }
+
   // Check if this packet type is allowed to be repeated
   uint8_t pkt_type = packet->getPayloadType();
   if (pkt_type < mesh::MAX_PACKET_TYPES && (_prefs.repeat_packet_types & (1 << pkt_type)) == 0) {

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -355,6 +355,13 @@ bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
         }
       }
     }
+
+    // Check max hops for advert packets (0 = no limit)
+    if (_prefs.advert_max_hops > 0 && packet->path_len > _prefs.advert_max_hops) {
+      MESH_DEBUG_PRINTLN("allowPacketForward: advert exceeded max hops (%d > %d)",
+                        packet->path_len, _prefs.advert_max_hops);
+      return false;
+    }
   }
 
   return true;
@@ -760,6 +767,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   // Packet filtering defaults - repeat everything by default
   _prefs.repeat_packet_types = 0xFFFF; // Repeat all packet types by default
   _prefs.repeat_advert_types = 0xFFFF; // Repeat all advert types by default
+  _prefs.advert_max_hops = 0;          // No hop limit by default
 }
 
 void MyMesh::begin(FILESYSTEM *fs) {

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -27,6 +27,7 @@
 #include <helpers/ArduinoHelpers.h>
 #include <helpers/ClientACL.h>
 #include <helpers/CommonCLI.h>
+#include <helpers/PacketTypeNames.h>
 #include <helpers/IdentityStore.h>
 #include <helpers/SimpleMeshTables.h>
 #include <helpers/StaticPoolPacketManager.h>

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -643,6 +643,18 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
           _prefs->adc_multiplier = 0.0f;
           strcpy(reply, "Error: unsupported by this board");
         };
+      } else if (memcmp(config, "repeat on", 9) == 0) {
+        // Turn all packet types ON (set all bits)
+        _prefs->repeat_packet_types = 0xFFFF;
+        _prefs->disable_fwd = false;  // Sync for downgrade compatibility
+        savePrefs();
+        strcpy(reply, "OK - all packet types will be repeated");
+      } else if (memcmp(config, "repeat off", 10) == 0) {
+        // Turn all packet types OFF (clear all bits)
+        _prefs->repeat_packet_types = 0x0000;
+        _prefs->disable_fwd = true;  // Sync for downgrade compatibility
+        savePrefs();
+        strcpy(reply, "OK - all packet types will not be repeated");
       } else if (memcmp(config, "repeat ", 7) == 0) {
         const char* rest = &config[7];
 
@@ -761,18 +773,6 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
             strcpy(reply, "Error: format is 'set repeat <type> on/off'");
           }
         }
-      } else if (memcmp(config, "repeat on", 9) == 0) {
-        // Turn all packet types ON (set all bits)
-        _prefs->repeat_packet_types = 0xFFFF;
-        _prefs->disable_fwd = false;  // Sync for downgrade compatibility
-        savePrefs();
-        strcpy(reply, "OK - all packet types will be repeated");
-      } else if (memcmp(config, "repeat off", 10) == 0) {
-        // Turn all packet types OFF (clear all bits)
-        _prefs->repeat_packet_types = 0x0000;
-        _prefs->disable_fwd = true;  // Sync for downgrade compatibility
-        savePrefs();
-        strcpy(reply, "OK - all packet types will not be repeated");
       } else {
         sprintf(reply, "unknown config: %s", config);
       }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -2,6 +2,7 @@
 #include "CommonCLI.h"
 #include "TxtDataHelpers.h"
 #include "AdvertDataHelpers.h"
+#include "PacketTypeNames.h"
 #include <RTClib.h>
 
 // Believe it or not, this std C function is busted on some platforms!
@@ -72,7 +73,9 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->advert_loc_policy, sizeof (_prefs->advert_loc_policy));          // 161
     file.read((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier)); // 166
-    // 170
+    file.read((uint8_t *)&_prefs->repeat_packet_types, sizeof(_prefs->repeat_packet_types)); // 170
+    file.read((uint8_t *)&_prefs->repeat_advert_types, sizeof(_prefs->repeat_advert_types)); // 172
+    // 173
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -99,7 +102,25 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->gps_enabled = constrain(_prefs->gps_enabled, 0, 1);
     _prefs->advert_loc_policy = constrain(_prefs->advert_loc_policy, 0, 2);
 
+    // Validate packet repeat bitmask - ensure no bits set beyond valid packet types
+    uint16_t valid_mask = (1 << mesh::MAX_PACKET_TYPES) - 1;
+    _prefs->repeat_packet_types &= valid_mask;
+
+    // Validate advert repeat bitmask - ensure no bits set beyond valid advert types
+    uint8_t valid_adv_mask = (1 << mesh::MAX_ADVERT_TYPES) - 1;
+    _prefs->repeat_advert_types &= valid_adv_mask;
+
     file.close();
+
+    // Migrate legacy disable_fwd to new granular filtering system
+    if (_prefs->disable_fwd && _prefs->repeat_packet_types == 0xFFFF) {
+      // Old firmware had disable_fwd=true but new filtering not configured yet
+      // Migrate: clear all bits to block all packet types (bit=1 means allow)
+      _prefs->repeat_packet_types = 0x0000;  // Block all packet types
+      savePrefs();  // Persist migration immediately
+    }
+    // Note: We keep disable_fwd in sync with filtering state for downgrade compatibility
+    // If repeat_packet_types != 0xFFFF (any filtering), keep disable_fwd=true for old firmware
   }
 }
 
@@ -155,7 +176,9 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->advert_loc_policy, sizeof(_prefs->advert_loc_policy));           // 161
     file.write((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
-    // 170
+    file.write((uint8_t *)&_prefs->repeat_packet_types, sizeof(_prefs->repeat_packet_types));       // 170
+    file.write((uint8_t *)&_prefs->repeat_advert_types, sizeof(_prefs->repeat_advert_types));       // 172
+    // 173
 
     file.close();
   }
@@ -282,8 +305,70 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         sprintf(reply, "> %s", tmp);
       } else if (memcmp(config, "name", 4) == 0) {
         sprintf(reply, "> %s", _prefs->node_name);
-      } else if (memcmp(config, "repeat", 6) == 0) {
-        sprintf(reply, "> %s", _prefs->disable_fwd ? "off" : "on");
+      } else if (memcmp(config, "repeat advert", 13) == 0 && (config[13] == 0 || config[13] == ' ')) {
+        // Show which advert sub-types are allowed to repeat
+        reply[0] = '>';
+        reply[1] = ' ';
+        int pos = 2;
+        bool has_any = false;
+
+        for (int i = 0; i < mesh::MAX_ADVERT_TYPES; i++) {
+          if ((_prefs->repeat_advert_types & (1 << i)) != 0) {
+            const char* name = mesh::getAdvertTypeName(i);
+            int len = strlen(name);
+
+            if (pos + (has_any ? 1 : 0) + len + 1 >= 160) {
+              strcpy(&reply[pos], "...");
+              pos += 3;
+              break;
+            }
+
+            if (has_any) {
+              reply[pos++] = ',';
+            }
+            strcpy(&reply[pos], name);
+            pos += len;
+            has_any = true;
+          }
+        }
+
+        if (!has_any) {
+          strcpy(&reply[2], "all filtered");
+        } else {
+          reply[pos] = 0;
+        }
+      } else if (memcmp(config, "repeat", 6) == 0 && (config[6] == 0 || config[6] == ' ')) {
+        // Show which packet types are being repeated
+        reply[0] = '>';
+        reply[1] = ' ';
+        int pos = 2;
+        bool has_any = false;
+
+        for (int i = 0; i < mesh::MAX_PACKET_TYPES; i++) {
+          if ((_prefs->repeat_packet_types & (1 << i)) != 0) {  // If bit set, it's being repeated
+            const char* name = mesh::getPacketTypeName(i);
+            int len = strlen(name);
+
+            if (pos + (has_any ? 1 : 0) + len + 1 >= 160) {
+              strcpy(&reply[pos], "...");
+              pos += 3;
+              break;
+            }
+
+            if (has_any) {
+              reply[pos++] = ',';
+            }
+            strcpy(&reply[pos], name);
+            pos += len;
+            has_any = true;
+          }
+        }
+
+        if (!has_any) {
+          strcpy(&reply[2], "all filtered");
+        } else {
+          reply[pos] = 0;
+        }
       } else if (memcmp(config, "lat", 3) == 0) {
         sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lat));
       } else if (memcmp(config, "lon", 3) == 0) {
@@ -413,10 +498,6 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         StrHelper::strncpy(_prefs->node_name, &config[5], sizeof(_prefs->node_name));
         savePrefs();
         strcpy(reply, "OK");
-      } else if (memcmp(config, "repeat ", 7) == 0) {
-        _prefs->disable_fwd = memcmp(&config[7], "off", 3) == 0;
-        savePrefs();
-        strcpy(reply, _prefs->disable_fwd ? "OK - repeat is now OFF" : "OK - repeat is now ON");
       } else if (memcmp(config, "radio ", 6) == 0) {
         strcpy(tmp, &config[6]);
         const char *parts[4];
@@ -550,6 +631,116 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
           _prefs->adc_multiplier = 0.0f;
           strcpy(reply, "Error: unsupported by this board");
         };
+      } else if (memcmp(config, "repeat ", 7) == 0) {
+        const char* rest = &config[7];
+
+        // Check for advert sub-type commands: "repeat advert.sensor on/off"
+        if (memcmp(rest, "advert.", 7) == 0) {
+          const char* adv_type_and_state = &rest[7];
+          // Find space separating type from on/off
+          const char* space_pos = strchr(adv_type_and_state, ' ');
+          if (space_pos != NULL) {
+            int type_len = space_pos - adv_type_and_state;
+            char adv_type_name[16];
+            if (type_len < 16) {
+              memcpy(adv_type_name, adv_type_and_state, type_len);
+              adv_type_name[type_len] = 0;
+
+              const char* state = space_pos + 1;
+              int adv_type_idx = mesh::findAdvertTypeByName(adv_type_name);
+
+              if (adv_type_idx >= 0) {
+                if (memcmp(state, "on", 2) == 0) {
+                  _prefs->repeat_advert_types |= (1 << adv_type_idx);
+                  savePrefs();
+                  sprintf(reply, "OK - %s adverts will be repeated", adv_type_name);
+                } else if (memcmp(state, "off", 3) == 0) {
+                  _prefs->repeat_advert_types &= ~(1 << adv_type_idx);
+                  savePrefs();
+                  sprintf(reply, "OK - %s adverts will not be repeated", adv_type_name);
+                } else {
+                  strcpy(reply, "Error: use 'on' or 'off'");
+                }
+              } else {
+                strcpy(reply, "Error: unknown advert type (use: none,chat,repeater,room,sensor)");
+              }
+            } else {
+              strcpy(reply, "Error: advert type name too long");
+            }
+          } else {
+            strcpy(reply, "Error: format is 'set repeat advert.<type> on/off'");
+          }
+        }
+        // Check for packet type commands: "repeat advert on/off", "repeat grp.txt on/off"
+        else {
+          // Find space separating type from on/off
+          const char* space_pos = strchr(rest, ' ');
+          if (space_pos != NULL) {
+            int type_len = space_pos - rest;
+            char type_name[16];
+            if (type_len < 16) {
+              memcpy(type_name, rest, type_len);
+              type_name[type_len] = 0;
+
+              const char* state = space_pos + 1;
+              int type_idx = mesh::findPacketTypeByName(type_name);
+
+              if (type_idx >= 0) {
+                if (memcmp(state, "on", 2) == 0) {
+                  _prefs->repeat_packet_types |= (1 << type_idx);  // Set bit = repeat ON
+
+                  // Special handling for advert: enable all advert sub-types
+                  if (type_idx == PAYLOAD_TYPE_ADVERT) {
+                    _prefs->repeat_advert_types = (1 << mesh::MAX_ADVERT_TYPES) - 1;  // All bits set
+                  }
+
+                  // Sync disable_fwd for downgrade compatibility
+                  _prefs->disable_fwd = (_prefs->repeat_packet_types != 0xFFFF);
+
+                  savePrefs();
+                  sprintf(reply, "OK - %s packets will be repeated", type_name);
+                } else if (memcmp(state, "off", 3) == 0) {
+                  _prefs->repeat_packet_types &= ~(1 << type_idx);   // Clear bit = repeat OFF
+
+                  // Special handling for advert: clear all advert sub-types
+                  if (type_idx == PAYLOAD_TYPE_ADVERT) {
+                    _prefs->repeat_advert_types = 0x00;  // All bits clear
+                  }
+
+                  // Sync disable_fwd for downgrade compatibility
+                  _prefs->disable_fwd = (_prefs->repeat_packet_types != 0xFFFF);
+
+                  savePrefs();
+                  if (type_idx == PAYLOAD_TYPE_ADVERT) {
+                    sprintf(reply, "OK - %s packets will not be repeated (use 'set repeat advert.<type> on' for exceptions)", type_name);
+                  } else {
+                    sprintf(reply, "OK - %s packets will not be repeated", type_name);
+                  }
+                } else {
+                  strcpy(reply, "Error: use 'on' or 'off'");
+                }
+              } else {
+                strcpy(reply, "Error: unknown type (use: req,resp,txt,ack,advert,grp.txt,grp.data,anon,path,trace,multi,control,raw)");
+              }
+            } else {
+              strcpy(reply, "Error: packet type name too long");
+            }
+          } else {
+            strcpy(reply, "Error: format is 'set repeat <type> on/off'");
+          }
+        }
+      } else if (memcmp(config, "repeat on", 9) == 0) {
+        // Turn all packet types ON (set all bits)
+        _prefs->repeat_packet_types = 0xFFFF;
+        _prefs->disable_fwd = false;  // Sync for downgrade compatibility
+        savePrefs();
+        strcpy(reply, "OK - all packet types will be repeated");
+      } else if (memcmp(config, "repeat off", 10) == 0) {
+        // Turn all packet types OFF (clear all bits)
+        _prefs->repeat_packet_types = 0x0000;
+        _prefs->disable_fwd = true;  // Sync for downgrade compatibility
+        savePrefs();
+        strcpy(reply, "OK - all packet types will not be repeated");
       } else {
         sprintf(reply, "unknown config: %s", config);
       }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -364,13 +364,13 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         }
 
         // Add separator
-        strcpy(&reply[pos], " (filters: ");
+        strcpy(&reply[pos], " (allowed: ");
         pos += 11;
 
         // Show configured packet types
         bool has_any = false;
         for (int i = 0; i < mesh::MAX_PACKET_TYPES; i++) {
-          if ((_prefs->repeat_packet_types & (1 << i)) != 0) {  // If bit set, it's configured
+          if ((_prefs->repeat_packet_types & (1 << i)) != 0) {  // If bit set, it's allowed
             const char* name = mesh::getPacketTypeName(i);
             int len = strlen(name);
 
@@ -662,12 +662,12 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         // Enable global repeat switch (bitmask settings are preserved)
         _prefs->disable_fwd = false;
         savePrefs();
-        strcpy(reply, "OK - repeating enabled (using configured packet filters)");
+        strcpy(reply, "OK - repeating enabled");
       } else if (memcmp(config, "repeat off", 10) == 0) {
         // Disable global repeat switch (bitmask settings are preserved)
         _prefs->disable_fwd = true;
         savePrefs();
-        strcpy(reply, "OK - repeating disabled (packet filters preserved)");
+        strcpy(reply, "OK - repeating disabled");
       } else if (memcmp(config, "repeat ", 7) == 0) {
         const char* rest = &config[7];
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -315,7 +315,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         if (_prefs->advert_max_hops == 0) {
           sprintf(reply, "> unlimited");
         } else {
-          sprintf(reply, "> %d", _prefs->advert_max_hops);
+          sprintf(reply, "> %d (excluding companion adverts)", _prefs->advert_max_hops);
         }
       } else if (memcmp(config, "repeat advert", 13) == 0 && (config[13] == 0 || config[13] == ' ')) {
         // Show which advert sub-types are allowed to repeat
@@ -674,7 +674,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
               if (value == 0) {
                 strcpy(reply, "OK - advert max hops set to unlimited");
               } else {
-                sprintf(reply, "OK - advert max hops set to %d", value);
+                sprintf(reply, "OK - advert max hops set to %d (excluding companion adverts)", value);
               }
             }
           }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -695,6 +695,15 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 if (adv_type_idx >= 0) {
                 if (memcmp(state, "on", 2) == 0) {
                   _prefs->repeat_advert_types |= (1 << adv_type_idx);
+
+                  // Automatically enable advert packet type if it's off
+                  if ((_prefs->repeat_packet_types & (1 << PAYLOAD_TYPE_ADVERT)) == 0) {
+                    _prefs->repeat_packet_types |= (1 << PAYLOAD_TYPE_ADVERT);
+                  }
+
+                  // Sync disable_fwd for downgrade compatibility
+                  _prefs->disable_fwd = (_prefs->repeat_packet_types != 0xFFFF);
+
                   savePrefs();
                   sprintf(reply, "OK - %s adverts will be repeated", adv_type_name);
                 } else if (memcmp(state, "off", 3) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -50,6 +50,8 @@ struct NodePrefs { // persisted to file
   uint8_t advert_loc_policy;
   uint32_t discovery_mod_timestamp;
   float adc_multiplier;
+  uint16_t repeat_packet_types;     // Bitmask: bit=1 means ALLOW repeat (0-15)
+  uint8_t repeat_advert_types;      // Bitmask: bit=1 means ALLOW advert type through
 };
 
 class CommonCLICallbacks {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -52,6 +52,7 @@ struct NodePrefs { // persisted to file
   float adc_multiplier;
   uint16_t repeat_packet_types;     // Bitmask: bit=1 means ALLOW repeat (0-15)
   uint8_t repeat_advert_types;      // Bitmask: bit=1 means ALLOW advert type through
+  uint8_t advert_max_hops;          // Max hops for advert packets (0 = no limit)
 };
 
 class CommonCLICallbacks {

--- a/src/helpers/PacketTypeNames.h
+++ b/src/helpers/PacketTypeNames.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <Packet.h>
+#include <helpers/AdvertDataHelpers.h>
+
+namespace mesh {
+
+constexpr int MAX_PACKET_TYPES = 16;
+constexpr int MAX_ADVERT_TYPES = 5;
+
+// Packet type name strings - stored in flash memory
+// These correspond to PAYLOAD_TYPE_* values 0x00 through 0x0F
+static const char* const PACKET_TYPE_NAMES[MAX_PACKET_TYPES] = {
+  "req",       // 0x00 PAYLOAD_TYPE_REQ
+  "resp",      // 0x01 PAYLOAD_TYPE_RESPONSE
+  "txt",       // 0x02 PAYLOAD_TYPE_TXT_MSG
+  "ack",       // 0x03 PAYLOAD_TYPE_ACK
+  "advert",    // 0x04 PAYLOAD_TYPE_ADVERT
+  "grp.txt",   // 0x05 PAYLOAD_TYPE_GRP_TXT
+  "grp.data",  // 0x06 PAYLOAD_TYPE_GRP_DATA
+  "anon",      // 0x07 PAYLOAD_TYPE_ANON_REQ
+  "path",      // 0x08 PAYLOAD_TYPE_PATH
+  "trace",     // 0x09 PAYLOAD_TYPE_TRACE
+  "multi",     // 0x0A PAYLOAD_TYPE_MULTIPART
+  "control",   // 0x0B PAYLOAD_TYPE_CONTROL
+  "12",        // 0x0C (reserved)
+  "13",        // 0x0D (reserved)
+  "14",        // 0x0E (reserved)
+  "raw"        // 0x0F PAYLOAD_TYPE_RAW_CUSTOM
+};
+
+// Advert type name strings - stored in flash memory
+// These correspond to ADV_TYPE_* values 0 through 4
+static const char* const ADVERT_TYPE_NAMES[MAX_ADVERT_TYPES] = {
+  "none",      // 0 ADV_TYPE_NONE
+  "chat",      // 1 ADV_TYPE_CHAT (companion radios)
+  "repeater",  // 2 ADV_TYPE_REPEATER
+  "room",      // 3 ADV_TYPE_ROOM (room servers)
+  "sensor"     // 4 ADV_TYPE_SENSOR
+};
+
+// Helper function to safely get packet type name
+inline const char* getPacketTypeName(uint8_t type) {
+  if (type >= MAX_PACKET_TYPES) return "unknown";
+  return PACKET_TYPE_NAMES[type];
+}
+
+// Helper function to find packet type index by name
+inline int findPacketTypeByName(const char* name) {
+  for (int i = 0; i < MAX_PACKET_TYPES; i++) {
+    if (strcmp(name, PACKET_TYPE_NAMES[i]) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Helper function to safely get advert type name
+inline const char* getAdvertTypeName(uint8_t type) {
+  if (type >= MAX_ADVERT_TYPES) return "unknown";
+  return ADVERT_TYPE_NAMES[type];
+}
+
+// Helper function to find advert type index by name
+inline int findAdvertTypeByName(const char* name) {
+  for (int i = 0; i < MAX_ADVERT_TYPES; i++) {
+    if (strcmp(name, ADVERT_TYPE_NAMES[i]) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+}


### PR DESCRIPTION
Adds configurable packet filtering for MeshCore repeaters to reduce airtime congestion on large mesh networks. This allows network operators to selectively control which packet types their repeaters forward, with granular sub-type filtering for advert packets and distance-based hop count limits.

## Motivation

Large mesh networks suffer from airtime congestion (see discussion in meshcore-dev#1217) when repeaters forward all packet types indiscriminately. This feature allows operators to:
- Block group messages on public repeaters
- Filter advert types by device category (chat, sensor, room, repeater)
- Limit advert propagation distance with hop count filtering (always excluding companion adverts)
- Emergency stop: disable all forwarding instantly with preserved filter configuration

## Core Changes

**New Header: `src/helpers/PacketTypeNames.h`**
- Centralized packet and advert type name definitions
- Provides helper functions for type name lookup

**New Preferences (offsets 170-173):**
- `uint16_t repeat_packet_types` - Bitmask for 16 packet types (bit=1 means allow)
- `uint8_t repeat_advert_types` - Bitmask for 5 advert sub-types (bit=1 means allow)
- `uint8_t advert_max_hops` - Maximum hop count for advert packets excluding from companions (0 = unlimited)

**Repurposed Preference:**
- `bool disable_fwd` - Now acts as a global on/off switch independent of bitmask settings

**Extended `allowPacketForward()` in MyMesh.cpp:**
1. Check flood-mode constraints
2. **Check global disable_fwd switch (preserves bitmask)**
3. Check packet type bitmask
4. For adverts: check sub-type bitmask and hop count limit (if not from a companion)
5. Return true to forward, false to block

## Design Decisions

 - **Preference Retention**: The `disable_fwd` preference now acts as a global on/off switch that preserves all bitmask filter settings. Users can configure granular filtering, then toggle repeating on/off without losing their custom configuration.
 - **Backwards compatible**: Migrates `disable_fwd=true` from old firmware to `repeat_packet_types=0x0000` on first load
 - **Positive Logic**: bit=1 means "allow" (intuitive: `set repeat on` enables forwarding)
 - **Permissive Default**: 0xFFFF repeats everything (backward compatible behavior)
 - **Auto-Enable Parent Type**: When enabling an advert sub-type, the advert packet type is automatically enabled if currently off.
 - **Flood-Mode Guard**: Hop count filtering only applies to flood-mode adverts (excluding companion adverts), since path_len is not meaningful for direct-mode packets.

## CLI Reference

- `get repeat` - Show global state (ON/OFF) and configured packet type filters
- `get repeat advert` - Show which advert sub-types are configured
- `get repeat advert.max_hops` - Show hop count limit
- `set repeat on` - Enable forwarding globally (uses configured packet filters)
- `set repeat off` - Disable forwarding globally (packet filters preserved)
- `set repeat {type} {on|off}` - Configure specific packet type filter
- `set repeat advert.{subtype} {on|off}` - Configure specific advert sub-type filter
- `set repeat advert.max_hops {0-255}` - Set hop count limit (0 = unlimited) for adverts (excluding from companions)

## Example Workflow

```bash
# Configure granular filters
set repeat txt on
set repeat grp.txt off
set repeat advert.sensor on
set repeat advert.chat off

# Check configuration
get repeat
> ON (filters: txt,advert)

# Temporarily disable repeating (settings preserved)
set repeat off
> OK - repeating disabled (packet filters preserved)

# Re-enable repeating (custom filters still active)
set repeat on
> OK - repeating enabled (using configured packet filters)

# Verify filters were preserved
get repeat
> ON (filters: txt,advert)
```

## Testing

All repeater builds pass and functionality has been validated on a Heltec v3 and T114 (no display).