### PR TITLE
Sync gps time every 30min

### DIFF
--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -43,6 +43,8 @@ class MicroNMEALocationProvider : public LocationProvider {
     int _pin_en;
     long next_check = 0;
     long time_valid = 0;
+    unsigned long _last_time_sync = 0;
+    static const unsigned long TIME_SYNC_INTERVAL = 1800000; // Re-sync every 30 minutes
 
 public :
     MicroNMEALocationProvider(Stream& ser, mesh::RTCClock* clock = NULL, int pin_reset = GPS_RESET, int pin_en = GPS_EN,RefCountedDigitalPin* peripher_power=NULL) :
@@ -129,10 +131,15 @@ public :
 
         if (millis() > next_check) {
             next_check = millis() + 1000;
+            // Re-enable time sync periodically when GPS has valid fix
+            if (!_time_sync_needed && _clock != NULL && (millis() - _last_time_sync) > TIME_SYNC_INTERVAL) {
+                _time_sync_needed = true;
+            }
             if (_time_sync_needed && time_valid > 2) {
                 if (_clock != NULL) {
                     _clock->setCurrentTime(getTimestamp());
                     _time_sync_needed = false;
+                    _last_time_sync = millis();
                 }
             }
             if (isValid()) {


### PR DESCRIPTION
## Summary

Re-syncs the RTC clock from GPS every 30 minutes to combat clock drift, which is especially significant when powersaving is enabled.

Currently, GPS time sync only happens once on the initial fix. After that, the ESP32's internal oscillator drifts and the RTC gradually becomes inaccurate. This adds periodic re-synchronization while the GPS has a valid fix.

## Changes

- Added `_last_time_sync` to track when the last GPS→RTC sync occurred
- Added `TIME_SYNC_INTERVAL` constant (30 minutes)
- Re-enables `_time_sync_needed` flag periodically so the existing sync logic fires again
- First sync still happens immediately on boot (unchanged behaviour)
- Requires 3 consecutive seconds of valid GPS fix before syncing (existing `time_valid > 2` guard)

## Notes

- `millis()` overflow after 49 days is handled correctly by unsigned subtraction
- GPS spoofing is not a new concern — if GPS is spoofed from the start, the initial sync would already be wrong
- Only active when `_clock` is non-NULL (i.e. when an RTC is configured)

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=sync-gps-time-30min)