### PR TITLE
Validate advert payload length before parsing

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -251,6 +251,12 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
     }
     case PAYLOAD_TYPE_ADVERT: {
       int i = 0;
+      int min_advert_len = PUB_KEY_SIZE + 4 + SIGNATURE_SIZE;
+      if (pkt->payload_len < min_advert_len) {
+        MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): incomplete advertisement packet, payload_len=%d", getLogDateTime(), (int)pkt->payload_len);
+        break;
+      }
+
       Identity id;
       memcpy(id.pub_key, &pkt->payload[i], PUB_KEY_SIZE); i += PUB_KEY_SIZE;
 
@@ -258,9 +264,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       memcpy(&timestamp, &pkt->payload[i], 4); i += 4;
       const uint8_t* signature = &pkt->payload[i]; i += SIGNATURE_SIZE;
 
-      if (i > pkt->payload_len) {
-        MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): incomplete advertisement packet", getLogDateTime());
-      } else if (self_id.matches(id.pub_key)) {
+      if (self_id.matches(id.pub_key)) {
         MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): receiving SELF advert packet", getLogDateTime());
       } else if (!_tables->wasSeen(pkt)) {
         _tables->markSeen(pkt);


### PR DESCRIPTION
## Severity: Low

## Summary

The ADVERT packet handler copies the public key (32 bytes), timestamp (4 bytes), and signature (64 bytes) from the payload before checking whether `payload_len` is large enough to contain them. With a short payload, the memcpy operations read uninitialized data from within the payload buffer array.

The reads stay within the 184-byte `payload[]` array so this is not a true out-of-bounds access, but the parsed values (pub_key, timestamp, signature) contain garbage. The bounds check at line 251 catches it before any side-effects occur (no routing, no signature verification passes with garbage), but the ordering is sloppy and could become a real bug if the buffer layout changes.

## Fix

Move the bounds check before any parsing. Undersized adverts are now rejected immediately with a debug log, before any memcpy operations execute.

## Test plan

- [ ] Normal advertisement exchange still works
- [ ] Short/corrupt adverts are rejected with debug message
- [ ] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/advert-bounds-check-order)