### PR TITLE
Robust contacts - backup first before saving and fallback to backup file

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -365,7 +365,6 @@ void DataStore::saveContacts(DataStoreHost* host) {
 
 #ifdef HAS_ATOMIC_WRITE_SUPPORT
     if (write_success) {
-      fs->remove("/contacts3.bak");
       fs->rename("/contacts3", "/contacts3.bak");
       fs->rename("/contacts3.tmp", "/contacts3");
       fs->remove("/contacts3.bak");

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -7,6 +7,12 @@
   #define MAX_BLOBRECS 20
 #endif
 
+// Atomic writes require ~2x storage for contacts file
+// Only enable on platforms with sufficient flash
+#if !defined(NRF52_PLATFORM) || defined(EXTRAFS) || defined(QSPIFLASH)
+  #define HAS_ATOMIC_WRITE_SUPPORT
+#endif
+
 DataStore::DataStore(FILESYSTEM& fs, mesh::RTCClock& clock) : _fs(&fs), _fsExtra(nullptr), _clock(&clock),
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
     identity_store(fs, "")
@@ -278,6 +284,7 @@ void DataStore::loadContacts(DataStoreHost* host) {
   FILESYSTEM* fs = _getContactsChannelsFS();
   File file = openRead(fs, "/contacts3");
 
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
   // If main file doesn't exist or is empty, try backup
   if (!file || file.size() == 0) {
     if (file) file.close();
@@ -286,6 +293,7 @@ void DataStore::loadContacts(DataStoreHost* host) {
       file = openRead(fs, "/contacts3.bak");
     }
   }
+#endif
 
   if (file) {
     bool full = false;
@@ -319,8 +327,12 @@ void DataStore::loadContacts(DataStoreHost* host) {
 void DataStore::saveContacts(DataStoreHost* host) {
   FILESYSTEM* fs = _getContactsChannelsFS();
 
-  // Write to temp file first (atomic write pattern)
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
   File file = openWrite(fs, "/contacts3.tmp");
+#else
+  File file = openWrite(fs, "/contacts3");
+#endif
+
   if (file) {
     uint32_t idx = 0;
     ContactInfo c;
@@ -351,16 +363,17 @@ void DataStore::saveContacts(DataStoreHost* host) {
     file.flush();
     file.close();
 
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
     if (write_success) {
-      // Atomic swap: remove old backup, rename current to backup, rename temp to current
       fs->remove("/contacts3.bak");
       fs->rename("/contacts3", "/contacts3.bak");
       fs->rename("/contacts3.tmp", "/contacts3");
+      fs->remove("/contacts3.bak");
     } else {
-      // Write failed, remove incomplete temp file
       fs->remove("/contacts3.tmp");
-      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed, temp file removed");
+      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed");
     }
+#endif
   }
 }
 

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -275,42 +275,57 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
 }
 
 void DataStore::loadContacts(DataStoreHost* host) {
-File file = openRead(_getContactsChannelsFS(), "/contacts3");
-    if (file) {
-      bool full = false;
-      while (!full) {
-        ContactInfo c;
-        uint8_t pub_key[32];
-        uint8_t unused;
+  FILESYSTEM* fs = _getContactsChannelsFS();
+  File file = openRead(fs, "/contacts3");
 
-        bool success = (file.read(pub_key, 32) == 32);
-        success = success && (file.read((uint8_t *)&c.name, 32) == 32);
-        success = success && (file.read(&c.type, 1) == 1);
-        success = success && (file.read(&c.flags, 1) == 1);
-        success = success && (file.read(&unused, 1) == 1);
-        success = success && (file.read((uint8_t *)&c.sync_since, 4) == 4); // was 'reserved'
-        success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
-        success = success && (file.read((uint8_t *)&c.last_advert_timestamp, 4) == 4);
-        success = success && (file.read(c.out_path, 64) == 64);
-        success = success && (file.read((uint8_t *)&c.lastmod, 4) == 4);
-        success = success && (file.read((uint8_t *)&c.gps_lat, 4) == 4);
-        success = success && (file.read((uint8_t *)&c.gps_lon, 4) == 4);
-
-        if (!success) break; // EOF
-
-        c.id = mesh::Identity(pub_key);
-        if (!host->onContactLoaded(c)) full = true;
-      }
-      file.close();
+  // If main file doesn't exist or is empty, try backup
+  if (!file || file.size() == 0) {
+    if (file) file.close();
+    if (fs->exists("/contacts3.bak")) {
+      MESH_DEBUG_PRINTLN("WARN: contacts3 missing/empty, loading from backup");
+      file = openRead(fs, "/contacts3.bak");
     }
+  }
+
+  if (file) {
+    bool full = false;
+    while (!full) {
+      ContactInfo c;
+      uint8_t pub_key[32];
+      uint8_t unused;
+
+      bool success = (file.read(pub_key, 32) == 32);
+      success = success && (file.read((uint8_t *)&c.name, 32) == 32);
+      success = success && (file.read(&c.type, 1) == 1);
+      success = success && (file.read(&c.flags, 1) == 1);
+      success = success && (file.read(&unused, 1) == 1);
+      success = success && (file.read((uint8_t *)&c.sync_since, 4) == 4); // was 'reserved'
+      success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
+      success = success && (file.read((uint8_t *)&c.last_advert_timestamp, 4) == 4);
+      success = success && (file.read(c.out_path, 64) == 64);
+      success = success && (file.read((uint8_t *)&c.lastmod, 4) == 4);
+      success = success && (file.read((uint8_t *)&c.gps_lat, 4) == 4);
+      success = success && (file.read((uint8_t *)&c.gps_lon, 4) == 4);
+
+      if (!success) break; // EOF
+
+      c.id = mesh::Identity(pub_key);
+      if (!host->onContactLoaded(c)) full = true;
+    }
+    file.close();
+  }
 }
 
 void DataStore::saveContacts(DataStoreHost* host) {
-  File file = openWrite(_getContactsChannelsFS(), "/contacts3");
+  FILESYSTEM* fs = _getContactsChannelsFS();
+
+  // Write to temp file first (atomic write pattern)
+  File file = openWrite(fs, "/contacts3.tmp");
   if (file) {
     uint32_t idx = 0;
     ContactInfo c;
     uint8_t unused = 0;
+    bool write_success = true;
 
     while (host->getContactForSave(idx, c)) {
       bool success = (file.write(c.id.pub_key, 32) == 32);
@@ -326,11 +341,26 @@ void DataStore::saveContacts(DataStoreHost* host) {
       success = success && (file.write((uint8_t *)&c.gps_lat, 4) == 4);
       success = success && (file.write((uint8_t *)&c.gps_lon, 4) == 4);
 
-      if (!success) break; // write failed
+      if (!success) {
+        write_success = false;
+        break; // write failed
+      }
 
       idx++;  // advance to next contact
     }
+    file.flush();
     file.close();
+
+    if (write_success) {
+      // Atomic swap: remove old backup, rename current to backup, rename temp to current
+      fs->remove("/contacts3.bak");
+      fs->rename("/contacts3", "/contacts3.bak");
+      fs->rename("/contacts3.tmp", "/contacts3");
+    } else {
+      // Write failed, remove incomplete temp file
+      fs->remove("/contacts3.tmp");
+      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed, temp file removed");
+    }
   }
 }
 

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -351,7 +351,6 @@ void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactIn
 
 #ifdef HAS_ATOMIC_WRITE_SUPPORT
     if (write_success) {
-      fs->remove("/contacts3.bak");
       fs->rename("/contacts3", "/contacts3.bak");
       fs->rename("/contacts3.tmp", "/contacts3");
       fs->remove("/contacts3.bak");

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -257,42 +257,57 @@ bool DataStore::savePrefs(NodePrefs& _prefs) {
 }
 
 void DataStore::loadContacts(DataStoreHost* host) {
-File file = openRead(_getContactsChannelsFS(), "/contacts3");
-    if (file) {
-      bool full = false;
-      while (!full) {
-        ContactInfo c;
-        uint8_t pub_key[32];
-        uint8_t unused;
+  FILESYSTEM* fs = _getContactsChannelsFS();
+  File file = openRead(fs, "/contacts3");
 
-        bool success = (file.read(pub_key, 32) == 32);
-        success = success && (file.read((uint8_t *)&c.name, 32) == 32);
-        success = success && (file.read(&c.type, 1) == 1);
-        success = success && (file.read(&c.flags, 1) == 1);
-        success = success && (file.read(&unused, 1) == 1);
-        success = success && (file.read((uint8_t *)&c.sync_since, 4) == 4); // was 'reserved'
-        success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
-        success = success && (file.read((uint8_t *)&c.last_advert_timestamp, 4) == 4);
-        success = success && (file.read(c.out_path, 64) == 64);
-        success = success && (file.read((uint8_t *)&c.lastmod, 4) == 4);
-        success = success && (file.read((uint8_t *)&c.gps_lat, 4) == 4);
-        success = success && (file.read((uint8_t *)&c.gps_lon, 4) == 4);
-
-        if (!success) break; // EOF
-
-        c.id = mesh::Identity(pub_key);
-        if (!host->onContactLoaded(c)) full = true;
-      }
-      file.close();
+  // If main file doesn't exist or is empty, try backup
+  if (!file || file.size() == 0) {
+    if (file) file.close();
+    if (fs->exists("/contacts3.bak")) {
+      MESH_DEBUG_PRINTLN("WARN: contacts3 missing/empty, loading from backup");
+      file = openRead(fs, "/contacts3.bak");
     }
+  }
+
+  if (file) {
+    bool full = false;
+    while (!full) {
+      ContactInfo c;
+      uint8_t pub_key[32];
+      uint8_t unused;
+
+      bool success = (file.read(pub_key, 32) == 32);
+      success = success && (file.read((uint8_t *)&c.name, 32) == 32);
+      success = success && (file.read(&c.type, 1) == 1);
+      success = success && (file.read(&c.flags, 1) == 1);
+      success = success && (file.read(&unused, 1) == 1);
+      success = success && (file.read((uint8_t *)&c.sync_since, 4) == 4); // was 'reserved'
+      success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
+      success = success && (file.read((uint8_t *)&c.last_advert_timestamp, 4) == 4);
+      success = success && (file.read(c.out_path, 64) == 64);
+      success = success && (file.read((uint8_t *)&c.lastmod, 4) == 4);
+      success = success && (file.read((uint8_t *)&c.gps_lat, 4) == 4);
+      success = success && (file.read((uint8_t *)&c.gps_lon, 4) == 4);
+
+      if (!success) break; // EOF
+
+      c.id = mesh::Identity(pub_key);
+      if (!host->onContactLoaded(c)) full = true;
+    }
+    file.close();
+  }
 }
 
 void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactInfo& c)) {
-  File file = openWrite(_getContactsChannelsFS(), "/contacts3");
+  FILESYSTEM* fs = _getContactsChannelsFS();
+
+  // Write to temp file first (atomic write pattern)
+  File file = openWrite(fs, "/contacts3.tmp");
   if (file) {
     uint32_t idx = 0;
     ContactInfo c;
     uint8_t unused = 0;
+    bool write_success = true;
 
     while (host->getContactForSave(idx, c)) {
       if (filter && !filter(c)) {
@@ -312,11 +327,26 @@ void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactIn
       success = success && (file.write((uint8_t *)&c.gps_lat, 4) == 4);
       success = success && (file.write((uint8_t *)&c.gps_lon, 4) == 4);
 
-      if (!success) break; // write failed
+      if (!success) {
+        write_success = false;
+        break; // write failed
+      }
 
       idx++;  // advance to next contact
     }
+    file.flush();
     file.close();
+
+    if (write_success) {
+      // Atomic swap: remove old backup, rename current to backup, rename temp to current
+      fs->remove("/contacts3.bak");
+      fs->rename("/contacts3", "/contacts3.bak");
+      fs->rename("/contacts3.tmp", "/contacts3");
+    } else {
+      // Write failed, remove incomplete temp file
+      fs->remove("/contacts3.tmp");
+      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed, temp file removed");
+    }
   }
 }
 

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -7,6 +7,12 @@
   #define MAX_BLOBRECS 20
 #endif
 
+// Atomic writes require ~2x storage for contacts file
+// Only enable on platforms with sufficient flash
+#if !defined(NRF52_PLATFORM) || defined(EXTRAFS) || defined(QSPIFLASH)
+  #define HAS_ATOMIC_WRITE_SUPPORT
+#endif
+
 DataStore::DataStore(FILESYSTEM& fs, mesh::RTCClock& clock) : _fs(&fs), _fsExtra(nullptr), _clock(&clock),
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
     identity_store(fs, "")
@@ -260,6 +266,7 @@ void DataStore::loadContacts(DataStoreHost* host) {
   FILESYSTEM* fs = _getContactsChannelsFS();
   File file = openRead(fs, "/contacts3");
 
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
   // If main file doesn't exist or is empty, try backup
   if (!file || file.size() == 0) {
     if (file) file.close();
@@ -268,6 +275,7 @@ void DataStore::loadContacts(DataStoreHost* host) {
       file = openRead(fs, "/contacts3.bak");
     }
   }
+#endif
 
   if (file) {
     bool full = false;
@@ -301,8 +309,12 @@ void DataStore::loadContacts(DataStoreHost* host) {
 void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactInfo& c)) {
   FILESYSTEM* fs = _getContactsChannelsFS();
 
-  // Write to temp file first (atomic write pattern)
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
   File file = openWrite(fs, "/contacts3.tmp");
+#else
+  File file = openWrite(fs, "/contacts3");
+#endif
+
   if (file) {
     uint32_t idx = 0;
     ContactInfo c;
@@ -337,16 +349,17 @@ void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactIn
     file.flush();
     file.close();
 
+#ifdef HAS_ATOMIC_WRITE_SUPPORT
     if (write_success) {
-      // Atomic swap: remove old backup, rename current to backup, rename temp to current
       fs->remove("/contacts3.bak");
       fs->rename("/contacts3", "/contacts3.bak");
       fs->rename("/contacts3.tmp", "/contacts3");
+      fs->remove("/contacts3.bak");
     } else {
-      // Write failed, remove incomplete temp file
       fs->remove("/contacts3.tmp");
-      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed, temp file removed");
+      MESH_DEBUG_PRINTLN("ERROR: saveContacts write failed");
     }
+#endif
   }
 }
 


### PR DESCRIPTION
**Problem:** Contacts sometimes partially disappear on Heltec v4 and Heltec Wireless Tracker v1.2. This is likely caused by power loss or reset during a direct overwrite of the contacts file.

**Solution:** Atomic-style write pattern for `saveContacts`:

1. Write contacts to a temporary file (`/contacts3.tmp`)
2. Flush to ensure data is on flash
3. Rename existing `/contacts3` → `/contacts3.bak`
4. Rename `/contacts3.tmp` → `/contacts3`
5. Remove `/contacts3.bak` (no longer needed until next save)

If the write fails mid-save, the `.tmp` file is removed and the original contacts file is left untouched.

On load, if `/contacts3` is missing or empty, `loadContacts` falls back to `/contacts3.bak` automatically. This covers the edge case where power is lost between steps 3 and 4.

**Platform guard:** Only enabled on devices with sufficient flash for the temporary file (~2x contacts storage during save). Disabled on NRF52 unless `EXTRAFS` or `QSPIFLASH` is defined.

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=robust-contacts)