### PR TITLE
Fix Room Server message delivery failure when companion RTC differs from app clock

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -950,9 +950,8 @@ void MyMesh::handleCmdFrame(size_t len) {
     int i = 1;
     uint8_t txt_type = cmd_frame[i++];
     uint8_t attempt = cmd_frame[i++];
-    uint32_t msg_timestamp;
-    memcpy(&msg_timestamp, &cmd_frame[i], 4);
-    i += 4;
+    uint32_t msg_timestamp = getRTCClock()->getCurrentTimeUnique(); // Use node's RTC for consistency
+    i += 4; // skip timestamp in cmd_frame (not used)
     uint8_t *pub_key_prefix = &cmd_frame[i];
     i += 6;
     ContactInfo *recipient = lookupContactByPubKey(pub_key_prefix, 6);
@@ -964,7 +963,6 @@ void MyMesh::handleCmdFrame(size_t len) {
       int result;
       uint32_t expected_ack;
       if (txt_type == TXT_TYPE_CLI_DATA) {
-        msg_timestamp = getRTCClock()->getCurrentTimeUnique(); // Use node's RTC instead of app timestamp to avoid tripping replay protection
         result = sendCommandData(*recipient, msg_timestamp, attempt, text, est_timeout);
         expected_ack = 0; // no Ack expected
       } else {
@@ -996,9 +994,8 @@ void MyMesh::handleCmdFrame(size_t len) {
     int i = 1;
     uint8_t txt_type = cmd_frame[i++]; // should be TXT_TYPE_PLAIN
     uint8_t channel_idx = cmd_frame[i++];
-    uint32_t msg_timestamp;
-    memcpy(&msg_timestamp, &cmd_frame[i], 4);
-    i += 4;
+    uint32_t msg_timestamp = getRTCClock()->getCurrentTimeUnique(); // Use node's RTC for consistency
+    i += 4; // skip timestamp in cmd_frame (not used)
     const char *text = (char *)&cmd_frame[i];
 
     if (txt_type != TXT_TYPE_PLAIN) {
@@ -1064,13 +1061,9 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_SET_DEVICE_TIME && len >= 5) {
     uint32_t secs;
     memcpy(&secs, &cmd_frame[1], 4);
-    uint32_t curr = getRTCClock()->getCurrentTime();
-    if (secs >= curr) {
-      getRTCClock()->setCurrentTime(secs);
-      writeOKFrame();
-    } else {
-      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
-    }
+    // Allow setting time to any value (removed >= check to allow correcting a clock stuck in the future)
+    getRTCClock()->setCurrentTime(secs);
+    writeOKFrame();
   } else if (cmd_frame[0] == CMD_SEND_SELF_ADVERT) {
     mesh::Packet* pkt;
     if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {


### PR DESCRIPTION
## Problem
Companions cannot send messages to Room Servers when the companion's RTC clock is ahead of the app's clock. Messages silently fail with retries until "Failed" status, while login and sync operations work normally. On top of that, users could not fix this themselves because the firmware prevented setting the RTC to an earlier time.

## Root Cause
There was an inconsistency in timestamp sources:

| Operation | Timestamp Source (Before) |
|-----------|---------------------------|
| Login (`sendLogin`) | Companion's RTC (`BaseChatMesh.cpp:486`) |
| Sync/Request (`sendRequest`) | Companion's RTC (`BaseChatMesh.cpp:547`) |
| **Send Message** | **App's timestamp** (via `cmd_frame`) |
| **Group Channel Message** | **App's timestamp** (via `cmd_frame`) |

Room Servers track `last_timestamp` per client to prevent replay attacks (`simple_room_server/MyMesh.cpp:405`). Messages with timestamps older than `last_timestamp` are silently discarded.

**Failure scenario:**
1. User logs in → Room Server stores `last_timestamp` = companion's RTC (e.g., `1500`)
2. User sends message → App provides timestamp (e.g., `1001`)
3. Room Server checks: `1001 >= 1500`? **NO** → message discarded, no ACK sent
4. Companion retries until timeout → "Failed"

## Additional Issue

Users could not fix a future-stuck RTC because `CMD_SET_DEVICE_TIME` rejected any time earlier than the current RTC (`companion_radio/MyMesh.cpp:1068`).

## Solutions

**Fix 1:** Use companion's RTC for all message timestamps (consistency)
```cpp
  // CMD_SEND_TXT_MSG (line 953)
  uint32_t msg_timestamp = getRTCClock()->getCurrentTimeUnique();
  i += 4; // skip timestamp in cmd_frame (not used)

  // CMD_SEND_CHANNEL_TXT_MSG (line 997)
  uint32_t msg_timestamp = getRTCClock()->getCurrentTimeUnique();
  i += 4; // skip timestamp in cmd_frame (not used)
```

**Fix 2:** Allow RTC to be corrected even when current RTC is in the future
```cpp
  // CMD_SET_DEVICE_TIME handler - removed (secs >= curr) check
  getRTCClock()->setCurrentTime(secs);
  writeOKFrame();
```

## Testing
- Verified on LilyGo T-Echo Companion, with Heltec V4 Room Server
- Login, sync, and message sending all work correctly after fix
- RTC can now be corrected when stuck in the future