### PR TITLE
Document alt INA3221 addr, avoid INA219 conflict

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -61,7 +61,9 @@ static SensirionI2cSht4x SHT4X;
 #endif
 
 #if ENV_INCLUDE_INA3221
-#define TELEM_INA3221_ADDRESS   0x42      // INA3221 3 channel current sensor I2C address
+#ifndef TELEM_INA3221_ADDRESS
+#define TELEM_INA3221_ADDRESS   0x42      // INA3221 3 channel current sensor I2C address (0x40-0x43 based on A0 pin)
+#endif
 #define TELEM_INA3221_SHUNT_VALUE 0.100 // most variants will have a 0.1 ohm shunts
 #define TELEM_INA3221_NUM_CHANNELS 3
 #include <Adafruit_INA3221.h>
@@ -268,6 +270,13 @@ bool EnvironmentSensorManager::begin() {
   #endif
 
   #if ENV_INCLUDE_INA219
+  // Skip INA219 if INA3221 is at the same address (they conflict)
+  #if ENV_INCLUDE_INA3221
+  if (INA3221_initialized && TELEM_INA219_ADDRESS == TELEM_INA3221_ADDRESS) {
+    INA219_initialized = false;
+    MESH_DEBUG_PRINTLN("INA219 skipped - INA3221 at same address %02X", TELEM_INA219_ADDRESS);
+  } else
+  #endif
   if (INA219.begin(TELEM_WIRE)) {
     MESH_DEBUG_PRINTLN("Found INA219 at address: %02X", TELEM_INA219_ADDRESS);
     INA219_initialized = true;


### PR DESCRIPTION
This adds a support for defining alternate INA3221 addresses.

It also adds some special handling in the case you change the address to 0x40 and it conflicts with INA219. In that case, the INA3221 responds to INA219 commands, but with garbage data

I was very confused when the [INA3221](https://done.land/components/power/measuringcurrent/viashunt/ina3221/) generic board I got from Aliexpress wasn't making sense. I got an additional channel of data, but the voltage was halved and the current was related to channel 2 in a weird way. If you can solder, fixing the problem is a bridge away, but sometimes you need a software fix


AI disclosure: I used Claude Code when developing this, but I tested it on my hardware and have fully read through the diff