### PR TITLE
Proposal for refactoring variant definition architecture

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -87,9 +87,12 @@ build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM
   -D LFS_NO_ASSERT=1
   -D EXTRAFS=1
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
 lib_deps =
   ${arduino_base.lib_deps}
   https://github.com/oltaco/CustomLFS @ 0.2.1
+
 ; ----------------- RP2040 ---------------------
 
 [rp2040_base]
@@ -118,34 +121,134 @@ lib_deps = ${arduino_base.lib_deps}
 
 [sensor_base]
 build_flags =
-  -D ENV_INCLUDE_GPS=1
   -D ENV_INCLUDE_AHTX0=1
   -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_BME680=1
+  -D ENV_INCLUDE_BMP085=1
   -D ENV_INCLUDE_BMP280=1
-  -D ENV_INCLUDE_SHTC3=1
-  -D ENV_INCLUDE_SHT4X=1
-  -D ENV_INCLUDE_LPS22HB=1
-  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_GPS=1
   -D ENV_INCLUDE_INA219=1
   -D ENV_INCLUDE_INA226=1
   -D ENV_INCLUDE_INA260=1
+  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_LPS22HB=1
   -D ENV_INCLUDE_MLX90614=1
+  -D ENV_INCLUDE_SHT4X=1
+  -D ENV_INCLUDE_SHTC3=1
   -D ENV_INCLUDE_VL53L0X=1
-  -D ENV_INCLUDE_BME680=1
-  -D ENV_INCLUDE_BMP085=1
 lib_deps =
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  robtillaart/INA226 @ ^0.6.4
-  adafruit/Adafruit INA260 Library @ ^1.5.3
   adafruit/Adafruit AHTX0 @ ^2.0.5
   adafruit/Adafruit BME280 Library @ ^2.3.0
-  adafruit/Adafruit BMP280 Library @ ^2.6.8
-  adafruit/Adafruit SHTC3 Library @ ^1.0.1
-  sensirion/Sensirion I2C SHT4x @ ^1.1.2
-  arduino-libraries/Arduino_LPS22HB @ ^1.0.2
-  adafruit/Adafruit MLX90614 Library @ ^2.1.5
-  adafruit/Adafruit_VL53L0X @ ^1.2.4
-  stevemarple/MicroNMEA @ ^2.0.6
   adafruit/Adafruit BME680 Library @ ^2.0.4
   adafruit/Adafruit BMP085 Library @ ^1.2.4
+  adafruit/Adafruit BMP280 Library @ ^2.6.8
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit INA260 Library @ ^1.5.3
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit MLX90614 Library @ ^2.1.5
+  adafruit/Adafruit SHTC3 Library @ ^1.0.1
+  adafruit/Adafruit_VL53L0X @ ^1.2.4
+  arduino-libraries/Arduino_LPS22HB @ ^1.0.2
+  robtillaart/INA226 @ ^0.6.4
+  sensirion/Sensirion I2C SHT4x @ ^1.1.2
+  stevemarple/MicroNMEA @ ^2.0.6
+build_src_filter =
+  +<helpers/sensors>
+
+[radio_sx1262]
+build_flags =
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+build_src_filter =
+  ; placeholder
+lib_deps =
+  ; placeholder 
+
+[repeater_base]
+build_flags =
+  -D ADVERT_NAME='"MeshCore Repeater"'
+  -D ADMIN_PASSWORD='"password"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter =
+  +<../examples/simple_repeater>
+lib_deps =
+  ; placeholder 
+
+[bridge_rs232]
+build_flags =
+  ${repeater_base.build_flags}
+  -D ADVERT_NAME='"MeshCore RS232 Bridge"'
+;  -D BRIDGE_DEBUG=1
+build_src_filter =
+  ${repeater_base.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+lib_deps =
+  ; placeholder 
+
+[room_server_base]
+build_flags =
+  ${repeater_base.build_flags}
+  -D ADVERT_NAME='"MeshCore Room Server"'
+  -D ROOM_PASSWORD='"hello"'
+build_src_filter =
+  +<../examples/simple_room_server>
+lib_deps =
+  ; placeholder 
+
+[companion_base]
+build_flags =
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter =
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  densaugeo/base64 @ ~1.4.0
+
+[companion_ble]
+extends =
+  companion_base
+build_flags =
+  ${companion_base.build_flags}
+  -D BLE_PIN_CODE=123456
+;  -D BLE_DEBUG_LOGGING=1
+build_src_filter =
+  ${companion_base.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+lib_deps =
+  ${companion_base.lib_deps}
+
+[ui_base]
+build_flags =
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=NullDisplayDriver
+build_src_filter =
+  +<../examples/companion_radio/ui-new/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+lib_deps =
+  ; placeholder 
+  
+[display_st7789]
+extends =
+  ui_base
+build_flags =
+  ${ui_base.build_flags}
+  -D ST7789
+  -D DISPLAY_CLASS=ST7789Display
+build_src_filter =
+  ${ui_base.build_src_filter}
+  +<helpers/ui/ST7789Display.cpp>
+  +<helpers/ui/OLEDDisplay.cpp>
+  +<helpers/ui/OLEDDisplayFonts.cpp>
+lib_deps =
+  adafruit/Adafruit GFX Library @ ^1.11.7
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
+
+; epaper
+;adafruit/Adafruit EPD @ 4.6.1
+;zinggjm/GxEPD2

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -1,5 +1,7 @@
 #include "EnvironmentSensorManager.h"
 
+#include <Wire.h>
+
 #if ENV_PIN_SDA && ENV_PIN_SCL
 #define TELEM_WIRE &Wire1  // Use Wire1 as the I2C bus for Environment Sensors
 #else

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -5,12 +5,13 @@
 extends = nrf52_base
 board = heltec_t114
 board_build.ldscript = boards/nrf52840_s140_v6.ld
-build_flags = ${nrf52_base.build_flags}
+debug_tool = jlink                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
+upload_protocol = nrfutil
+build_flags =
+  ${nrf52_base.build_flags}
+  ${radio_sx1262.build_flags}
   ${sensor_base.build_flags}
-  -I lib/nrf52/s140_nrf52_6.1.1_API/include
-  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
   -I variants/heltec_t114
-  -I src/helpers/ui
   -D HELTEC_T114
   -D NRF52_POWER_MANAGEMENT
   -D P_LORA_DIO_1=20
@@ -21,12 +22,10 @@ build_flags = ${nrf52_base.build_flags}
   -D P_LORA_MISO=23
   -D P_LORA_MOSI=22
   -D P_LORA_TX_LED=35
-  -D RADIO_CLASS=CustomSX1262
-  -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
   -D SX126X_POWER_EN=37
   -D SX126X_DIO2_AS_RF_SWITCH=true
-  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8                                                                                                                                                                                                                                                                                                                                                                                    
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D PIN_GPS_RX=39
@@ -36,108 +35,89 @@ build_flags = ${nrf52_base.build_flags}
   -D PIN_GPS_RESET_ACTIVE=LOW
   -D ENV_PIN_SDA=PIN_WIRE1_SDA
   -D ENV_PIN_SCL=PIN_WIRE1_SCL
-build_src_filter = ${nrf52_base.build_src_filter}
-  +<helpers/*.cpp>
-  +<helpers/sensors>
+build_src_filter =
+  ${nrf52_base.build_src_filter}
+  ${radio_sx1262.build_src_filter}
+  ${sensor_base.build_src_filter}
   +<../variants/heltec_t114>
 lib_deps =
   ${nrf52_base.lib_deps}
+  ${radio_sx1262.lib_deps}
   ${sensor_base.lib_deps}
-debug_tool = jlink
-upload_protocol = nrfutil
 
 [env:Heltec_t114_without_display_repeater]
-extends = Heltec_t114
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<../examples/simple_repeater>
-
+extends =
+  Heltec_t114
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${repeater_base.build_src_filter}
 build_flags =
   ${Heltec_t114.build_flags}
-  -D ADVERT_NAME='"Heltec_T114 Repeater"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D MAX_NEIGHBOURS=50
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  ${repeater_base.build_flags}
+lib_deps =
+  ${Heltec_t114.lib_deps}
+  ${repeater_base.lib_deps}
 
 [env:Heltec_t114_without_display_repeater_bridge_rs232]
-extends = Heltec_t114
+extends =
+  Heltec_t114
 build_flags =
   ${Heltec_t114.build_flags}
-  -D ADVERT_NAME='"RS232 Bridge"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D MAX_NEIGHBOURS=50
+  ${bridge_rs232.build_flags}
   -D WITH_RS232_BRIDGE=Serial2
   -D WITH_RS232_BRIDGE_RX=9
   -D WITH_RS232_BRIDGE_TX=10
-;  -D BRIDGE_DEBUG=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<helpers/bridges/RS232Bridge.cpp>
-  +<../examples/simple_repeater>
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${bridge_rs232.build_src_filter}
+lib_deps =
+  ${Heltec_t114.lib_deps}
+  ${bridge_rs232.lib_deps}
 
 [env:Heltec_t114_without_display_room_server]
-extends = Heltec_t114
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<../examples/simple_room_server>
+extends =
+  Heltec_t114
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${room_server_base.build_src_filter}
 build_flags =
   ${Heltec_t114.build_flags}
-  -D ADVERT_NAME='"Heltec_T114 Room"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D ROOM_PASSWORD='"hello"'
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  ${room_server_base.build_flags}
+lib_deps =
+  ${Heltec_t114.lib_deps}
+  ${room_server_base.lib_deps}
 
 [env:Heltec_t114_without_display_companion_radio_ble]
-extends = Heltec_t114
-board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+extends =
+  Heltec_t114
+board_build.ldscript =
+  boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
-  -I examples/companion_radio/ui-new
-  -D DISPLAY_CLASS=NullDisplayDriver
-  -D MAX_CONTACTS=350
-  -D MAX_GROUP_CHANNELS=40
-  -D BLE_PIN_CODE=123456
-;  -D BLE_DEBUG_LOGGING=1
-  -D OFFLINE_QUEUE_SIZE=256
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<helpers/nrf52/SerialBLEInterface.cpp>
-  +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  ${companion_ble.build_flags}
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${companion_ble.build_src_filter}
 lib_deps =
   ${Heltec_t114.lib_deps}
-  densaugeo/base64 @ ~1.4.0
+  ${companion_ble.lib_deps}
 
 [env:Heltec_t114_without_display_companion_radio_usb]
-extends = Heltec_t114
-board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+extends =
+  Heltec_t114
+board_build.ldscript =
+  boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114.build_flags}
-  -I examples/companion_radio/ui-new
-  -D DISPLAY_CLASS=NullDisplayDriver
-  -D MAX_CONTACTS=350
-  -D MAX_GROUP_CHANNELS=40
-;  -D BLE_PIN_CODE=123456
-;  -D BLE_DEBUG_LOGGING=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<helpers/nrf52/*.cpp>
-  +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  ${companion_base.build_flags}
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${companion_base.build_src_filter}
 lib_deps =
   ${Heltec_t114.lib_deps}
-  densaugeo/base64 @ ~1.4.0
+  ${companion_base.lib_deps}
 
 ;
 ; Heltec T114 with ST7789 display
@@ -146,109 +126,87 @@ lib_deps =
 extends = Heltec_t114
 board = heltec_t114
 board_build.ldscript = boards/nrf52840_s140_v6.ld
-build_flags = ${Heltec_t114.build_flags}
-  -D ST7789
-  -D HELTEC_T114_WITH_DISPLAY
-  -D DISPLAY_CLASS=ST7789Display
-build_src_filter = ${Heltec_t114.build_src_filter}
-  +<helpers/ui/ST7789Display.cpp>
-  +<helpers/ui/MomentaryButton.cpp>
-  +<helpers/ui/OLEDDisplay.cpp>
-  +<helpers/ui/OLEDDisplayFonts.cpp>
-lib_deps =
-  ${Heltec_t114.lib_deps}
-  adafruit/Adafruit SSD1306 @ ^2.5.13
-debug_tool = jlink
-upload_protocol = nrfutil
-
-[env:Heltec_t114_repeater]
-extends = Heltec_t114_with_display
-build_src_filter = ${Heltec_t114_with_display.build_src_filter}
-  +<../examples/simple_repeater>
-
-build_flags =
-  ${Heltec_t114_with_display.build_flags}
-  -D ADVERT_NAME='"Heltec_T114 Repeater"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D MAX_NEIGHBOURS=50
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-
-[env:Heltec_t114_repeater_bridge_rs232]
-extends = Heltec_t114
 build_flags =
   ${Heltec_t114.build_flags}
-  -D ADVERT_NAME='"RS232 Bridge"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D MAX_NEIGHBOURS=50
+  ${display_st7789.build_flags}
+  -D HELTEC_T114_WITH_DISPLAY
+build_src_filter =
+  ${Heltec_t114.build_src_filter}
+  ${display_st7789.build_src_filter}
+lib_deps =
+  ${Heltec_t114.lib_deps}
+  ${display_st7789.lib_deps}
+
+[env:Heltec_t114_repeater]
+extends =
+  Heltec_t114_with_display
+build_flags =
+  ${Heltec_t114_with_display.build_flags}
+  ${repeater_base.build_flags}
+build_src_filter =
+  ${Heltec_t114_with_display.build_src_filter}
+  ${repeater_base.build_src_filter}
+lib_deps =
+  ${Heltec_t114_with_display.lib_deps}
+  ${repeater_base.lib_deps}
+
+[env:Heltec_t114_repeater_bridge_rs232]
+extends =
+  Heltec_t114_with_display
+build_flags =
+  ${Heltec_t114_with_display.build_flags}
+  ${bridge_rs232.build_flags}
   -D WITH_RS232_BRIDGE=Serial2
   -D WITH_RS232_BRIDGE_RX=9
   -D WITH_RS232_BRIDGE_TX=10
-;  -D BRIDGE_DEBUG=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114_with_display.build_src_filter}
-  +<helpers/bridges/RS232Bridge.cpp>
-  +<../examples/simple_repeater>
+build_src_filter =
+  ${Heltec_t114_with_display.build_src_filter}
+  ${bridge_rs232.build_src_filter}
+lib_deps =
+  ${Heltec_t114_with_display.lib_deps}
+  ${bridge_rs232.lib_deps}
 
 [env:Heltec_t114_room_server]
-extends = Heltec_t114_with_display
-build_src_filter = ${Heltec_t114_with_display.build_src_filter}
-  +<../examples/simple_room_server>
+extends =
+  Heltec_t114_with_display
+build_src_filter =
+  ${Heltec_t114_with_display.build_src_filter}
+  ${room_server_base.build_src_filter}
 build_flags =
   ${Heltec_t114_with_display.build_flags}
-  -D ADVERT_NAME='"Heltec_T114 Room"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D ROOM_PASSWORD='"hello"'
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  ${room_server_base.build_flags}
+lib_deps =
+  ${Heltec_t114_with_display.lib_deps}
+  ${room_server_base.lib_deps}
 
 [env:Heltec_t114_companion_radio_ble]
-extends = Heltec_t114_with_display
-board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+extends =
+  Heltec_t114_with_display
+board_build.ldscript =
+  boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
-  -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=350
-  -D MAX_GROUP_CHANNELS=40
-  -D BLE_PIN_CODE=123456
-  -D ENV_INCLUDE_GPS=1   ; enable the GPS page in UI
-;  -D BLE_DEBUG_LOGGING=1
-  -D OFFLINE_QUEUE_SIZE=256
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114_with_display.build_src_filter}
-  +<helpers/nrf52/SerialBLEInterface.cpp>
-  +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  ${companion_ble.build_flags}
+build_src_filter =
+  ${Heltec_t114_with_display.build_src_filter}
+  ${companion_ble.build_src_filter}
 lib_deps =
   ${Heltec_t114_with_display.lib_deps}
-  densaugeo/base64 @ ~1.4.0
-
+  ${companion_ble.lib_deps}
+                         
 [env:Heltec_t114_companion_radio_usb]
-extends = Heltec_t114_with_display
-board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+extends =
+  Heltec_t114
+board_build.ldscript =
+  boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
 build_flags =
   ${Heltec_t114_with_display.build_flags}
-  -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=350
-  -D MAX_GROUP_CHANNELS=40
-;  -D BLE_PIN_CODE=123456
-;  -D BLE_DEBUG_LOGGING=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_t114_with_display.build_src_filter}
-  +<helpers/nrf52/*.cpp>
-  +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  ${companion_base.build_flags}
+build_src_filter =
+  ${Heltec_t114_with_display.build_src_filter}
+  ${companion_base.build_src_filter}
 lib_deps =
   ${Heltec_t114_with_display.lib_deps}
-  densaugeo/base64 @ ~1.4.0
+  ${companion_base.lib_deps}


### PR DESCRIPTION
This PR outlines a proposed architectural refactoring of variant definitions within the MeshCore ecosystem. The t114 variant has been refactored as a proof-of-concept implementation. This proposal seeks to determine whether this architectural pattern should be adopted for all variant definitions. before investing more effort into it.

Current variant definitions suffer from significant maintainability challenges. The prevalent practice of copying and pasting configuration sections between variants has resulted in fragmented, inconsistent definitions.

This implementation introduces a modular environment composition system designed to maximize reusability and simplify the creation of new board targets. The refactored t114 variant demonstrates how board targets can be assembled from pre-built, reusable components rather than defined as monolithic configurations.

The core innovation is a library of standardized environment modules that can be mixed and matched to build new targets. Instead of starting from scratch or copying entire configurations, developers can now select base components, combine functionality and customize only what's necessary . This approach makes building new targets significantly easier and faster as common functionality is packaged into reusable modules that can be included with a single reference.

The modular architecture also improves consistency across targets. When a module is updated or improved, all targets using that module benefit automatically. This eliminates the need to manually propagate version upgrades or enhancements across dozens of individual variant files.

@ripplebiz @liamcottle @recrof @fdlamotte 