### PR TITLE
Use constant-time comparison for MAC verification

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,5 +1,6 @@
 #include "Utils.h"
 #include <AES.h>
+#include <Crypto.h>
 #include <SHA256.h>
 
 #ifdef USE_CC310_HW_CRYPTO
@@ -177,10 +178,7 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
 #endif
-  // constant-time comparison to prevent timing side-channel attacks
-  uint8_t diff = 0;
-  for (int i = 0; i < CIPHER_MAC_SIZE; i++) diff |= hmac[i] ^ src[i];
-  if (diff == 0) {
+  if (secure_compare(hmac, src, CIPHER_MAC_SIZE)) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -177,7 +177,10 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
 #endif
-  if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
+  // constant-time comparison to prevent timing side-channel attacks
+  uint8_t diff = 0;
+  for (int i = 0; i < CIPHER_MAC_SIZE; i++) diff |= hmac[i] ^ src[i];
+  if (diff == 0) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -165,7 +165,10 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
 #endif
-  if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
+  // constant-time comparison to prevent timing side-channel attacks
+  uint8_t diff = 0;
+  for (int i = 0; i < CIPHER_MAC_SIZE; i++) diff |= hmac[i] ^ src[i];
+  if (diff == 0) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,5 +1,6 @@
 #include "Utils.h"
 #include <AES.h>
+#include <Crypto.h>
 #include <SHA256.h>
 
 #ifdef USE_CC310_HW_CRYPTO
@@ -165,10 +166,7 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
 #endif
-  // constant-time comparison to prevent timing side-channel attacks
-  uint8_t diff = 0;
-  for (int i = 0; i < CIPHER_MAC_SIZE; i++) diff |= hmac[i] ^ src[i];
-  if (diff == 0) {
+  if (secure_compare(hmac, src, CIPHER_MAC_SIZE)) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC


### PR DESCRIPTION
## Severity: low

## Summary

The HMAC verification in `MACThenDecrypt` uses standard `memcmp()`, which short-circuits on the first mismatched byte. The time taken to return reveals how many leading bytes of the MAC were correct, leaking information through a timing side-channel.

## How this can be exploited

MeshCore uses a 2-byte MAC (65,536 possible values). With a timing-variable comparison, an attacker can break the MAC verification into two sequential brute-forces:

1. **First byte** — send 256 packets, each with a different first MAC byte and an arbitrary second byte. The packet where `memcmp` takes slightly longer to reject reveals the correct first byte (because it proceeded to compare the second byte before failing).
2. **Second byte** — with the first byte known, send up to 256 more packets varying the second byte. The one that triggers decryption (noticeably slower due to AES work) reveals the correct second byte.

Total: ~384 attempts on average instead of ~32,768 for blind brute-force.

**On local interfaces (BLE, WiFi, serial)** the timing difference between a 1-byte and 2-byte comparison is measurable with sub-millisecond precision. Over RF the timing window is harder to exploit directly, but a BLE-connected attacker (e.g. a compromised phone app, or someone within Bluetooth range of a companion radio) could:

- **Forge messages from any known contact** — craft packets that pass MAC verification without knowing the shared secret, then inject arbitrary text messages, commands, or requests that appear to come from a trusted peer
- **Forge admin commands** — if the attacker can target a repeater or room server's BLE interface, they can forge REQ packets to execute privileged operations (config changes, ACL modifications)
- **Replay with modification** — combine with the ECB encryption mode to splice known ciphertext blocks into forged packets with valid MACs

## Fix

Replace `memcmp` with a constant-time XOR-accumulate loop. The comparison now always examines every byte regardless of where the first mismatch occurs, eliminating the timing signal.

## Test plan

- [x] Normal encrypted message exchange still works (send/receive between peers)
- [x] Invalid MACs still rejected (packets with wrong shared secret don't decrypt)
- [x] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/constant-time-mac-compare)