### PR TITLE
Added Backlight toggle on new quad-click button event

### DIFF
--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -37,6 +37,7 @@ class UITask : public AbstractUITask {
   unsigned long _alert_expiry;
   int _msgcount;
   unsigned long ui_started_at, next_batt_chck;
+  bool _forceBacklight = false;
   int next_backlight_btn_check = 0;
 #ifdef PIN_STATUS_LED
   int led_state = 0;
@@ -60,6 +61,7 @@ class UITask : public AbstractUITask {
   char handleLongPress(char c);
   char handleDoubleClick(char c);
   char handleTripleClick(char c);
+  char handleQuadClick(char c);
 
   void setCurrScreen(UIScreen* c);
 
@@ -78,6 +80,7 @@ public:
   bool hasDisplay() const { return _display != NULL; }
   bool isButtonPressed() const;
 
+  void toggleBacklight();
   void toggleBuzzer();
   bool getGPSState();
   void toggleGPS();

--- a/src/helpers/ui/MomentaryButton.cpp
+++ b/src/helpers/ui/MomentaryButton.cpp
@@ -131,9 +131,12 @@ int MomentaryButton::check(bool repeat_click) {
       case 3:
         event = BUTTON_EVENT_TRIPLE_CLICK;
         break;
+      case 4:
+        event = BUTTON_EVENT_QUAD_CLICK;
+        break;
       default:
-        // For 4+ clicks, treat as triple click?
-        event = BUTTON_EVENT_TRIPLE_CLICK;
+        // For 4+ clicks, treat as quad click?
+        event = BUTTON_EVENT_QUAD_CLICK;
         break;
     }
     _click_count = 0;

--- a/src/helpers/ui/MomentaryButton.h
+++ b/src/helpers/ui/MomentaryButton.h
@@ -7,6 +7,7 @@
 #define BUTTON_EVENT_LONG_PRESS  2
 #define BUTTON_EVENT_DOUBLE_CLICK 3
 #define BUTTON_EVENT_TRIPLE_CLICK 4
+#define BUTTON_EVENT_QUAD_CLICK 5
 
 class MomentaryButton {
   int8_t _pin;


### PR DESCRIPTION
This aligns companion radio firmware with the stock LilyGo T-Echo behavior, which also uses quad-click to toggle the backlight.

**Highlights**
- Added BUTTON_EVENT_QUAD_CLICK to MomentaryButton for detecting 4 consecutive clicks
- Quad-clicking the user button toggles a "forced backlight" mode, keeping the backlight always on
- Added showAlert() feedback to both toggleBuzzer() and toggleBacklight() to notify the user when the requested hardware is not available. This reduces confusion when triple/quad clicks appear to do nothing.