### PR TITLE
Update to support battery voltage on D3 pin for Xiao ESP32S3 repeater

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -8,6 +8,7 @@ build_flags = ${esp32_base.build_flags}
   -I variants/xiao_s3_wio
   -UENV_INCLUDE_GPS
   -D SEEED_XIAO_S3
+  -D PIN_VBAT_READ=D3 ; user added voltage divider
   -D P_LORA_DIO_1=39
   -D P_LORA_NSS=41
   -D P_LORA_RESET=42   ; RADIOLIB_NC


### PR DESCRIPTION
Added D3 pin as battery voltage input. This voltage divider is not present on a stock Xiao ESP32S3 board, but can be easy added, the D3 pin is not used and is near the battery pads.