### PR TITLE
Tighten TRACE path_len guard to account for SNR append

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -40,7 +40,7 @@ int Mesh::searchChannelsByHash(const uint8_t* hash, GroupChannel channels[], int
 
 DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
   if (pkt->isRouteDirect() && pkt->getPayloadType() == PAYLOAD_TYPE_TRACE) {
-    if (pkt->path_len < MAX_PATH_SIZE) {
+    if (pkt->path_len + 1 < MAX_PATH_SIZE) {
       uint8_t i = 0;
       uint32_t trace_tag;
       memcpy(&trace_tag, &pkt->payload[i], 4); i += 4;


### PR DESCRIPTION
## Severity: Low

## Summary

When a node forwards a TRACE packet, it appends its SNR reading to `pkt->path` and increments `path_len`. The existing guard checks `path_len < MAX_PATH_SIZE`, which allows `path_len` of 63 through. After the append, `path_len` becomes 64 — equal to `MAX_PATH_SIZE`. The write itself is in-bounds (the array is 64 bytes, index 63 is valid), but `path_len` is now at the maximum, which could cause an off-by-one in any downstream code that uses `path_len` as an array index without re-checking.

Not exploitable in the current codebase, but a defensive fix to prevent future bugs as the code evolves.

## Fix

Change the guard from `path_len < MAX_PATH_SIZE` to `path_len + 1 < MAX_PATH_SIZE`, ensuring there is always room for the SNR append without `path_len` reaching `MAX_PATH_SIZE`.

## Test plan

- [ ] TRACE packets still forwarded correctly through multi-hop paths
- [ ] Long paths (62+ hops) terminate gracefully instead of appending at the boundary
- [ ] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/trace-path-len-bounds)