### PR TITLE
ThinkNode M1 GPS fixes

### DIFF
--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -83,6 +83,7 @@ build_flags =
   -D PIN_BUZZER=6
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
   -D QSPIFLASH=1
+  -D ENV_INCLUDE_GPS=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M1.build_src_filter}

--- a/variants/thinknode_m1/target.cpp
+++ b/variants/thinknode_m1/target.cpp
@@ -11,7 +11,7 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
-MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1);
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
 ThinkNodeM1SensorManager sensors = ThinkNodeM1SensorManager(nmea);
 
 #ifdef DISPLAY_CLASS

--- a/variants/thinknode_m1/target.h
+++ b/variants/thinknode_m1/target.h
@@ -22,6 +22,7 @@ class ThinkNodeM1SensorManager : public SensorManager {
   void stop_gps();
 public:
   ThinkNodeM1SensorManager(LocationProvider &location): _location(&location) { }
+  LocationProvider* getLocationProvider() override { return _location; }
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
   void loop() override;


### PR DESCRIPTION
This PR fixes the broken GPS on ThinkNode M1 and adds few missing pieces.

fix: added getLocationProvider() override which is required for GPS to work after previous refactoring of SensorManager.
feat: added GPS page in the new UI
feat: pass rtc_clock so that GPS can sync clock

Tested and working.

Closes https://github.com/meshcore-dev/MeshCore/issues/1285