### PR TITLE
Validate buffer length before reading fields in Packet::readFrom

### DIFF
--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -67,7 +67,7 @@ bool Packet::readFrom(const uint8_t src[], uint8_t len) {
   uint8_t i = 0;
   header = src[i++];
   if (hasTransportCodes()) {
-    if (i + 4 >= len) return false;  // need 4 bytes for transport codes + path_len after
+    if (i + 4 >= len) return false;  // need 4 transport bytes + the path_len byte
     memcpy(&transport_codes[0], &src[i], 2); i += 2;
     memcpy(&transport_codes[1], &src[i], 2); i += 2;
   } else {

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -63,9 +63,11 @@ uint8_t Packet::writeTo(uint8_t dest[]) const {
 }
 
 bool Packet::readFrom(const uint8_t src[], uint8_t len) {
+  if (len < 2) return false;  // minimum: header + path_len
   uint8_t i = 0;
   header = src[i++];
   if (hasTransportCodes()) {
+    if (i + 4 >= len) return false;  // need 4 bytes for transport codes + path_len after
     memcpy(&transport_codes[0], &src[i], 2); i += 2;
     memcpy(&transport_codes[1], &src[i], 2); i += 2;
   } else {
@@ -75,9 +77,8 @@ bool Packet::readFrom(const uint8_t src[], uint8_t len) {
   if (!isValidPathLen(path_len)) return false;   // bad encoding
 
   uint8_t bl = getPathByteLen();
+  if (i + bl >= len) return false;  // path + at least 1 byte payload must fit
   memcpy(path, &src[i], bl); i += bl;
-
-  if (i >= len) return false;   // bad encoding
   payload_len = len - i;
   if (payload_len > sizeof(payload)) return false;  // bad encoding
   memcpy(payload, &src[i], payload_len); //i += payload_len;


### PR DESCRIPTION
## Severity: Low

## Summary

`Packet::readFrom` reads the header byte, transport codes (4 bytes if present), and `path_len` from the source buffer before performing any length validation. With a short input (e.g. `len = 0`), these reads go past the end of the source buffer.

Unlike the main radio receive path (which parses packets inline in `Dispatcher::checkRecv` with proper bounds checking), `readFrom` is used by bridge interfaces (RS232, ESP-NOW) and `importContact` (flash blob storage). A corrupted blob or malformed bridge frame could trigger the over-read.

## Fix

Add upfront length checks:
- Minimum 2 bytes overall (header + path_len)
- Transport codes require 4 additional bytes
- Path bytes plus at least 1 byte of payload must fit before proceeding

## Test plan

- [ ] Bridge packet reception still works (RS232, ESP-NOW)
- [ ] Contact import/export still works
- [ ] Short/corrupt inputs return false without reading past the buffer
- [ ] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/packet-readfrom-bounds)