### PR TITLE
Add minimum payload_len check for TRACE packet parsing

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -40,7 +40,7 @@ int Mesh::searchChannelsByHash(const uint8_t* hash, GroupChannel channels[], int
 
 DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
   if (pkt->isRouteDirect() && pkt->getPayloadType() == PAYLOAD_TYPE_TRACE) {
-    if (pkt->path_len < MAX_PATH_SIZE) {
+    if (pkt->path_len < MAX_PATH_SIZE && pkt->payload_len >= 9) {  // need trace_tag(4) + auth_code(4) + flags(1)
       uint8_t i = 0;
       uint32_t trace_tag;
       memcpy(&trace_tag, &pkt->payload[i], 4); i += 4;


### PR DESCRIPTION
## Severity: Medium

## Summary

The TRACE packet handler reads 9 bytes from the payload — `trace_tag` (4), `auth_code` (4), and `flags` (1) — before any length validation. The Dispatcher layer does not enforce a minimum `payload_len` for any packet type, so a TRACE packet with `payload_len = 0` reaches this code and reads stale data from the payload buffer.

Additionally, `uint8_t len = pkt->payload_len - i` (where `i = 9`) underflows when `payload_len < 9`, wrapping to ~247. This can cause the subsequent `offset >= len` check to pass or fail incorrectly, leading to unintended trace forwarding or hash matching against garbage data.

**Who can exploit this:** any node on the mesh — TRACE packets are unauthenticated and direct-routed.

**What it takes:** a single crafted short TRACE packet.

## What users might see

Incorrect trace routing, spurious trace forwarding, or (less likely) nodes processing traces they shouldn't. No crash — reads stay within the 184-byte payload buffer.

## Fix

Add `pkt->payload_len >= 9` to the existing guard condition so undersized TRACE packets are silently dropped before any field parsing.

## Test plan

- [ ] Normal path traces still work
- [ ] Short/corrupt TRACE packets are silently dropped
- [ ] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/trace-min-payload-len)