### PR TITLE
Fix orphan blob accumulation on firmware upgrade

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -555,6 +555,7 @@ bool DataStore::putBlobByKey(const uint8_t key[], int key_len, const uint8_t src
 bool DataStore::deleteBlobByKey(const uint8_t key[], int key_len) {
   return true; // this is just a stub on NRF52/STM32 platforms
 }
+void DataStore::cleanOrphanBlobs(DataStoreHost* host) {}
 #else
 inline void makeBlobPath(const uint8_t key[], int key_len, char* path, size_t path_size) {
   char fname[18];
@@ -598,7 +599,39 @@ bool DataStore::deleteBlobByKey(const uint8_t key[], int key_len) {
   makeBlobPath(key, key_len, path, sizeof(path));
 
   _fs->remove(path);
-  
+
   return true; // return true even if file did not exist
+}
+
+void DataStore::cleanOrphanBlobs(DataStoreHost* host) {
+  if (_fs->exists("/bl/.cleaned")) return;
+  MESH_DEBUG_PRINTLN("Cleaning orphan blobs...");
+  File root = openRead("/bl");
+  if (root) {
+    for (File f = root.openNextFile(); f; f = root.openNextFile()) {
+      const char* name = f.name();
+      f.close();
+      if (name[0] == '.' || strlen(name) != 16) continue;
+      uint8_t file_key[8];
+      if (!mesh::Utils::fromHex(file_key, 8, name)) continue;
+      bool found = false;
+      ContactInfo c;
+      for (uint32_t i = 0; host->getContactForSave(i, c) && !found; i++) {
+        found = (memcmp(file_key, c.id.pub_key, 8) == 0);
+      }
+      if (!found) {
+        char path[24];
+        sprintf(path, "/bl/%s", name);
+        _fs->remove(path);
+      }
+    }
+    root.close();
+  }
+#if defined(ESP32)
+  File m = _fs->open("/bl/.cleaned", "w", true);
+#else
+  File m = _fs->open("/bl/.cleaned", "w");
+#endif
+  if (m) m.close();
 }
 #endif

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -43,6 +43,7 @@ public:
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);
   bool deleteBlobByKey(const uint8_t key[], int key_len);
+  void cleanOrphanBlobs(DataStoreHost* host);
   File openRead(const char* filename);
   File openRead(FILESYSTEM* fs, const char* filename);
   bool removeFile(const char* filename);

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -969,34 +969,8 @@ void MyMesh::begin(bool has_display) {
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
 
-#if defined(ESP32) || defined(RP2040_PLATFORM)
-  // One-time cleanup of orphan blobs from pre-v1.13 firmware
-  FILESYSTEM* fs = _store->getPrimaryFS();
-  if (!fs->exists("/bl/.cleaned")) {
-    MESH_DEBUG_PRINTLN("Cleaning orphan blobs...");
-    File root = _store->openRead("/bl");
-    if (root) {
-      for (File f = root.openNextFile(); f; f = root.openNextFile()) {
-        const char* name = f.name();
-        f.close();
-        uint8_t key[8];
-        if (name[0] != '.' && strlen(name) == 16 && mesh::Utils::fromHex(key, 8, name)) {
-          bool found = false;
-          for (int i = 0; i < num_contacts && !found; i++)
-            found = (memcmp(contacts[i].id.pub_key, key, 8) == 0);
-          if (!found) _store->deleteBlobByKey(key, 8);
-        }
-      }
-      root.close();
-    }
-#if defined(ESP32)
-    File m = fs->open("/bl/.cleaned", "w", true);
-#else
-    File m = fs->open("/bl/.cleaned", "w");
-#endif
-    if (m) m.close();
-  }
-#endif
+  _store->cleanOrphanBlobs(this);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -968,6 +968,35 @@ void MyMesh::begin(bool has_display) {
   resetContacts();
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
+
+#if defined(ESP32) || defined(RP2040_PLATFORM)
+  // One-time cleanup of orphan blobs from pre-v1.13 firmware
+  FILESYSTEM* fs = _store->getPrimaryFS();
+  if (!fs->exists("/bl/.cleaned")) {
+    MESH_DEBUG_PRINTLN("Cleaning orphan blobs...");
+    File root = _store->openRead("/bl");
+    if (root) {
+      for (File f = root.openNextFile(); f; f = root.openNextFile()) {
+        const char* name = f.name();
+        f.close();
+        uint8_t key[8];
+        if (name[0] != '.' && strlen(name) == 16 && mesh::Utils::fromHex(key, 8, name)) {
+          bool found = false;
+          for (int i = 0; i < num_contacts && !found; i++)
+            found = (memcmp(contacts[i].id.pub_key, key, 8) == 0);
+          if (!found) _store->deleteBlobByKey(key, 8);
+        }
+      }
+      root.close();
+    }
+#if defined(ESP32)
+    File m = fs->open("/bl/.cleaned", "w", true);
+#else
+    File m = fs->open("/bl/.cleaned", "w");
+#endif
+    if (m) m.close();
+  }
+#endif
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1042,34 +1042,8 @@ void MyMesh::begin(bool has_display) {
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
 
-#if defined(ESP32) || defined(RP2040_PLATFORM)
-  // One-time cleanup of orphan blobs from pre-v1.13 firmware
-  FILESYSTEM* fs = _store->getPrimaryFS();
-  if (!fs->exists("/bl/.cleaned")) {
-    MESH_DEBUG_PRINTLN("Cleaning orphan blobs...");
-    File root = _store->openRead("/bl");
-    if (root) {
-      for (File f = root.openNextFile(); f; f = root.openNextFile()) {
-        const char* name = f.name();
-        f.close();
-        uint8_t key[8];
-        if (name[0] != '.' && strlen(name) == 16 && mesh::Utils::fromHex(key, 8, name)) {
-          bool found = false;
-          for (int i = 0; i < num_contacts && !found; i++)
-            found = (memcmp(contacts[i].id.pub_key, key, 8) == 0);
-          if (!found) _store->deleteBlobByKey(key, 8);
-        }
-      }
-      root.close();
-    }
-#if defined(ESP32)
-    File m = fs->open("/bl/.cleaned", "w", true);
-#else
-    File m = fs->open("/bl/.cleaned", "w");
-#endif
-    if (m) m.close();
-  }
-#endif
+  _store->cleanOrphanBlobs(this);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1041,6 +1041,35 @@ void MyMesh::begin(bool has_display) {
   resetContacts();
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
+
+#if defined(ESP32) || defined(RP2040_PLATFORM)
+  // One-time cleanup of orphan blobs from pre-v1.13 firmware
+  FILESYSTEM* fs = _store->getPrimaryFS();
+  if (!fs->exists("/bl/.cleaned")) {
+    MESH_DEBUG_PRINTLN("Cleaning orphan blobs...");
+    File root = _store->openRead("/bl");
+    if (root) {
+      for (File f = root.openNextFile(); f; f = root.openNextFile()) {
+        const char* name = f.name();
+        f.close();
+        uint8_t key[8];
+        if (name[0] != '.' && strlen(name) == 16 && mesh::Utils::fromHex(key, 8, name)) {
+          bool found = false;
+          for (int i = 0; i < num_contacts && !found; i++)
+            found = (memcmp(contacts[i].id.pub_key, key, 8) == 0);
+          if (!found) _store->deleteBlobByKey(key, 8);
+        }
+      }
+      root.close();
+    }
+#if defined(ESP32)
+    File m = fs->open("/bl/.cleaned", "w", true);
+#else
+    File m = fs->open("/bl/.cleaned", "w");
+#endif
+    if (m) m.close();
+  }
+#endif
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 


### PR DESCRIPTION
Fixes #1519

Related: #1495

## What's this about?

PR #1495 fixed the blob leak going forward, but devices upgrading from older firmware (like v1.11.0) still have thousands of orphan blobs sitting in `/bl/` eating up storage space.

This adds a one-time cleanup that runs on first boot after upgrade - it just walks through `/bl/`, checks each blob against the contacts list, and deletes any that don't belong to an actual contact. A marker file prevents it from running again.

Only affects ESP32 and RP2040 (the platforms that use the `/bl/` directory).

This code can probably be removed after a few releases once most users have upgraded past this version.

## Note

I also experimented with an LRU approach that caps blob count and evicts oldest files periodically - works well as an ongoing safety net, but this simpler approach should be enough for the upgrade cleanup.

## Testing
- Flash on a device with existing orphan blobs
- Check cleanup runs once and cleans up the orphans
- Reboot and verify it doesn't run again
- Make sure legit contact blobs are still there

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/onetime-blob-cleanup)