### PR TITLE
Add ChaChaPoly AEAD-4 encryption with nonce persistence

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -395,6 +395,42 @@ bool DataStore::saveNonces(DataStoreHost* host) {
   return false;
 }
 
+void DataStore::loadSessionKeys(DataStoreHost* host) {
+  File file = openRead(_getContactsChannelsFS(), "/sess_keys");
+  if (file) {
+    uint8_t rec[71];  // 4-byte pub_key prefix + 1 flags + 2 nonce + 32 session_key + 32 prev_session_key
+    while (file.read(rec, 71) == 71) {
+      uint16_t nonce;
+      memcpy(&nonce, &rec[5], 2);
+      host->onSessionKeyLoaded(rec, rec[4], nonce, &rec[7], &rec[39]);
+    }
+    file.close();
+  }
+}
+
+bool DataStore::saveSessionKeys(DataStoreHost* host) {
+  File file = openWrite(_getContactsChannelsFS(), "/sess_keys");
+  if (file) {
+    uint8_t pub_key_prefix[4];
+    uint8_t flags;
+    uint16_t nonce;
+    uint8_t session_key[32];
+    uint8_t prev_session_key[32];
+    for (int idx = 0; idx < MAX_SESSION_KEYS; idx++) {
+      if (host->getSessionKeyForSave(idx, pub_key_prefix, &flags, &nonce, session_key, prev_session_key)) {
+        file.write(pub_key_prefix, 4);
+        file.write(&flags, 1);
+        file.write((uint8_t*)&nonce, 2);
+        file.write(session_key, 32);
+        file.write(prev_session_key, 32);
+      }
+    }
+    file.close();
+    return true;
+  }
+  return false;
+}
+
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
 
 #define MAX_ADVERT_PKT_LEN   (2 + 32 + PUB_KEY_SIZE + 4 + SIGNATURE_SIZE + MAX_ADVERT_DATA_SIZE)

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -365,6 +365,36 @@ void DataStore::saveChannels(DataStoreHost* host) {
   }
 }
 
+void DataStore::loadNonces(DataStoreHost* host) {
+  File file = openRead(_getContactsChannelsFS(), "/nonces");
+  if (file) {
+    uint8_t rec[6];  // 4-byte pub_key prefix + 2-byte nonce
+    while (file.read(rec, 6) == 6) {
+      uint16_t nonce;
+      memcpy(&nonce, &rec[4], 2);
+      host->onNonceLoaded(rec, nonce);
+    }
+    file.close();
+  }
+}
+
+bool DataStore::saveNonces(DataStoreHost* host) {
+  File file = openWrite(_getContactsChannelsFS(), "/nonces");
+  if (file) {
+    int idx = 0;
+    uint8_t pub_key_prefix[4];
+    uint16_t nonce;
+    while (host->getNonceForSave(idx, pub_key_prefix, &nonce)) {
+      file.write(pub_key_prefix, 4);
+      file.write((uint8_t*)&nonce, 2);
+      idx++;
+    }
+    file.close();
+    return true;
+  }
+  return false;
+}
+
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
 
 #define MAX_ADVERT_PKT_LEN   (2 + 32 + PUB_KEY_SIZE + 4 + SIGNATURE_SIZE + MAX_ADVERT_DATA_SIZE)

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -397,37 +397,105 @@ bool DataStore::saveNonces(DataStoreHost* host) {
 
 void DataStore::loadSessionKeys(DataStoreHost* host) {
   File file = openRead(_getContactsChannelsFS(), "/sess_keys");
-  if (file) {
-    uint8_t rec[71];  // 4-byte pub_key prefix + 1 flags + 2 nonce + 32 session_key + 32 prev_session_key
-    while (file.read(rec, 71) == 71) {
-      uint16_t nonce;
-      memcpy(&nonce, &rec[5], 2);
-      host->onSessionKeyLoaded(rec, rec[4], nonce, &rec[7], &rec[39]);
+  if (!file) return;
+  while (true) {
+    uint8_t rec[SESSION_KEY_RECORD_MIN_SIZE];
+    if (file.read(rec, SESSION_KEY_RECORD_MIN_SIZE) != SESSION_KEY_RECORD_MIN_SIZE) break;
+    uint8_t flags = rec[4];
+    uint16_t nonce;
+    memcpy(&nonce, &rec[5], 2);
+    uint8_t prev_key[SESSION_KEY_SIZE];
+    if (flags & SESSION_FLAG_PREV_VALID) {
+      if (file.read(prev_key, SESSION_KEY_SIZE) != SESSION_KEY_SIZE) break;
+    } else {
+      memset(prev_key, 0, SESSION_KEY_SIZE);
     }
-    file.close();
+    host->onSessionKeyLoaded(rec, flags, nonce, &rec[7], prev_key);
   }
+  file.close();
 }
 
 bool DataStore::saveSessionKeys(DataStoreHost* host) {
-  File file = openWrite(_getContactsChannelsFS(), "/sess_keys");
-  if (file) {
-    uint8_t pub_key_prefix[4];
-    uint8_t flags;
-    uint16_t nonce;
-    uint8_t session_key[32];
-    uint8_t prev_session_key[32];
-    for (int idx = 0; idx < MAX_SESSION_KEYS; idx++) {
-      if (host->getSessionKeyForSave(idx, pub_key_prefix, &flags, &nonce, session_key, prev_session_key)) {
-        file.write(pub_key_prefix, 4);
-        file.write(&flags, 1);
-        file.write((uint8_t*)&nonce, 2);
-        file.write(session_key, 32);
-        file.write(prev_session_key, 32);
+  FILESYSTEM* fs = _getContactsChannelsFS();
+
+  // 1. Read old flash file into buffer (variable-length records)
+  uint8_t old_buf[MAX_SESSION_KEYS_FLASH * SESSION_KEY_RECORD_SIZE];
+  int old_len = 0;
+  File rf = openRead(fs, "/sess_keys");
+  if (rf) {
+    while (true) {
+      if (old_len + SESSION_KEY_RECORD_MIN_SIZE > (int)sizeof(old_buf)) break;
+      if (rf.read(&old_buf[old_len], SESSION_KEY_RECORD_MIN_SIZE) != SESSION_KEY_RECORD_MIN_SIZE) break;
+      uint8_t flags = old_buf[old_len + 4];
+      int rec_len = SESSION_KEY_RECORD_MIN_SIZE;
+      if (flags & SESSION_FLAG_PREV_VALID) {
+        if (old_len + SESSION_KEY_RECORD_SIZE > (int)sizeof(old_buf)) break;
+        if (rf.read(&old_buf[old_len + SESSION_KEY_RECORD_MIN_SIZE], SESSION_KEY_SIZE) != SESSION_KEY_SIZE) break;
+        rec_len = SESSION_KEY_RECORD_SIZE;
       }
+      old_len += rec_len;
     }
-    file.close();
-    return true;
+    rf.close();
   }
+
+  // 2. Write merged file
+  File wf = openWrite(fs, "/sess_keys");
+  if (!wf) return false;
+
+  // Write kept old records (variable-length)
+  int pos = 0;
+  while (pos + SESSION_KEY_RECORD_MIN_SIZE <= old_len) {
+    uint8_t* rec = &old_buf[pos];
+    uint8_t flags = rec[4];
+    int rec_len = (flags & SESSION_FLAG_PREV_VALID) ? SESSION_KEY_RECORD_SIZE : SESSION_KEY_RECORD_MIN_SIZE;
+    if (pos + rec_len > old_len) break;
+    if (!host->isSessionKeyInRAM(rec) && !host->isSessionKeyRemoved(rec)) {
+      wf.write(rec, rec_len);
+    }
+    pos += rec_len;
+  }
+  // Write current RAM entries (variable-length)
+  for (int idx = 0; idx < MAX_SESSION_KEYS_RAM; idx++) {
+    uint8_t pk[4]; uint8_t fl; uint16_t n; uint8_t sk[32]; uint8_t psk[32];
+    if (!host->getSessionKeyForSave(idx, pk, &fl, &n, sk, psk)) continue;
+    wf.write(pk, 4); wf.write(&fl, 1); wf.write((uint8_t*)&n, 2);
+    wf.write(sk, 32);
+    if (fl & SESSION_FLAG_PREV_VALID) {
+      wf.write(psk, 32);
+    }
+  }
+  wf.close();
+  return true;
+}
+
+bool DataStore::loadSessionKeyByPrefix(const uint8_t* prefix,
+    uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key) {
+  File f = openRead(_getContactsChannelsFS(), "/sess_keys");
+  if (!f) return false;
+  while (true) {
+    uint8_t rec[SESSION_KEY_RECORD_MIN_SIZE];
+    if (f.read(rec, SESSION_KEY_RECORD_MIN_SIZE) != SESSION_KEY_RECORD_MIN_SIZE) break;
+    uint8_t rec_flags = rec[4];
+    bool has_prev = (rec_flags & SESSION_FLAG_PREV_VALID);
+    if (memcmp(rec, prefix, 4) == 0) {
+      *flags = rec_flags;
+      memcpy(nonce, &rec[5], 2);
+      memcpy(session_key, &rec[7], SESSION_KEY_SIZE);
+      if (has_prev) {
+        if (f.read(prev_session_key, SESSION_KEY_SIZE) != SESSION_KEY_SIZE) break;
+      } else {
+        memset(prev_session_key, 0, SESSION_KEY_SIZE);
+      }
+      f.close();
+      return true;
+    }
+    // Skip prev_key if present
+    if (has_prev) {
+      uint8_t skip[SESSION_KEY_SIZE];
+      if (f.read(skip, SESSION_KEY_SIZE) != SESSION_KEY_SIZE) break;
+    }
+  }
+  f.close();
   return false;
 }
 

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -17,6 +17,8 @@ public:
                                    const uint8_t* session_key, const uint8_t* prev_session_key) { return false; }
   virtual bool getSessionKeyForSave(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
                                      uint8_t* session_key, uint8_t* prev_session_key) { return false; }
+  virtual bool isSessionKeyInRAM(const uint8_t* pub_key_prefix) { return false; }
+  virtual bool isSessionKeyRemoved(const uint8_t* pub_key_prefix) { return false; }
 };
 
 class DataStore {
@@ -49,6 +51,8 @@ public:
   bool saveNonces(DataStoreHost* host);
   void loadSessionKeys(DataStoreHost* host);
   bool saveSessionKeys(DataStoreHost* host);
+  bool loadSessionKeyByPrefix(const uint8_t* prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key);
   void migrateToSecondaryFS();
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -13,6 +13,10 @@ public:
   virtual bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) =0;
   virtual bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) { return false; }
   virtual bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) { return false; }
+  virtual bool onSessionKeyLoaded(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                                   const uint8_t* session_key, const uint8_t* prev_session_key) { return false; }
+  virtual bool getSessionKeyForSave(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                                     uint8_t* session_key, uint8_t* prev_session_key) { return false; }
 };
 
 class DataStore {
@@ -43,6 +47,8 @@ public:
   void saveChannels(DataStoreHost* host);
   void loadNonces(DataStoreHost* host);
   bool saveNonces(DataStoreHost* host);
+  void loadSessionKeys(DataStoreHost* host);
+  bool saveSessionKeys(DataStoreHost* host);
   void migrateToSecondaryFS();
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -11,6 +11,8 @@ public:
   virtual bool getContactForSave(uint32_t idx, ContactInfo& contact) =0;
   virtual bool onChannelLoaded(uint8_t channel_idx, const ChannelDetails& ch) =0;
   virtual bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) =0;
+  virtual bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) { return false; }
+  virtual bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) { return false; }
 };
 
 class DataStore {
@@ -39,6 +41,8 @@ public:
   void saveContacts(DataStoreHost* host, bool (*filter)(const ContactInfo& c) = NULL);
   void loadChannels(DataStoreHost* host);
   void saveChannels(DataStoreHost* host);
+  void loadNonces(DataStoreHost* host);
+  bool saveNonces(DataStoreHost* host);
   void migrateToSecondaryFS();
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -871,6 +871,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   next_ack_idx = 0;
   sign_data = NULL;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   memset(advert_paths, 0, sizeof(advert_paths));
   memset(send_scope.key, 0, sizeof(send_scope.key));
   send_unscoped = false;
@@ -968,6 +969,14 @@ void MyMesh::begin(bool has_display) {
   resetContacts();
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
+
+  // Load persisted AEAD nonces and apply boot bump if needed
+  _store->loadNonces(this);
+  bool dirty_reset = wasDirtyReset(board);
+  finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 
@@ -1464,6 +1473,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     if (dirty_contacts_expiry) { // is there are pending dirty contacts write needed?
       saveContacts();
     }
+    if (isNonceDirty()) saveNonces();
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -2186,6 +2196,7 @@ void MyMesh::checkCLIRescueCmd() {
       }
 
     } else if (strcmp(cli_command, "reboot") == 0) {
+      if (isNonceDirty()) saveNonces();
       board.reboot();  // doesn't return
     } else {
       Serial.println("  Error: unknown command");
@@ -2235,6 +2246,14 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     saveContacts();
     dirty_contacts_expiry = 0;
+  }
+
+  // periodic AEAD nonce persistence
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (isNonceDirty()) {
+      saveNonces();
+    }
+    next_nonce_persist = futureMillis(60000);
   }
 
 #ifdef DISPLAY_CLASS

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2250,6 +2250,14 @@ void MyMesh::checkSerialInterface() {
   }
 }
 
+bool MyMesh::isSessionKeyInRAM(const uint8_t* pub_key_prefix) {
+  return isSessionKeyInRAMPool(pub_key_prefix);
+}
+
+bool MyMesh::isSessionKeyRemoved(const uint8_t* pub_key_prefix) {
+  return isSessionKeyRemovedFromPool(pub_key_prefix);
+}
+
 void MyMesh::loop() {
   BaseChatMesh::loop();
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -977,6 +977,8 @@ void MyMesh::begin(bool has_display) {
   if (dirty_reset) saveNonces();  // persist bumped nonces immediately
   next_nonce_persist = futureMillis(60000);
 
+  _store->loadSessionKeys(this);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 
@@ -1474,6 +1476,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       saveContacts();
     }
     if (isNonceDirty()) saveNonces();
+    saveSessionKeys();
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -2195,8 +2198,22 @@ void MyMesh::checkCLIRescueCmd() {
 
       }
 
+    } else if (memcmp(cli_command, "rekey ", 6) == 0) {
+      const char* name_prefix = &cli_command[6];
+      ContactInfo* c = searchContactsByPrefix(name_prefix);
+      if (c) {
+        if (initiateSessionKeyNegotiation(*c)) {
+          Serial.print("  Session key negotiation started with: ");
+          Serial.println(c->name);
+        } else {
+          Serial.println("  Error: failed to initiate (no AEAD or pool full)");
+        }
+      } else {
+        Serial.println("  Error: contact not found");
+      }
     } else if (strcmp(cli_command, "reboot") == 0) {
       if (isNonceDirty()) saveNonces();
+      saveSessionKeys();
       board.reboot();  // doesn't return
     } else {
       Serial.println("  Error: unknown command");
@@ -2248,10 +2265,13 @@ void MyMesh::loop() {
     dirty_contacts_expiry = 0;
   }
 
-  // periodic AEAD nonce persistence
+  // periodic AEAD nonce and session key persistence
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (isNonceDirty()) {
       saveNonces();
+    }
+    if (isSessionKeysDirty()) {
+      saveSessionKeys();
     }
     next_nonce_persist = futureMillis(60000);
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1050,6 +1050,8 @@ void MyMesh::begin(bool has_display) {
   if (dirty_reset) saveNonces();  // persist bumped nonces immediately
   next_nonce_persist = futureMillis(60000);
 
+  _store->loadSessionKeys(this);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 
@@ -1564,6 +1566,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       saveContacts();
     }
     if (isNonceDirty()) saveNonces();
+    saveSessionKeys();
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -2356,8 +2359,22 @@ void MyMesh::checkCLIRescueCmd() {
 
       }
 
+    } else if (memcmp(cli_command, "rekey ", 6) == 0) {
+      const char* name_prefix = &cli_command[6];
+      ContactInfo* c = searchContactsByPrefix(name_prefix);
+      if (c) {
+        if (initiateSessionKeyNegotiation(*c)) {
+          Serial.print("  Session key negotiation started with: ");
+          Serial.println(c->name);
+        } else {
+          Serial.println("  Error: failed to initiate (no AEAD or pool full)");
+        }
+      } else {
+        Serial.println("  Error: contact not found");
+      }
     } else if (strcmp(cli_command, "reboot") == 0) {
       if (isNonceDirty()) saveNonces();
+      saveSessionKeys();
       board.reboot();  // doesn't return
     } else {
       Serial.println("  Error: unknown command");
@@ -2409,10 +2426,13 @@ void MyMesh::loop() {
     dirty_contacts_expiry = 0;
   }
 
-  // periodic AEAD nonce persistence
+  // periodic AEAD nonce and session key persistence
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (isNonceDirty()) {
       saveNonces();
+    }
+    if (isSessionKeysDirty()) {
+      saveSessionKeys();
     }
     next_nonce_persist = futureMillis(60000);
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2411,6 +2411,14 @@ void MyMesh::checkSerialInterface() {
   }
 }
 
+bool MyMesh::isSessionKeyInRAM(const uint8_t* pub_key_prefix) {
+  return isSessionKeyInRAMPool(pub_key_prefix);
+}
+
+bool MyMesh::isSessionKeyRemoved(const uint8_t* pub_key_prefix) {
+  return isSessionKeyRemovedFromPool(pub_key_prefix);
+}
+
 void MyMesh::loop() {
   BaseChatMesh::loop();
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -938,6 +938,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   next_ack_idx = 0;
   sign_data = NULL;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   memset(advert_paths, 0, sizeof(advert_paths));
   memset(send_scope.key, 0, sizeof(send_scope.key));
   send_unscoped = false;
@@ -1041,6 +1042,14 @@ void MyMesh::begin(bool has_display) {
   resetContacts();
   _store->loadContacts(this);
   bootstrapRTCfromContacts();
+
+  // Load persisted AEAD nonces and apply boot bump if needed
+  _store->loadNonces(this);
+  bool dirty_reset = wasDirtyReset(board);
+  finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
+
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 
@@ -1554,6 +1563,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     if (dirty_contacts_expiry) { // is there are pending dirty contacts write needed?
       saveContacts();
     }
+    if (isNonceDirty()) saveNonces();
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -2347,6 +2357,7 @@ void MyMesh::checkCLIRescueCmd() {
       }
 
     } else if (strcmp(cli_command, "reboot") == 0) {
+      if (isNonceDirty()) saveNonces();
       board.reboot();  // doesn't return
     } else {
       Serial.println("  Error: unknown command");
@@ -2396,6 +2407,14 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     saveContacts();
     dirty_contacts_expiry = 0;
+  }
+
+  // periodic AEAD nonce persistence
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (isNonceDirty()) {
+      saveNonces();
+    }
+    next_nonce_persist = futureMillis(60000);
   }
 
 #ifdef DISPLAY_CLASS

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -161,6 +161,14 @@ protected:
   bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) override { return getChannel(channel_idx, ch); }
   bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) override { return applyLoadedNonce(pub_key_prefix, nonce); }
   bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) override { return getNonceEntry(idx, pub_key_prefix, nonce); }
+  bool onSessionKeyLoaded(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                           const uint8_t* session_key, const uint8_t* prev_session_key) override {
+    return applyLoadedSessionKey(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
+  bool getSessionKeyForSave(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                              uint8_t* session_key, uint8_t* prev_session_key) override {
+    return getSessionKeyEntry(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -210,6 +218,8 @@ private:
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
   void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
+  void saveSessionKeys() { if (_store->saveSessionKeys(this)) clearSessionKeysDirty(); }
+  void onSessionKeysUpdated() override { saveSessionKeys(); }
 
   DataStore* _store;
   NodePrefs _prefs;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -159,6 +159,8 @@ protected:
   bool getContactForSave(uint32_t idx, ContactInfo& contact) override { return getContactByIdx(idx, contact); }
   bool onChannelLoaded(uint8_t channel_idx, const ChannelDetails& ch) override { return setChannel(channel_idx, ch); }
   bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) override { return getChannel(channel_idx, ch); }
+  bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) override { return applyLoadedNonce(pub_key_prefix, nonce); }
+  bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) override { return getNonceEntry(idx, pub_key_prefix, nonce); }
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -207,6 +209,7 @@ private:
   // helpers, short-cuts
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
+  void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
 
   DataStore* _store;
   NodePrefs _prefs;
@@ -229,6 +232,7 @@ private:
   uint8_t *sign_data;
   uint32_t sign_data_len;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
 
   TransportKey send_scope;
 

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -169,6 +169,8 @@ protected:
                               uint8_t* session_key, uint8_t* prev_session_key) override {
     return getSessionKeyEntry(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
   }
+  bool isSessionKeyInRAM(const uint8_t* pub_key_prefix) override;
+  bool isSessionKeyRemoved(const uint8_t* pub_key_prefix) override;
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -218,8 +220,15 @@ private:
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
   void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
-  void saveSessionKeys() { if (_store->saveSessionKeys(this)) clearSessionKeysDirty(); }
+  void saveSessionKeys() { if (_store->saveSessionKeys(this)) { clearSessionKeysDirty(); clearSessionKeysRemoved(); } }
   void onSessionKeysUpdated() override { saveSessionKeys(); }
+
+  // Flash-backed session key overrides
+  bool loadSessionKeyRecordFromFlash(const uint8_t* pub_key_prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key) override {
+    return _store->loadSessionKeyByPrefix(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
+  void mergeAndSaveSessionKeys() override { saveSessionKeys(); }
 
   DataStore* _store;
   NodePrefs _prefs;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -189,6 +189,8 @@ protected:
                               uint8_t* session_key, uint8_t* prev_session_key) override {
     return getSessionKeyEntry(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
   }
+  bool isSessionKeyInRAM(const uint8_t* pub_key_prefix) override;
+  bool isSessionKeyRemoved(const uint8_t* pub_key_prefix) override;
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -240,8 +242,15 @@ private:
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
   void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
-  void saveSessionKeys() { if (_store->saveSessionKeys(this)) clearSessionKeysDirty(); }
+  void saveSessionKeys() { if (_store->saveSessionKeys(this)) { clearSessionKeysDirty(); clearSessionKeysRemoved(); } }
   void onSessionKeysUpdated() override { saveSessionKeys(); }
+
+  // Flash-backed session key overrides
+  bool loadSessionKeyRecordFromFlash(const uint8_t* pub_key_prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key) override {
+    return _store->loadSessionKeyByPrefix(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
+  void mergeAndSaveSessionKeys() override { saveSessionKeys(); }
 
   DataStore* _store;
   NodePrefs _prefs;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -181,6 +181,14 @@ protected:
   bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) override { return getChannel(channel_idx, ch); }
   bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) override { return applyLoadedNonce(pub_key_prefix, nonce); }
   bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) override { return getNonceEntry(idx, pub_key_prefix, nonce); }
+  bool onSessionKeyLoaded(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                           const uint8_t* session_key, const uint8_t* prev_session_key) override {
+    return applyLoadedSessionKey(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
+  bool getSessionKeyForSave(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                              uint8_t* session_key, uint8_t* prev_session_key) override {
+    return getSessionKeyEntry(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
+  }
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -232,6 +240,8 @@ private:
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
   void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
+  void saveSessionKeys() { if (_store->saveSessionKeys(this)) clearSessionKeysDirty(); }
+  void onSessionKeysUpdated() override { saveSessionKeys(); }
 
   DataStore* _store;
   NodePrefs _prefs;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -179,6 +179,8 @@ protected:
   bool getContactForSave(uint32_t idx, ContactInfo& contact) override { return getContactByIdx(idx, contact); }
   bool onChannelLoaded(uint8_t channel_idx, const ChannelDetails& ch) override { return setChannel(channel_idx, ch); }
   bool getChannelForSave(uint8_t channel_idx, ChannelDetails& ch) override { return getChannel(channel_idx, ch); }
+  bool onNonceLoaded(const uint8_t* pub_key_prefix, uint16_t nonce) override { return applyLoadedNonce(pub_key_prefix, nonce); }
+  bool getNonceForSave(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) override { return getNonceEntry(idx, pub_key_prefix, nonce); }
 
   void clearPendingReqs() {
     pending_login = pending_status = pending_telemetry = pending_discovery = pending_req = 0;
@@ -229,6 +231,7 @@ private:
   // helpers, short-cuts
   void saveChannels() { _store->saveChannels(this); }
   void saveContacts();
+  void saveNonces() { if (_store->saveNonces(this)) clearNonceDirty(); }
 
   DataStore* _store;
   NodePrefs _prefs;
@@ -252,6 +255,7 @@ private:
   uint8_t *sign_data;
   uint32_t sign_data_len;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
 
   TransportKey send_scope;
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -631,7 +631,7 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -641,7 +641,10 @@ void MyMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -689,11 +692,11 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -754,7 +757,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -883,6 +886,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   uptime_millis = 0;
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   set_radio_at = revert_radio_at = 0;
   _logging = false;
   region_load_active = false;
@@ -951,6 +955,12 @@ void MyMesh::begin(FILESYSTEM *fs) {
   // load persisted prefs
   _cli.loadPrefs(_fs);
   acl.load(_fs, self_id);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
   // TODO: key_store.begin();
   region_map.load(_fs);
 
@@ -1325,6 +1335,12 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 
   // update uptime

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -621,6 +621,31 @@ void MyMesh::getPeerSharedSecret(uint8_t *dest_secret, int peer_idx) {
   }
 }
 
+uint8_t MyMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->flags;
+  return 0;
+}
+
+uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->nextAeadNonce();
+  return 0;
+}
+
+void MyMesh::onPeerAeadDetected(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients()) {
+    auto c = acl.getClientByIdx(i);
+    if (!(c->flags & CONTACT_FLAG_AEAD)) {
+      c->flags |= CONTACT_FLAG_AEAD;
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    }
+  }
+}
+
 static bool isShare(const mesh::Packet *packet) {
   if (packet->hasTransportCodes()) {
     return packet->transport_codes[0] == 0 && packet->transport_codes[1] == 0;  // codes { 0, 0 } means 'send to nowhere'
@@ -664,11 +689,11 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len);
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -729,7 +754,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len);
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -629,24 +629,34 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* MyMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void MyMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t MyMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 static bool isShare(const mesh::Packet *packet) {
@@ -683,20 +693,37 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
     memcpy(&timestamp, data, 4);
 
     if (timestamp > client->last_timestamp) { // prevent replay attacks
-      int reply_len = handleRequest(client, timestamp, &data[4], len - 4);
+      int reply_len;
+      bool use_static_secret = false;
+
+      // Intercept session key INIT before handleRequest
+      if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {
+        memcpy(reply_data, &timestamp, 4);
+        reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+        int n = acl.handleSessionKeyInit(client, &data[5], &reply_data[5], getRNG());
+        reply_len = (n > 0) ? 5 + n : 0;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      } else {
+        reply_len = handleRequest(client, timestamp, &data[4], len - 4);
+      }
       if (reply_len == 0) return; // invalid command
 
       client->last_timestamp = timestamp;
       client->last_activity = getRTCClock()->getCurrentTime();
 
+      // Session key ACCEPT must be encrypted with static ECDH secret + static nonce,
+      // because the initiator hasn't derived the session key yet.
+      const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*client);
+      uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*client) : acl.getEncryptionNonce(*client);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+        mesh::Packet *path = createPathReturn(client->id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, enc_key, reply_data, reply_len, enc_nonce);
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -757,7 +784,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), temp, 5 + text_len, acl.getEncryptionNonce(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -957,6 +984,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   acl.load(_fs, self_id);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1340,6 +1368,7 @@ void MyMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -640,6 +640,31 @@ void MyMesh::getPeerSharedSecret(uint8_t *dest_secret, int peer_idx) {
   }
 }
 
+uint8_t MyMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->flags;
+  return 0;
+}
+
+uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->nextAeadNonce();
+  return 0;
+}
+
+void MyMesh::onPeerAeadDetected(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients()) {
+    auto c = acl.getClientByIdx(i);
+    if (!(c->flags & CONTACT_FLAG_AEAD)) {
+      c->flags |= CONTACT_FLAG_AEAD;
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    }
+  }
+}
+
 static bool isShare(const mesh::Packet *packet) {
   if (packet->hasTransportCodes()) {
     return packet->transport_codes[0] == 0 && packet->transport_codes[1] == 0;  // codes { 0, 0 } means 'send to nowhere'
@@ -683,11 +708,11 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len);
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -748,7 +773,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len);
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -648,24 +648,34 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* MyMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void MyMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t MyMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 static bool isShare(const mesh::Packet *packet) {
@@ -702,20 +712,37 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
     memcpy(&timestamp, data, 4);
 
     if (timestamp > client->last_timestamp) { // prevent replay attacks
-      int reply_len = handleRequest(client, timestamp, &data[4], len - 4);
+      int reply_len;
+      bool use_static_secret = false;
+
+      // Intercept session key INIT before handleRequest
+      if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {
+        memcpy(reply_data, &timestamp, 4);
+        reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+        int n = acl.handleSessionKeyInit(client, &data[5], &reply_data[5], getRNG());
+        reply_len = (n > 0) ? 5 + n : 0;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      } else {
+        reply_len = handleRequest(client, timestamp, &data[4], len - 4);
+      }
       if (reply_len == 0) return; // invalid command
 
       client->last_timestamp = timestamp;
       client->last_activity = getRTCClock()->getCurrentTime();
 
+      // Session key ACCEPT must be encrypted with static ECDH secret + static nonce,
+      // because the initiator hasn't derived the session key yet.
+      const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*client);
+      uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*client) : acl.getEncryptionNonce(*client);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+        mesh::Packet *path = createPathReturn(client->id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, enc_key, reply_data, reply_len, enc_nonce);
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -776,7 +803,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), temp, 5 + text_len, acl.getEncryptionNonce(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -978,6 +1005,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   acl.load(_fs, self_id);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1362,6 +1390,7 @@ void MyMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -650,7 +650,7 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -660,7 +660,10 @@ void MyMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -708,11 +711,11 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
         if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
         mesh::Packet *reply =
-            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
+            createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -773,7 +776,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         memcpy(temp, &timestamp, 4);        // mostly an extra blob to help make packet_hash unique
         temp[4] = (TXT_TYPE_CLI_DATA << 2); // NOTE: legacy was: TXT_TYPE_PLAIN
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -902,6 +905,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   uptime_millis = 0;
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   set_radio_at = revert_radio_at = 0;
   _logging = false;
   region_load_active = false;
@@ -972,6 +976,12 @@ void MyMesh::begin(FILESYSTEM *fs) {
   // load persisted prefs
   _cli.loadPrefs(_fs);
   acl.load(_fs, self_id);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
   // TODO: key_store.begin();
   region_map.load(_fs);
 
@@ -1347,6 +1357,12 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 
   // update uptime

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -171,6 +171,9 @@ protected:
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  void onPeerAeadDetected(int peer_idx) override;
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len);
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -103,6 +103,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   unsigned long pending_discover_until;
   bool region_load_active;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif
@@ -196,6 +197,9 @@ public:
 
   void savePrefs() override {
     _cli.savePrefs(_fs);
+  }
+  void onBeforeReboot() override {
+    if (acl.isNonceDirty()) acl.saveNonces();
   }
 
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis, uint8_t path_hash_size);

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -175,6 +175,11 @@ protected:
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerAeadDetected(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len);
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -168,6 +168,9 @@ protected:
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  void onPeerAeadDetected(int peer_idx) override;
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len);
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -172,6 +172,11 @@ protected:
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerAeadDetected(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len);
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -100,6 +100,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   unsigned long pending_discover_until;
   bool region_load_active;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif
@@ -193,6 +194,9 @@ public:
 
   void savePrefs() override {
     _cli.savePrefs(_fs);
+  }
+  void onBeforeReboot() override {
+    if (acl.isNonceDirty()) acl.saveNonces();
   }
 
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis, uint8_t path_hash_size);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, client->nextAeadNonce());
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, acl.nextAeadNonceFor(*client));
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -441,7 +441,7 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -451,7 +451,10 @@ void MyMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -549,7 +552,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -606,10 +609,10 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
             mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -664,6 +667,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   uptime_millis = 0;
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   _logging = false;
   region_load_active = false;
   set_radio_at = revert_radio_at = 0;
@@ -726,6 +730,12 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
   acl.load(_fs, self_id);
   region_map.load(_fs);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
 
   // establish default-scope
   {
@@ -1084,6 +1094,12 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs, MyMesh::saveFilter);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 
   // TODO: periodically check for OLD/inactive entries in known_clients[], and evict

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, acl.nextAeadNonceFor(*client));
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), reply_data, len, acl.getEncryptionNonce(*client));
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -439,24 +439,34 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* MyMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void MyMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t MyMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, const uint8_t *secret,
@@ -552,7 +562,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), temp, 5 + text_len, acl.getEncryptionNonce(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -604,15 +614,30 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           }
         }
       } else {
-        int reply_len = handleRequest(client, sender_timestamp, &data[4], len - 4);
+        int reply_len;
+        bool use_static_secret = false;
+
+        // Intercept session key INIT before handleRequest
+        if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {
+          memcpy(reply_data, &sender_timestamp, 4);
+          reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+          int n = acl.handleSessionKeyInit(client, &data[5], &reply_data[5], getRNG());
+          reply_len = (n > 0) ? 5 + n : 0;
+          use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+        } else {
+          reply_len = handleRequest(client, sender_timestamp, &data[4], len - 4);
+        }
         if (reply_len > 0) { // valid command
+          const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*client);
+          uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*client) : acl.getEncryptionNonce(*client);
+
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-            mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            mesh::Packet *path = createPathReturn(client->id, enc_key, packet->path, packet->path_len,
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, enc_key, reply_data, reply_len, enc_nonce);
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -732,6 +757,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   region_map.load(_fs);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1099,6 +1125,7 @@ void MyMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len);
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, client->nextAeadNonce());
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -431,6 +431,31 @@ void MyMesh::getPeerSharedSecret(uint8_t *dest_secret, int peer_idx) {
   }
 }
 
+uint8_t MyMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->flags;
+  return 0;
+}
+
+uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->nextAeadNonce();
+  return 0;
+}
+
+void MyMesh::onPeerAeadDetected(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients()) {
+    auto c = acl.getClientByIdx(i);
+    if (!(c->flags & CONTACT_FLAG_AEAD)) {
+      c->flags |= CONTACT_FLAG_AEAD;
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    }
+  }
+}
+
 void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, const uint8_t *secret,
                             uint8_t *data, size_t len) {
   int i = matching_peer_indexes[sender_idx];
@@ -524,7 +549,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len);
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -581,10 +606,10 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
             mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len);
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len);
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, client->nextAeadNonce());
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -430,6 +430,31 @@ void MyMesh::getPeerSharedSecret(uint8_t *dest_secret, int peer_idx) {
   }
 }
 
+uint8_t MyMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->flags;
+  return 0;
+}
+
+uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->nextAeadNonce();
+  return 0;
+}
+
+void MyMesh::onPeerAeadDetected(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients()) {
+    auto c = acl.getClientByIdx(i);
+    if (!(c->flags & CONTACT_FLAG_AEAD)) {
+      c->flags |= CONTACT_FLAG_AEAD;
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    }
+  }
+}
+
 void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, const uint8_t *secret,
                             uint8_t *data, size_t len) {
   int i = matching_peer_indexes[sender_idx];
@@ -523,7 +548,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len);
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -580,10 +605,10 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
             mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len);
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, acl.nextAeadNonceFor(*client));
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), reply_data, len, acl.getEncryptionNonce(*client));
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -438,24 +438,34 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* MyMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void MyMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* MyMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t MyMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, const uint8_t *secret,
@@ -551,7 +561,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, acl.getEncryptionKey(*client), temp, 5 + text_len, acl.getEncryptionNonce(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -603,15 +613,30 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           }
         }
       } else {
-        int reply_len = handleRequest(client, sender_timestamp, &data[4], len - 4);
+        int reply_len;
+        bool use_static_secret = false;
+
+        // Intercept session key INIT before handleRequest
+        if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {
+          memcpy(reply_data, &sender_timestamp, 4);
+          reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+          int n = acl.handleSessionKeyInit(client, &data[5], &reply_data[5], getRNG());
+          reply_len = (n > 0) ? 5 + n : 0;
+          use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+        } else {
+          reply_len = handleRequest(client, sender_timestamp, &data[4], len - 4);
+        }
         if (reply_len > 0) { // valid command
+          const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*client);
+          uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*client) : acl.getEncryptionNonce(*client);
+
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-            mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            mesh::Packet *path = createPathReturn(client->id, enc_key, packet->path, packet->path_len,
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, enc_key, reply_data, reply_len, enc_nonce);
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -732,6 +757,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   region_map.load(_fs);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1108,6 +1134,7 @@ void MyMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -88,7 +88,7 @@ void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
   mesh::Utils::sha256((uint8_t *)&client->extra.room.pending_ack, 4, reply_data, len, client->id.pub_key, PUB_KEY_SIZE);
   client->extra.room.push_post_timestamp = post.post_timestamp;
 
-  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, client->nextAeadNonce());
+  auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, client->shared_secret, reply_data, len, acl.nextAeadNonceFor(*client));
   if (reply) {
     if (client->out_path_len == OUT_PATH_UNKNOWN) {
       unsigned long delay_millis = 0;
@@ -440,7 +440,7 @@ uint8_t MyMesh::getPeerFlags(int peer_idx) {
 uint16_t MyMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -450,7 +450,10 @@ void MyMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -548,7 +551,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         // mesh::Utils::sha256((uint8_t *)&expected_ack_crc, 4, temp, 5 + text_len, self_id.pub_key,
         // PUB_KEY_SIZE);
 
-        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, client->nextAeadNonce());
+        auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, client->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*client));
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodReply(reply, delay_millis + SERVER_RESPONSE_DELAY, packet->getPathHashSize());
@@ -605,10 +608,10 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
             mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, client->nextAeadNonce());
+                                                  PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*client));
             if (path) sendFloodReply(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
           } else {
-            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, client->nextAeadNonce());
+            mesh::Packet *reply = createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*client));
             if (reply) {
               if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
                 sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
@@ -663,6 +666,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   uptime_millis = 0;
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   _logging = false;
   region_load_active = false;
   set_radio_at = revert_radio_at = 0;
@@ -726,6 +730,12 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
   acl.load(_fs, self_id);
   region_map.load(_fs);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
 
   // establish default-scope
   {
@@ -1093,6 +1103,12 @@ void MyMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs, MyMesh::saveFilter);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 
   // TODO: periodically check for OLD/inactive entries in known_clients[], and evict

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -165,6 +165,11 @@ protected:
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerAeadDetected(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -161,6 +161,9 @@ protected:
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override ;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  void onPeerAeadDetected(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -101,6 +101,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   ClientACL acl;
   CommonCLI _cli;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   unsigned long next_push;
   uint16_t _num_posted, _num_post_pushes;
@@ -192,6 +193,9 @@ public:
 
   void savePrefs() override {
     _cli.savePrefs(_fs);
+  }
+  void onBeforeReboot() override {
+    if (acl.isNonceDirty()) acl.saveNonces();
   }
 
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis, uint8_t path_hash_size);

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -162,6 +162,9 @@ protected:
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override ;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  void onPeerAeadDetected(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -102,6 +102,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   ClientACL acl;
   CommonCLI _cli;
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   unsigned long next_push;
   uint16_t _num_posted, _num_post_pushes;
@@ -193,6 +194,9 @@ public:
 
   void savePrefs() override {
     _cli.savePrefs(_fs);
+  }
+  void onBeforeReboot() override {
+    if (acl.isNonceDirty()) acl.saveNonces();
   }
 
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis, uint8_t path_hash_size);

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -166,6 +166,11 @@ protected:
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerAeadDetected(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -256,7 +256,7 @@ void SensorMesh::sendAlert(const ClientInfo* c, Trigger* t) {
   mesh::Utils::sha256((uint8_t *)&t->expected_acks[t->attempt], 4, data, 5 + text_len, self_id.pub_key, PUB_KEY_SIZE);
   t->attempt++;
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len);
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, c->nextAeadNonce());
   if (pkt) {
     if (c->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
       sendDirect(pkt, c->out_path, c->out_path_len);
@@ -500,6 +500,31 @@ void SensorMesh::getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) {
   }
 }
 
+uint8_t SensorMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->flags;
+  return 0;
+}
+
+uint16_t SensorMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients())
+    return acl.getClientByIdx(i)->nextAeadNonce();
+  return 0;
+}
+
+void SensorMesh::onPeerAeadDetected(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < acl.getNumClients()) {
+    auto c = acl.getClientByIdx(i);
+    if (!(c->flags & CONTACT_FLAG_AEAD)) {
+      c->flags |= CONTACT_FLAG_AEAD;
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    }
+  }
+}
+
 void SensorMesh::sendAckTo(const ClientInfo& dest, uint32_t ack_hash, uint8_t path_hash_size) {
   if (dest.out_path_len == OUT_PATH_UNKNOWN) {
     mesh::Packet* ack = createAck(ack_hash);
@@ -540,10 +565,10 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, from->nextAeadNonce());
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len);
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, from->nextAeadNonce());
         if (reply) {
           if (from->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from->out_path, from->out_path_len, SERVER_RESPONSE_DELAY);
@@ -570,7 +595,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
             mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
+                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from->nextAeadNonce());
             if (path) sendFlood(path, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendAckTo(*from, ack_hash, packet->getPathHashSize());
@@ -598,7 +623,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
           temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len);
+          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, from->nextAeadNonce());
           if (reply) {
             if (from->out_path_len == OUT_PATH_UNKNOWN) {
               sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -256,7 +256,7 @@ void SensorMesh::sendAlert(const ClientInfo* c, Trigger* t) {
   mesh::Utils::sha256((uint8_t *)&t->expected_acks[t->attempt], 4, data, 5 + text_len, self_id.pub_key, PUB_KEY_SIZE);
   t->attempt++;
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, c->nextAeadNonce());
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, acl.nextAeadNonceFor(*c));
   if (pkt) {
     if (c->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
       sendDirect(pkt, c->out_path, c->out_path_len);
@@ -510,7 +510,7 @@ uint8_t SensorMesh::getPeerFlags(int peer_idx) {
 uint16_t SensorMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -520,7 +520,10 @@ void SensorMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -565,10 +568,10 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, from->nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*from));
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, from->nextAeadNonce());
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*from));
         if (reply) {
           if (from->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from->out_path, from->out_path_len, SERVER_RESPONSE_DELAY);
@@ -595,7 +598,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
             mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from->nextAeadNonce());
+                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.nextAeadNonceFor(*from));
             if (path) sendFlood(path, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendAckTo(*from, ack_hash, packet->getPathHashSize());
@@ -623,7 +626,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
           temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, from->nextAeadNonce());
+          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*from));
           if (reply) {
             if (from->out_path_len == OUT_PATH_UNKNOWN) {
               sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -730,6 +733,7 @@ SensorMesh::SensorMesh(mesh::MainBoard& board, mesh::Radio& radio, mesh::Millise
 {
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   last_read_time = 0;
   num_alert_tasks = 0;
   set_radio_at = revert_radio_at = 0;
@@ -772,6 +776,12 @@ void SensorMesh::begin(FILESYSTEM* fs) {
 
   acl.load(_fs, self_id);
   region_map.load(_fs);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
 
   // establish default-scope
   {
@@ -1000,5 +1010,11 @@ void SensorMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -256,7 +256,7 @@ void SensorMesh::sendAlert(const ClientInfo* c, Trigger* t) {
   mesh::Utils::sha256((uint8_t *)&t->expected_acks[t->attempt], 4, data, 5 + text_len, self_id.pub_key, PUB_KEY_SIZE);
   t->attempt++;
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, acl.nextAeadNonceFor(*c));
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, acl.getEncryptionKey(*c), data, 5 + text_len, acl.getEncryptionNonce(*c));
   if (pkt) {
     if (c->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
       sendDirect(pkt, c->out_path, c->out_path_len);
@@ -508,24 +508,34 @@ uint8_t SensorMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t SensorMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void SensorMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* SensorMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* SensorMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void SensorMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* SensorMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t SensorMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 void SensorMesh::sendAckTo(const ClientInfo& dest, uint32_t ack_hash, uint8_t path_hash_size) {
@@ -559,19 +569,34 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
     memcpy(&timestamp, data, 4);
 
     if (timestamp > from->last_timestamp) {  // prevent replay attacks
-      uint8_t reply_len = handleRequest(from->isAdmin() ? 0xFF : from->permissions, timestamp, data[4], &data[5], len - 5);
+      uint8_t reply_len;
+      bool use_static_secret = false;
+      if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {  // 4 (timestamp) + 1 (type) + 32 (ephemeral pub)
+        memcpy(reply_data, &timestamp, 4);
+        reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+        int n = acl.handleSessionKeyInit(from, &data[5], &reply_data[5], getRNG());
+        reply_len = (n > 0) ? 5 + n : 0;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      } else {
+        reply_len = handleRequest(from->isAdmin() ? 0xFF : from->permissions, timestamp, data[4], &data[5], len - 5);
+      }
       if (reply_len == 0) return;  // invalid command
 
       from->last_timestamp = timestamp;
       from->last_activity = getRTCClock()->getCurrentTime();
 
+      // Session key ACCEPT must be encrypted with static ECDH secret + static nonce,
+      // because the initiator hasn't derived the session key yet.
+      const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*from);
+      uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*from) : acl.getEncryptionNonce(*from);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*from));
+        mesh::Packet* path = createPathReturn(from->id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*from));
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, enc_key, reply_data, reply_len, enc_nonce);
         if (reply) {
           if (from->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from->out_path, from->out_path_len, SERVER_RESPONSE_DELAY);
@@ -597,8 +622,8 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-            mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.nextAeadNonceFor(*from));
+            mesh::Packet* path = createPathReturn(from->id, acl.getEncryptionKey(*from), packet->path, packet->path_len,
+                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.getEncryptionNonce(*from));
             if (path) sendFlood(path, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendAckTo(*from, ack_hash, packet->getPathHashSize());
@@ -626,7 +651,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
           temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*from));
+          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, acl.getEncryptionKey(*from), temp, 5 + text_len, acl.getEncryptionNonce(*from));
           if (reply) {
             if (from->out_path_len == OUT_PATH_UNKNOWN) {
               sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -778,6 +803,7 @@ void SensorMesh::begin(FILESYSTEM* fs) {
   region_map.load(_fs);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1015,6 +1041,7 @@ void SensorMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -256,7 +256,7 @@ void SensorMesh::sendAlert(const ClientInfo* c, Trigger* t) {
   mesh::Utils::sha256((uint8_t *)&t->expected_acks[t->attempt], 4, data, 5 + text_len, self_id.pub_key, PUB_KEY_SIZE);
   t->attempt++;
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, acl.nextAeadNonceFor(*c));
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, acl.getEncryptionKey(*c), data, 5 + text_len, acl.getEncryptionNonce(*c));
   if (pkt) {
     if (c->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
       sendDirect(pkt, c->out_path, c->out_path_len);
@@ -508,24 +508,34 @@ uint8_t SensorMesh::getPeerFlags(int peer_idx) {
 }
 
 uint16_t SensorMesh::getPeerNextAeadNonce(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients())
-    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
-  return 0;
+  return acl.peerNextAeadNonce(peer_idx, matching_peer_indexes);
 }
 
 void SensorMesh::onPeerAeadDetected(int peer_idx) {
-  int i = matching_peer_indexes[peer_idx];
-  if (i >= 0 && i < acl.getNumClients()) {
-    auto c = acl.getClientByIdx(i);
-    if (!(c->flags & CONTACT_FLAG_AEAD)) {
-      c->flags |= CONTACT_FLAG_AEAD;
-      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
-        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-        if (c->aead_nonce == 0) c->aead_nonce = 1;
-      }
+  auto* c = acl.resolveClient(peer_idx, matching_peer_indexes);
+  if (c && !(c->flags & CONTACT_FLAG_AEAD)) {
+    c->flags |= CONTACT_FLAG_AEAD;
+    if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) c->aead_nonce = 1;
     }
   }
+}
+
+const uint8_t* SensorMesh::getPeerSessionKey(int peer_idx) {
+  return acl.peerSessionKey(peer_idx, matching_peer_indexes);
+}
+const uint8_t* SensorMesh::getPeerPrevSessionKey(int peer_idx) {
+  return acl.peerPrevSessionKey(peer_idx, matching_peer_indexes);
+}
+void SensorMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  acl.peerSessionKeyDecryptSuccess(peer_idx, matching_peer_indexes);
+}
+const uint8_t* SensorMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  return acl.peerEncryptionKey(peer_idx, matching_peer_indexes, static_secret);
+}
+uint16_t SensorMesh::getPeerEncryptionNonce(int peer_idx) {
+  return acl.peerEncryptionNonce(peer_idx, matching_peer_indexes);
 }
 
 void SensorMesh::sendAckTo(const ClientInfo& dest, uint32_t ack_hash, uint8_t path_hash_size) {
@@ -559,19 +569,34 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
     memcpy(&timestamp, data, 4);
 
     if (timestamp > from->last_timestamp) {  // prevent replay attacks
-      uint8_t reply_len = handleRequest(from->isAdmin() ? 0xFF : from->permissions, timestamp, data[4], &data[5], len - 5);
+      uint8_t reply_len;
+      bool use_static_secret = false;
+      if (data[4] == REQ_TYPE_SESSION_KEY_INIT && len >= 37) {  // 4 (timestamp) + 1 (type) + 32 (ephemeral pub)
+        memcpy(reply_data, &timestamp, 4);
+        reply_data[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+        int n = acl.handleSessionKeyInit(from, &data[5], &reply_data[5], getRNG());
+        reply_len = (n > 0) ? 5 + n : 0;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      } else {
+        reply_len = handleRequest(from->isAdmin() ? 0xFF : from->permissions, timestamp, data[4], &data[5], len - 5);
+      }
       if (reply_len == 0) return;  // invalid command
 
       from->last_timestamp = timestamp;
       from->last_activity = getRTCClock()->getCurrentTime();
 
+      // Session key ACCEPT must be encrypted with static ECDH secret + static nonce,
+      // because the initiator hasn't derived the session key yet.
+      const uint8_t* enc_key = use_static_secret ? secret : acl.getEncryptionKey(*from);
+      uint16_t enc_nonce = use_static_secret ? acl.nextAeadNonceFor(*from) : acl.getEncryptionNonce(*from);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*from));
+        mesh::Packet* path = createPathReturn(from->id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, enc_nonce);
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*from));
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, enc_key, reply_data, reply_len, enc_nonce);
         if (reply) {
           if (from->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from->out_path, from->out_path_len, SERVER_RESPONSE_DELAY);
@@ -597,8 +622,8 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
 
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-            mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.nextAeadNonceFor(*from));
+            mesh::Packet* path = createPathReturn(from->id, acl.getEncryptionKey(*from), packet->path, packet->path_len,
+                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.getEncryptionNonce(*from));
             if (path) sendFlood(path, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendAckTo(*from, ack_hash, packet->getPathHashSize());
@@ -626,7 +651,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
           temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*from));
+          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, acl.getEncryptionKey(*from), temp, 5 + text_len, acl.getEncryptionNonce(*from));
           if (reply) {
             if (from->out_path_len == OUT_PATH_UNKNOWN) {
               sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -779,6 +804,7 @@ void SensorMesh::begin(FILESYSTEM* fs) {
   region_map.load(_fs);
   acl.setRNG(getRNG());
   acl.loadNonces();
+  acl.loadSessionKeys();
   bool dirty_reset = wasDirtyReset(board);
   acl.finalizeNonceLoad(dirty_reset);
   if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
@@ -1017,6 +1043,7 @@ void SensorMesh::loop() {
   // persist dirty AEAD nonces
   if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
     if (acl.isNonceDirty()) { acl.saveNonces(); }
+    if (acl.isSessionKeysDirty()) { acl.saveSessionKeys(); }
     next_nonce_persist = futureMillis(60000);
   }
 }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -256,7 +256,7 @@ void SensorMesh::sendAlert(const ClientInfo* c, Trigger* t) {
   mesh::Utils::sha256((uint8_t *)&t->expected_acks[t->attempt], 4, data, 5 + text_len, self_id.pub_key, PUB_KEY_SIZE);
   t->attempt++;
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, c->nextAeadNonce());
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, c->id, c->shared_secret, data, 5 + text_len, acl.nextAeadNonceFor(*c));
   if (pkt) {
     if (c->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
       sendDirect(pkt, c->out_path, c->out_path_len);
@@ -510,7 +510,7 @@ uint8_t SensorMesh::getPeerFlags(int peer_idx) {
 uint16_t SensorMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < acl.getNumClients())
-    return acl.getClientByIdx(i)->nextAeadNonce();
+    return acl.nextAeadNonceFor(*acl.getClientByIdx(i));
   return 0;
 }
 
@@ -520,7 +520,10 @@ void SensorMesh::onPeerAeadDetected(int peer_idx) {
     auto c = acl.getClientByIdx(i);
     if (!(c->flags & CONTACT_FLAG_AEAD)) {
       c->flags |= CONTACT_FLAG_AEAD;
-      getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+      if (c->aead_nonce == 0) {  // no persisted nonce — seed from RNG to avoid deterministic start
+        getRNG()->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+        if (c->aead_nonce == 0) c->aead_nonce = 1;
+      }
     }
   }
 }
@@ -565,10 +568,10 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, from->nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, reply_data, reply_len, acl.nextAeadNonceFor(*from));
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, from->nextAeadNonce());
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from->id, secret, reply_data, reply_len, acl.nextAeadNonceFor(*from));
         if (reply) {
           if (from->out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from->out_path, from->out_path_len, SERVER_RESPONSE_DELAY);
@@ -595,7 +598,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           if (packet->isRouteFlood()) {
             // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
             mesh::Packet* path = createPathReturn(from->id, secret, packet->path, packet->path_len,
-                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from->nextAeadNonce());
+                                                  PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, acl.nextAeadNonceFor(*from));
             if (path) sendFlood(path, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendAckTo(*from, ack_hash, packet->getPathHashSize());
@@ -623,7 +626,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
           memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
           temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, from->nextAeadNonce());
+          auto reply = createDatagram(PAYLOAD_TYPE_TXT_MSG, from->id, secret, temp, 5 + text_len, acl.nextAeadNonceFor(*from));
           if (reply) {
             if (from->out_path_len == OUT_PATH_UNKNOWN) {
               sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
@@ -730,6 +733,7 @@ SensorMesh::SensorMesh(mesh::MainBoard& board, mesh::Radio& radio, mesh::Millise
 {
   next_local_advert = next_flood_advert = 0;
   dirty_contacts_expiry = 0;
+  next_nonce_persist = 0;
   last_read_time = 0;
   num_alert_tasks = 0;
   set_radio_at = revert_radio_at = 0;
@@ -773,6 +777,12 @@ void SensorMesh::begin(FILESYSTEM* fs) {
 
   acl.load(_fs, self_id);
   region_map.load(_fs);
+  acl.setRNG(getRNG());
+  acl.loadNonces();
+  bool dirty_reset = wasDirtyReset(board);
+  acl.finalizeNonceLoad(dirty_reset);
+  if (dirty_reset) acl.saveNonces();  // persist bumped nonces immediately
+  next_nonce_persist = futureMillis(60000);
 
   // establish default-scope
   {
@@ -1002,5 +1012,11 @@ void SensorMesh::loop() {
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
     acl.save(_fs);
     dirty_contacts_expiry = 0;
+  }
+
+  // persist dirty AEAD nonces
+  if (next_nonce_persist && millisHasNowPassed(next_nonce_persist)) {
+    if (acl.isNonceDirty()) { acl.saveNonces(); }
+    next_nonce_persist = futureMillis(60000);
   }
 }

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -60,6 +60,9 @@ public:
   const char* getNodeName() { return _prefs.node_name; }
   NodePrefs* getNodePrefs() { return &_prefs; }
   void savePrefs() override { _cli.savePrefs(_fs); }
+  void onBeforeReboot() override {
+    if (acl.isNonceDirty()) acl.saveNonces();
+  }
   bool formatFileSystem() override;
   void sendSelfAdvertisement(int delay_millis, bool flood) override;
   void updateAdvertTimer() override;
@@ -142,6 +145,7 @@ private:
   CommonCLI _cli;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   unsigned long dirty_contacts_expiry;
+  unsigned long next_nonce_persist;
   CayenneLPP telemetry;
   TransportKeyStore key_store;
   RegionMap region_map;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -131,6 +131,11 @@ protected:
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerAeadDetected(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onControlDataRecv(mesh::Packet* packet) override;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -125,6 +125,9 @@ protected:
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  void onPeerAeadDetected(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onControlDataRecv(mesh::Packet* packet) override;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -156,15 +156,16 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
             uint8_t data[MAX_PACKET_PAYLOAD];
             int macAndDataLen = pkt->payload_len - i;
 
-            // Try ECB first (Phase 1: all senders use ECB), then AEAD-4 fallback.
-            // IMPORTANT: Phase 2 MUST swap to AEAD-first. ECB-first has a 1/65536
-            // false-positive rate on AEAD packets (nonce bytes matching truncated HMAC),
-            // producing garbage plaintext. AEAD-first has only 1/2^32 false-positive on
-            // ECB packets, which is negligible.
-            int len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
-            if (len <= 0) {
-              uint8_t assoc[3] = { pkt->header, dest_hash, src_hash };
+            // Try-both decode: AEAD-first for peers known to support it (avoids 1/65536
+            // ECB false-positive on AEAD packets), ECB-first for unknown/legacy peers.
+            uint8_t assoc[3] = { pkt->header, dest_hash, src_hash };
+            int len;
+            if (getPeerFlags(j) & CONTACT_FLAG_AEAD) {
               len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+              if (len <= 0) len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+            } else {
+              len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+              if (len <= 0) len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
             }
             if (len > 0) {  // success!
               if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH) {
@@ -183,7 +184,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
                 if (onPeerPathRecv(pkt, j, secret, path, path_len, extra_type, extra, extra_len)) {
                   if (pkt->isRouteFlood()) {
                     // send a reciprocal return path to sender, but send DIRECTLY!
-                    mesh::Packet* rpath = createPathReturn(&src_hash, secret, pkt->path, pkt->path_len, 0, NULL, 0);
+                    mesh::Packet* rpath = createPathReturn(&src_hash, secret, pkt->path, pkt->path_len, 0, NULL, 0, getPeerNextAeadNonce(j));
                     if (rpath) sendDirect(rpath, path, path_len, 500);
                   }
                 }
@@ -466,13 +467,13 @@ Packet* Mesh::createAdvert(const LocalIdentity& id, const uint8_t* app_data, siz
 
 #define MAX_COMBINED_PATH  (MAX_PACKET_PAYLOAD - 2 - CIPHER_BLOCK_SIZE)
 
-Packet* Mesh::createPathReturn(const Identity& dest, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len) {
+Packet* Mesh::createPathReturn(const Identity& dest, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len, uint16_t aead_nonce) {
   uint8_t dest_hash[PATH_HASH_SIZE];
   dest.copyHashTo(dest_hash);
-  return createPathReturn(dest_hash, secret, path, path_len, extra_type, extra, extra_len);
+  return createPathReturn(dest_hash, secret, path, path_len, extra_type, extra, extra_len, aead_nonce);
 }
 
-Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len) {
+Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len, uint16_t aead_nonce) {
   uint8_t path_hash_size = (path_len >> 6) + 1;
   uint8_t path_hash_count = path_len & 63;
 
@@ -504,7 +505,14 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
       getRNG()->random(&data[data_len], 4); data_len += 4;
     }
 
-    len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
+    if (aead_nonce) {
+      uint8_t dh = packet->payload[0];
+      uint8_t sh = packet->payload[1];
+      uint8_t assoc[3] = { packet->header, dh, sh };
+      len += Utils::aeadEncrypt(secret, &packet->payload[len], data, data_len, assoc, 3, aead_nonce, dh, sh);
+    } else {
+      len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
+    }
   }
 
   packet->payload_len = len;
@@ -512,9 +520,10 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
   return packet;
 }
 
-Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len) {
+Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len, uint16_t aead_nonce) {
   if (type == PAYLOAD_TYPE_TXT_MSG || type == PAYLOAD_TYPE_REQ || type == PAYLOAD_TYPE_RESPONSE) {
-    if (data_len + CIPHER_MAC_SIZE + CIPHER_BLOCK_SIZE-1 > MAX_PACKET_PAYLOAD) return NULL;
+    size_t max_overhead = aead_nonce ? (AEAD_NONCE_SIZE + AEAD_TAG_SIZE) : (CIPHER_MAC_SIZE + CIPHER_BLOCK_SIZE-1);
+    if (data_len + max_overhead > MAX_PACKET_PAYLOAD) return NULL;
   } else {
     return NULL;  // invalid type
   }
@@ -529,7 +538,15 @@ Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* 
   int len = 0;
   len += dest.copyHashTo(&packet->payload[len]);  // dest hash
   len += self_id.copyHashTo(&packet->payload[len]);  // src hash
-  len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
+
+  if (aead_nonce) {
+    uint8_t dest_hash = packet->payload[0];
+    uint8_t src_hash = packet->payload[1];
+    uint8_t assoc[3] = { packet->header, dest_hash, src_hash };
+    len += Utils::aeadEncrypt(secret, &packet->payload[len], data, data_len, assoc, 3, aead_nonce, dest_hash, src_hash);
+  } else {
+    len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
+  }
 
   packet->payload_len = len;
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -531,7 +531,8 @@ Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* 
   if (type == PAYLOAD_TYPE_TXT_MSG || type == PAYLOAD_TYPE_REQ || type == PAYLOAD_TYPE_RESPONSE) {
     size_t hash_prefix = PATH_HASH_SIZE * 2;  // dest_hash + src_hash
     size_t max_overhead = aead_nonce ? (AEAD_NONCE_SIZE + AEAD_TAG_SIZE) : (CIPHER_MAC_SIZE + CIPHER_BLOCK_SIZE-1);
-    if (data_len + hash_prefix + max_overhead > MAX_PACKET_PAYLOAD) return NULL;
+    size_t max_payload_data = MAX_PACKET_PAYLOAD - hash_prefix - max_overhead;
+    if (data_len > max_payload_data) return NULL;
   } else {
     return NULL;  // invalid type
   }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -156,17 +156,46 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
             uint8_t data[MAX_PACKET_PAYLOAD];
             int macAndDataLen = pkt->payload_len - i;
 
-            // Try-both decode: AEAD-first for peers known to support it (avoids 1/65536
-            // ECB false-positive on AEAD packets), ECB-first for unknown/legacy peers.
             // Mask out route type bits — they are set after encryption and vary per hop.
             uint8_t assoc[3] = { (uint8_t)(pkt->header & ~PH_ROUTE_MASK), dest_hash, src_hash };
-            int len;
+            int len = 0;
             bool decoded_aead = false;
-            if (getPeerFlags(j) & CONTACT_FLAG_AEAD) {
+            bool decoded_session = false;
+
+            // Session key decode path: try session key(s) first if available
+            const uint8_t* sess_key = getPeerSessionKey(j);
+            if (sess_key) {
+              len = Utils::aeadDecrypt(sess_key, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+              if (len > 0) {
+                decoded_session = true;
+                decoded_aead = true;
+              } else {
+                // Try prev_session_key (dual-decode window)
+                const uint8_t* prev_key = getPeerPrevSessionKey(j);
+                if (prev_key) {
+                  len = Utils::aeadDecrypt(prev_key, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+                  if (len > 0) {
+                    decoded_session = true;
+                    decoded_aead = true;
+                  }
+                }
+              }
+              if (!decoded_session) {
+                // Session key failed — try static ECDH, then ECB
+                len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+                if (len > 0) {
+                  decoded_aead = true;
+                } else {
+                  len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+                }
+              }
+            } else if (getPeerFlags(j) & CONTACT_FLAG_AEAD) {
+              // No session key — standard AEAD-first decode for AEAD-capable peers
               len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
               if (len > 0) decoded_aead = true;
               else len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
             } else {
+              // Legacy ECB-first decode
               len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
               if (len <= 0) {
                 len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
@@ -174,7 +203,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
               }
             }
             if (len > 0) {  // success!
-              if (decoded_aead) onPeerAeadDetected(j);
+              if (decoded_session) onSessionKeyDecryptSuccess(j);
+              else if (decoded_aead) onPeerAeadDetected(j);
               if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH) {
                 int k = 0;
                 uint8_t path_len = data[k++];
@@ -191,12 +221,12 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
                 if (onPeerPathRecv(pkt, j, secret, path, path_len, extra_type, extra, extra_len)) {
                   if (pkt->isRouteFlood()) {
                     // send a reciprocal return path to sender, but send DIRECTLY!
-                    mesh::Packet* rpath = createPathReturn(&src_hash, secret, pkt->path, pkt->path_len, 0, NULL, 0, getPeerNextAeadNonce(j));
+                    mesh::Packet* rpath = createPathReturn(&src_hash, getPeerEncryptionKey(j, secret), pkt->path, pkt->path_len, 0, NULL, 0, getPeerEncryptionNonce(j));
                     if (rpath) sendDirect(rpath, path, path_len, 500);
                   }
                 }
               } else {
-                onPeerDataRecv(pkt, pkt->getPayloadType(), j, secret, data, len);
+                onPeerDataRecv(pkt, pkt->getPayloadType(), j, getPeerEncryptionKey(j, secret), data, len);
               }
               found = true;
               break;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -502,8 +502,6 @@ Packet* Mesh::createAdvert(const LocalIdentity& id, const uint8_t* app_data, siz
   return packet;
 }
 
-#define MAX_COMBINED_PATH  (MAX_PACKET_PAYLOAD - 2 - CIPHER_BLOCK_SIZE)
-
 Packet* Mesh::createPathReturn(const Identity& dest, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len, uint16_t aead_nonce) {
   uint8_t dest_hash[PATH_HASH_SIZE];
   dest.copyHashTo(dest_hash);
@@ -514,7 +512,9 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
   uint8_t path_hash_size = (path_len >> 6) + 1;
   uint8_t path_hash_count = path_len & 63;
 
-  if (path_hash_count*path_hash_size + extra_len + 5 > MAX_COMBINED_PATH) return NULL;  // too long!!
+  size_t max_overhead = aead_nonce ? (AEAD_NONCE_SIZE + AEAD_TAG_SIZE) : (CIPHER_MAC_SIZE + CIPHER_BLOCK_SIZE-1);
+  size_t max_combined_path = MAX_PACKET_PAYLOAD - PATH_HASH_SIZE * 2 - max_overhead;
+  if (path_hash_count*path_hash_size + extra_len + 5 > max_combined_path) return NULL;  // too long!!
 
   Packet* packet = obtainNewPacket();
   if (packet == NULL) {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -158,16 +158,23 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
 
             // Try-both decode: AEAD-first for peers known to support it (avoids 1/65536
             // ECB false-positive on AEAD packets), ECB-first for unknown/legacy peers.
-            uint8_t assoc[3] = { pkt->header, dest_hash, src_hash };
+            // Mask out route type bits — they are set after encryption and vary per hop.
+            uint8_t assoc[3] = { (uint8_t)(pkt->header & ~PH_ROUTE_MASK), dest_hash, src_hash };
             int len;
+            bool decoded_aead = false;
             if (getPeerFlags(j) & CONTACT_FLAG_AEAD) {
               len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
-              if (len <= 0) len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+              if (len > 0) decoded_aead = true;
+              else len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
             } else {
               len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
-              if (len <= 0) len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+              if (len <= 0) {
+                len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+                if (len > 0) decoded_aead = true;
+              }
             }
             if (len > 0) {  // success!
+              if (decoded_aead) onPeerAeadDetected(j);
               if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH) {
                 int k = 0;
                 uint8_t path_len = data[k++];
@@ -228,7 +235,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           // Phase 2 MUST swap to AEAD-first (see peer message comment above).
           int len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
           if (len <= 0) {
-            uint8_t assoc[2] = { pkt->header, dest_hash };
+            uint8_t assoc[2] = { (uint8_t)(pkt->header & ~PH_ROUTE_MASK), dest_hash };
             len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 2, dest_hash, 0);
           }
           if (len > 0) {  // success!
@@ -265,7 +272,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           // worthwhile for public/hashtag channels where the PSK is already widely known.
           int len = Utils::MACThenDecrypt(channels[j].secret, data, macAndData, macAndDataLen);
           if (len <= 0) {
-            uint8_t assoc[2] = { pkt->header, channel_hash };
+            uint8_t assoc[2] = { (uint8_t)(pkt->header & ~PH_ROUTE_MASK), channel_hash };
             len = Utils::aeadDecrypt(channels[j].secret, data, macAndData, macAndDataLen, assoc, 2, channel_hash, 0);
           }
           if (len > 0) {  // success!
@@ -508,7 +515,7 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
     if (aead_nonce) {
       uint8_t dh = packet->payload[0];
       uint8_t sh = packet->payload[1];
-      uint8_t assoc[3] = { packet->header, dh, sh };
+      uint8_t assoc[3] = { (uint8_t)(packet->header & ~PH_ROUTE_MASK), dh, sh };
       len += Utils::aeadEncrypt(secret, &packet->payload[len], data, data_len, assoc, 3, aead_nonce, dh, sh);
     } else {
       len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
@@ -543,7 +550,7 @@ Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* 
   if (aead_nonce) {
     uint8_t dest_hash = packet->payload[0];
     uint8_t src_hash = packet->payload[1];
-    uint8_t assoc[3] = { packet->header, dest_hash, src_hash };
+    uint8_t assoc[3] = { (uint8_t)(packet->header & ~PH_ROUTE_MASK), dest_hash, src_hash };
     len += Utils::aeadEncrypt(secret, &packet->payload[len], data, data_len, assoc, 3, aead_nonce, dest_hash, src_hash);
   } else {
     len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -153,9 +153,19 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
             uint8_t secret[PUB_KEY_SIZE];
             getPeerSharedSecret(secret, j);
 
-            // decrypt, checking MAC is valid
             uint8_t data[MAX_PACKET_PAYLOAD];
-            int len = Utils::MACThenDecrypt(secret, data, macAndData, pkt->payload_len - i);
+            int macAndDataLen = pkt->payload_len - i;
+
+            // Try ECB first (Phase 1: all senders use ECB), then AEAD-4 fallback.
+            // IMPORTANT: Phase 2 MUST swap to AEAD-first. ECB-first has a 1/65536
+            // false-positive rate on AEAD packets (nonce bytes matching truncated HMAC),
+            // producing garbage plaintext. AEAD-first has only 1/2^32 false-positive on
+            // ECB packets, which is negligible.
+            int len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+            if (len <= 0) {
+              uint8_t assoc[3] = { pkt->header, dest_hash, src_hash };
+              len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 3, dest_hash, src_hash);
+            }
             if (len > 0) {  // success!
               if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH) {
                 int k = 0;
@@ -210,9 +220,16 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           uint8_t secret[PUB_KEY_SIZE];
           self_id.calcSharedSecret(secret, sender);
 
-          // decrypt, checking MAC is valid
           uint8_t data[MAX_PACKET_PAYLOAD];
-          int len = Utils::MACThenDecrypt(secret, data, macAndData, pkt->payload_len - i);
+          int macAndDataLen = pkt->payload_len - i;
+
+          // Try ECB first (Phase 1), then AEAD-4 fallback.
+          // Phase 2 MUST swap to AEAD-first (see peer message comment above).
+          int len = Utils::MACThenDecrypt(secret, data, macAndData, macAndDataLen);
+          if (len <= 0) {
+            uint8_t assoc[2] = { pkt->header, dest_hash };
+            len = Utils::aeadDecrypt(secret, data, macAndData, macAndDataLen, assoc, 2, dest_hash, 0);
+          }
           if (len > 0) {  // success!
             onAnonDataRecv(pkt, secret, sender, data, len);
             pkt->markDoNotRetransmit();
@@ -237,9 +254,19 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         int num = searchChannelsByHash(&channel_hash, channels, 4);
         // for each matching channel, try to decrypt data
         for (int j = 0; j < num; j++) {
-          // decrypt, checking MAC is valid
           uint8_t data[MAX_PACKET_PAYLOAD];
-          int len = Utils::MACThenDecrypt(channels[j].secret, data, macAndData, pkt->payload_len - i);
+          int macAndDataLen = pkt->payload_len - i;
+
+          // Try ECB first (Phase 1), then AEAD-4 fallback.
+          // Phase 2 MUST swap to AEAD-first (see peer message comment above).
+          // Note: group channels share a key, so nonce collisions across senders can leak
+          // P1 XOR P2 for colliding message pairs (no key recovery). Bounded risk, mainly
+          // worthwhile for public/hashtag channels where the PSK is already widely known.
+          int len = Utils::MACThenDecrypt(channels[j].secret, data, macAndData, macAndDataLen);
+          if (len <= 0) {
+            uint8_t assoc[2] = { pkt->header, channel_hash };
+            len = Utils::aeadDecrypt(channels[j].secret, data, macAndData, macAndDataLen, assoc, 2, channel_hash, 0);
+          }
           if (len > 0) {  // success!
             onGroupDataRecv(pkt, pkt->getPayloadType(), channels[j], data, len);
             break;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -522,8 +522,9 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
 
 Packet* Mesh::createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len, uint16_t aead_nonce) {
   if (type == PAYLOAD_TYPE_TXT_MSG || type == PAYLOAD_TYPE_REQ || type == PAYLOAD_TYPE_RESPONSE) {
+    size_t hash_prefix = PATH_HASH_SIZE * 2;  // dest_hash + src_hash
     size_t max_overhead = aead_nonce ? (AEAD_NONCE_SIZE + AEAD_TAG_SIZE) : (CIPHER_MAC_SIZE + CIPHER_BLOCK_SIZE-1);
-    if (data_len + max_overhead > MAX_PACKET_PAYLOAD) return NULL;
+    if (data_len + hash_prefix + max_overhead > MAX_PACKET_PAYLOAD) return NULL;
   } else {
     return NULL;  // invalid type
   }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -145,7 +145,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         // FUTURE: could send back multiple paths, using createPathReturn(), and let sender choose which to use(?)
 
         if (self_id.isHashMatch(&dest_hash)) {
-          // scan contacts DB, for all matching hashes of 'src_hash' (max 4 matches supported ATM)
+          // scan contacts DB, for all matching hashes of 'src_hash' (max 8 matches supported ATM)
           int num = searchPeersByHash(&src_hash);
           // for each matching contact, try to decrypt data
           bool found = false;

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -83,6 +83,8 @@ protected:
    * \param  peer_idx  index of peer, [0..n) where n is what searchPeersByHash() returned
    */
   virtual void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) { }
+  virtual uint8_t getPeerFlags(int peer_idx) { return 0; }
+  virtual uint16_t getPeerNextAeadNonce(int peer_idx) { return 0; }
 
   /**
    * \brief  A (now decrypted) data packet has been received (by a known peer).
@@ -183,15 +185,15 @@ public:
   RTCClock* getRTCClock() const { return _rtc; }
 
   Packet* createAdvert(const LocalIdentity& id, const uint8_t* app_data=NULL, size_t app_data_len=0);
-  Packet* createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t len);
+  Packet* createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t len, uint16_t aead_nonce=0);
   Packet* createAnonDatagram(uint8_t type, const LocalIdentity& sender, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len);
   Packet* createGroupDatagram(uint8_t type, const GroupChannel& channel, const uint8_t* data, size_t data_len);
   Packet* createAck(const uint8_t* ack, uint8_t len);
   Packet* createAck(uint32_t ack_crc) { return createAck((uint8_t *) &ack_crc, 4); }
   Packet* createMultiAck(const uint8_t* ack, uint8_t len, uint8_t remaining);
   Packet* createMultiAck(uint32_t ack_crc, uint8_t remaining) { return createMultiAck((uint8_t *)&ack_crc, 4, remaining); }
-  Packet* createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len);
-  Packet* createPathReturn(const Identity& dest, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len);
+  Packet* createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len, uint16_t aead_nonce=0);
+  Packet* createPathReturn(const Identity& dest, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len, uint16_t aead_nonce=0);
   Packet* createRawData(const uint8_t* data, size_t len);
   Packet* createTrace(uint32_t tag, uint32_t auth_code, uint8_t flags = 0);
   Packet* createControlData(const uint8_t* data, size_t len);

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -85,6 +85,7 @@ protected:
   virtual void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) { }
   virtual uint8_t getPeerFlags(int peer_idx) { return 0; }
   virtual uint16_t getPeerNextAeadNonce(int peer_idx) { return 0; }
+  virtual void onPeerAeadDetected(int peer_idx) { }
 
   /**
    * \brief  A (now decrypted) data packet has been received (by a known peer).

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -87,6 +87,14 @@ protected:
   virtual uint16_t getPeerNextAeadNonce(int peer_idx) { return 0; }
   virtual void onPeerAeadDetected(int peer_idx) { }
 
+  // Session key support (Phase 2)
+  virtual const uint8_t* getPeerSessionKey(int peer_idx) { return NULL; }
+  virtual const uint8_t* getPeerPrevSessionKey(int peer_idx) { return NULL; }
+  virtual void onSessionKeyDecryptSuccess(int peer_idx) { }
+  // Encryption key/nonce for outgoing messages to peer (session key with static ECDH fallback)
+  virtual const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) { return static_secret; }
+  virtual uint16_t getPeerEncryptionNonce(int peer_idx) { return getPeerNextAeadNonce(peer_idx); }
+
   /**
    * \brief  A (now decrypted) data packet has been received (by a known peer).
    *         NOTE: these can be received multiple times (per sender/msg-id), via different routes

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -17,6 +17,12 @@
 #define CIPHER_MAC_SIZE      2
 #define PATH_HASH_SIZE       1
 
+// AEAD-4 (ChaChaPoly) encryption
+#define AEAD_TAG_SIZE        4
+#define AEAD_NONCE_SIZE      2
+#define CONTACT_FLAG_AEAD    0x02   // bit 1 of ContactInfo.flags (bit 0 = favourite)
+#define FEAT1_AEAD_SUPPORT   0x0001 // bit 0 of feat1 uint16_t
+
 #define MAX_PACKET_PAYLOAD  184
 #define MAX_GROUP_DATA_LENGTH  (MAX_PACKET_PAYLOAD - CIPHER_BLOCK_SIZE - 3)
 #define MAX_PATH_SIZE        64

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -10,6 +10,7 @@
 #define SEED_SIZE           32
 #define SIGNATURE_SIZE      64
 #define MAX_ADVERT_DATA_SIZE  32
+#define SESSION_KEY_SIZE    32
 #define CIPHER_KEY_SIZE     16
 #define CIPHER_BLOCK_SIZE   16
 
@@ -25,7 +26,21 @@
 
 // AEAD nonce persistence
 #define NONCE_PERSIST_INTERVAL  50   // persist every N messages per peer
-#define NONCE_BOOT_BUMP         100  // add this on load after dirty boot (must be >= 2 * PERSIST_INTERVAL)
+#define NONCE_BOOT_BUMP         50   // add this on load after dirty boot (must be >= PERSIST_INTERVAL)
+
+// Session key negotiation (Phase 2)
+#define REQ_TYPE_SESSION_KEY_INIT   0x08
+#define RESP_TYPE_SESSION_KEY_ACCEPT 0x08  // response type byte in PAYLOAD_TYPE_RESPONSE
+
+#define NONCE_REKEY_THRESHOLD       60000  // start renegotiation when nonce exceeds this
+#define NONCE_INITIAL_MIN           1000   // min random nonce seed for new contacts
+#define NONCE_INITIAL_MAX           50000  // max random nonce seed for new contacts
+#define SESSION_KEY_TIMEOUT_MS      180000 // 3 minutes per attempt
+#define SESSION_KEY_MAX_RETRIES     3      // attempts per negotiation round
+#define MAX_SESSION_KEYS            8      // max concurrent session key entries
+#define SESSION_KEY_STALE_THRESHOLD 50     // sends without recv before fallback to static ECDH
+#define SESSION_KEY_ECB_THRESHOLD  100    // sends without recv before fallback to ECB
+#define SESSION_KEY_ABANDON_THRESHOLD 255 // sends without recv before clearing AEAD + session key
 
 #define MAX_PACKET_PAYLOAD  184
 #define MAX_GROUP_DATA_LENGTH  (MAX_PACKET_PAYLOAD - CIPHER_BLOCK_SIZE - 3)

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -37,7 +37,11 @@
 #define NONCE_INITIAL_MAX           50000  // max random nonce seed for new contacts
 #define SESSION_KEY_TIMEOUT_MS      180000 // 3 minutes per attempt
 #define SESSION_KEY_MAX_RETRIES     3      // attempts per negotiation round
-#define MAX_SESSION_KEYS            8      // max concurrent session key entries
+#define MAX_SESSION_KEYS_RAM        8      // max concurrent session key entries in RAM (LRU cache)
+#define MAX_SESSION_KEYS_FLASH     48     // max entries in flash file
+#define SESSION_KEY_RECORD_SIZE    71     // max bytes per record (with prev_key)
+#define SESSION_KEY_RECORD_MIN_SIZE 39   // min bytes per record: [pub_prefix:4][flags:1][nonce:2][key:32]
+#define SESSION_FLAG_PREV_VALID   0x01   // prev_session_key is valid for dual-decode
 #define SESSION_KEY_STALE_THRESHOLD 50     // sends without recv before fallback to static ECDH
 #define SESSION_KEY_ECB_THRESHOLD  100    // sends without recv before fallback to ECB
 #define SESSION_KEY_ABANDON_THRESHOLD 255 // sends without recv before clearing AEAD + session key

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -21,7 +21,7 @@
 // AEAD-4 (ChaChaPoly) encryption
 #define AEAD_TAG_SIZE        4
 #define AEAD_NONCE_SIZE      2
-#define CONTACT_FLAG_AEAD    0x02   // bit 1 of ContactInfo.flags (bit 0 = favourite)
+#define CONTACT_FLAG_AEAD    0x80   // bit 7 of ContactInfo.flags (bit 0 = favourite, bits 1-3 = telemetry perms)
 #define FEAT1_AEAD_SUPPORT   0x0001 // bit 0 of feat1 uint16_t
 
 // AEAD nonce persistence

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -23,6 +23,10 @@
 #define CONTACT_FLAG_AEAD    0x02   // bit 1 of ContactInfo.flags (bit 0 = favourite)
 #define FEAT1_AEAD_SUPPORT   0x0001 // bit 0 of feat1 uint16_t
 
+// AEAD nonce persistence
+#define NONCE_PERSIST_INTERVAL  50   // persist every N messages per peer
+#define NONCE_BOOT_BUMP         100  // add this on load after dirty boot (must be >= 2 * PERSIST_INTERVAL)
+
 #define MAX_PACKET_PAYLOAD  184
 #define MAX_GROUP_DATA_LENGTH  (MAX_PACKET_PAYLOAD - CIPHER_BLOCK_SIZE - 3)
 #define MAX_PATH_SIZE        64

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -181,7 +181,9 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
   if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
-  return 0; // invalid HMAC
+  // No need to zero dest on failure — MAC is checked before decryption,
+  // so dest is never written to when authentication fails.
+  return 0;
 }
 
 /*

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,6 +1,7 @@
 #include "Utils.h"
 #include <AES.h>
 #include <SHA256.h>
+#include <ChaChaPoly.h>
 
 #ifdef USE_CC310_HW_CRYPTO
 #include <Adafruit_nRFCrypto.h>
@@ -181,6 +182,120 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC
+}
+
+/*
+ * AEAD-4: ChaCha20-Poly1305 authenticated encryption with 4-byte tag.
+ *
+ * Wire format (replaces ECB's [HMAC:2][ciphertext:N*16]):
+ *   [nonce:2] [ciphertext:M] [tag:4]       (M = exact plaintext length)
+ *
+ * Key derivation (per-message, eliminates nonce-reuse catastrophe):
+ *   msg_key[32] = HMAC-SHA256(shared_secret[32], nonce_hi || nonce_lo || dest_hash || src_hash)
+ *   Including hashes makes keys direction-dependent: Alice->Bob and Bob->Alice derive
+ *   different keys even with the same nonce (for 255/256 peer pairs; the 1/256 where
+ *   dest_hash == src_hash remains a residual risk inherent to 1-byte hashes).
+ *
+ * IV construction (12 bytes, from on-wire fields):
+ *   iv[12] = { nonce_hi, nonce_lo, dest_hash, src_hash, 0, 0, 0, 0, 0, 0, 0, 0 }
+ *
+ * Associated data (authenticated but not encrypted):
+ *   Peer msgs:  header || dest_hash || src_hash
+ *   Anon reqs:  header || dest_hash
+ *   Group msgs: header || channel_hash
+ *
+ * Nonce: 16-bit counter per peer, seeded from HW RNG on boot. With per-message
+ * key derivation, even a nonce collision (across reboots) only leaks P1 XOR P2
+ * for that message pair — no key recovery, no impact on other messages.
+ *
+ * Group channels: all members share the same key, so cross-sender nonce
+ * collisions are possible (~300 msgs for 50% chance with random nonces).
+ * Damage is bounded (message pair leak, no key recovery).
+ */
+int Utils::aeadEncrypt(const uint8_t* shared_secret,
+                       uint8_t* dest,
+                       const uint8_t* src, int src_len,
+                       const uint8_t* assoc_data, int assoc_len,
+                       uint16_t nonce_counter,
+                       uint8_t dest_hash, uint8_t src_hash) {
+  if (src_len <= 0) return 0;
+
+  // Write nonce to output
+  dest[0] = (uint8_t)(nonce_counter >> 8);
+  dest[1] = (uint8_t)(nonce_counter & 0xFF);
+
+  // Derive per-message key: HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash)
+  // Including hashes makes the key direction-dependent, preventing keystream reuse
+  // when Alice->Bob and Bob->Alice use the same nonce (255/256 peer pairs).
+  uint8_t msg_key[32];
+  {
+    uint8_t kdf_input[AEAD_NONCE_SIZE + 2] = { dest[0], dest[1], dest_hash, src_hash };
+    SHA256 sha;
+    sha.resetHMAC(shared_secret, PUB_KEY_SIZE);
+    sha.update(kdf_input, sizeof(kdf_input));
+    sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, msg_key, 32);
+  }
+
+  // Build 12-byte IV from on-wire fields
+  uint8_t iv[12];
+  iv[0] = dest[0];  // nonce_hi
+  iv[1] = dest[1];  // nonce_lo
+  iv[2] = dest_hash;
+  iv[3] = src_hash;
+  memset(&iv[4], 0, 8);
+
+  ChaChaPoly cipher;
+  cipher.setKey(msg_key, 32);
+  cipher.setIV(iv, 12);
+  cipher.addAuthData(assoc_data, assoc_len);
+  cipher.encrypt(dest + AEAD_NONCE_SIZE, src, src_len);
+  cipher.computeTag(dest + AEAD_NONCE_SIZE + src_len, AEAD_TAG_SIZE);
+  cipher.clear();
+  memset(msg_key, 0, 32);
+
+  return AEAD_NONCE_SIZE + src_len + AEAD_TAG_SIZE;
+}
+
+int Utils::aeadDecrypt(const uint8_t* shared_secret,
+                       uint8_t* dest,
+                       const uint8_t* src, int src_len,
+                       const uint8_t* assoc_data, int assoc_len,
+                       uint8_t dest_hash, uint8_t src_hash) {
+  // Minimum: nonce(2) + at least 1 byte ciphertext + tag(4)
+  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE) return 0;
+
+  int ct_len = src_len - AEAD_NONCE_SIZE - AEAD_TAG_SIZE;
+
+  // Derive per-message key: HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash)
+  uint8_t msg_key[32];
+  {
+    uint8_t kdf_input[AEAD_NONCE_SIZE + 2] = { src[0], src[1], dest_hash, src_hash };
+    SHA256 sha;
+    sha.resetHMAC(shared_secret, PUB_KEY_SIZE);
+    sha.update(kdf_input, sizeof(kdf_input));
+    sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, msg_key, 32);
+  }
+
+  // Build 12-byte IV from on-wire fields
+  uint8_t iv[12];
+  iv[0] = src[0];  // nonce_hi
+  iv[1] = src[1];  // nonce_lo
+  iv[2] = dest_hash;
+  iv[3] = src_hash;
+  memset(&iv[4], 0, 8);
+
+  ChaChaPoly cipher;
+  cipher.setKey(msg_key, 32);
+  cipher.setIV(iv, 12);
+  cipher.addAuthData(assoc_data, assoc_len);
+  cipher.decrypt(dest, src + AEAD_NONCE_SIZE, ct_len);
+
+  bool valid = cipher.checkTag(src + AEAD_NONCE_SIZE + ct_len, AEAD_TAG_SIZE);
+  cipher.clear();
+  memset(msg_key, 0, 32);
+  if (!valid) memset(dest, 0, ct_len);
+
+  return valid ? ct_len : 0;
 }
 
 static const char hex_chars[] = "0123456789ABCDEF";

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -218,7 +218,8 @@ int Utils::aeadEncrypt(const uint8_t* shared_secret,
                        const uint8_t* assoc_data, int assoc_len,
                        uint16_t nonce_counter,
                        uint8_t dest_hash, uint8_t src_hash) {
-  if (src_len <= 0) return 0;
+  if (src_len <= 0 || src_len > MAX_PACKET_PAYLOAD) return 0;
+  if (assoc_len < 0 || assoc_len > MAX_PACKET_PAYLOAD) return 0;
 
   // Write nonce to output
   dest[0] = (uint8_t)(nonce_counter >> 8);
@@ -262,7 +263,8 @@ int Utils::aeadDecrypt(const uint8_t* shared_secret,
                        const uint8_t* assoc_data, int assoc_len,
                        uint8_t dest_hash, uint8_t src_hash) {
   // Minimum: nonce(2) + at least 1 byte ciphertext + tag(4)
-  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE) return 0;
+  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE || src_len > MAX_PACKET_PAYLOAD) return 0;
+  if (assoc_len < 0 || assoc_len > MAX_PACKET_PAYLOAD) return 0;
 
   int ct_len = src_len - AEAD_NONCE_SIZE - AEAD_TAG_SIZE;
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -206,7 +206,8 @@ int Utils::aeadEncrypt(const uint8_t* shared_secret,
                        const uint8_t* assoc_data, int assoc_len,
                        uint16_t nonce_counter,
                        uint8_t dest_hash, uint8_t src_hash) {
-  if (src_len <= 0) return 0;
+  if (src_len <= 0 || src_len > MAX_PACKET_PAYLOAD) return 0;
+  if (assoc_len < 0 || assoc_len > MAX_PACKET_PAYLOAD) return 0;
 
   // Write nonce to output
   dest[0] = (uint8_t)(nonce_counter >> 8);
@@ -250,7 +251,8 @@ int Utils::aeadDecrypt(const uint8_t* shared_secret,
                        const uint8_t* assoc_data, int assoc_len,
                        uint8_t dest_hash, uint8_t src_hash) {
   // Minimum: nonce(2) + at least 1 byte ciphertext + tag(4)
-  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE) return 0;
+  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE || src_len > MAX_PACKET_PAYLOAD) return 0;
+  if (assoc_len < 0 || assoc_len > MAX_PACKET_PAYLOAD) return 0;
 
   int ct_len = src_len - AEAD_NONCE_SIZE - AEAD_TAG_SIZE;
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -169,7 +169,9 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
   if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
-  return 0; // invalid HMAC
+  // No need to zero dest on failure — MAC is checked before decryption,
+  // so dest is never written to when authentication fails.
+  return 0;
 }
 
 /*

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,6 +1,7 @@
 #include "Utils.h"
 #include <AES.h>
 #include <SHA256.h>
+#include <ChaChaPoly.h>
 
 #ifdef USE_CC310_HW_CRYPTO
 #include <Adafruit_nRFCrypto.h>
@@ -169,6 +170,120 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC
+}
+
+/*
+ * AEAD-4: ChaCha20-Poly1305 authenticated encryption with 4-byte tag.
+ *
+ * Wire format (replaces ECB's [HMAC:2][ciphertext:N*16]):
+ *   [nonce:2] [ciphertext:M] [tag:4]       (M = exact plaintext length)
+ *
+ * Key derivation (per-message, eliminates nonce-reuse catastrophe):
+ *   msg_key[32] = HMAC-SHA256(shared_secret[32], nonce_hi || nonce_lo || dest_hash || src_hash)
+ *   Including hashes makes keys direction-dependent: Alice->Bob and Bob->Alice derive
+ *   different keys even with the same nonce (for 255/256 peer pairs; the 1/256 where
+ *   dest_hash == src_hash remains a residual risk inherent to 1-byte hashes).
+ *
+ * IV construction (12 bytes, from on-wire fields):
+ *   iv[12] = { nonce_hi, nonce_lo, dest_hash, src_hash, 0, 0, 0, 0, 0, 0, 0, 0 }
+ *
+ * Associated data (authenticated but not encrypted):
+ *   Peer msgs:  header || dest_hash || src_hash
+ *   Anon reqs:  header || dest_hash
+ *   Group msgs: header || channel_hash
+ *
+ * Nonce: 16-bit counter per peer, seeded from HW RNG on boot. With per-message
+ * key derivation, even a nonce collision (across reboots) only leaks P1 XOR P2
+ * for that message pair — no key recovery, no impact on other messages.
+ *
+ * Group channels: all members share the same key, so cross-sender nonce
+ * collisions are possible (~300 msgs for 50% chance with random nonces).
+ * Damage is bounded (message pair leak, no key recovery).
+ */
+int Utils::aeadEncrypt(const uint8_t* shared_secret,
+                       uint8_t* dest,
+                       const uint8_t* src, int src_len,
+                       const uint8_t* assoc_data, int assoc_len,
+                       uint16_t nonce_counter,
+                       uint8_t dest_hash, uint8_t src_hash) {
+  if (src_len <= 0) return 0;
+
+  // Write nonce to output
+  dest[0] = (uint8_t)(nonce_counter >> 8);
+  dest[1] = (uint8_t)(nonce_counter & 0xFF);
+
+  // Derive per-message key: HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash)
+  // Including hashes makes the key direction-dependent, preventing keystream reuse
+  // when Alice->Bob and Bob->Alice use the same nonce (255/256 peer pairs).
+  uint8_t msg_key[32];
+  {
+    uint8_t kdf_input[AEAD_NONCE_SIZE + 2] = { dest[0], dest[1], dest_hash, src_hash };
+    SHA256 sha;
+    sha.resetHMAC(shared_secret, PUB_KEY_SIZE);
+    sha.update(kdf_input, sizeof(kdf_input));
+    sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, msg_key, 32);
+  }
+
+  // Build 12-byte IV from on-wire fields
+  uint8_t iv[12];
+  iv[0] = dest[0];  // nonce_hi
+  iv[1] = dest[1];  // nonce_lo
+  iv[2] = dest_hash;
+  iv[3] = src_hash;
+  memset(&iv[4], 0, 8);
+
+  ChaChaPoly cipher;
+  cipher.setKey(msg_key, 32);
+  cipher.setIV(iv, 12);
+  cipher.addAuthData(assoc_data, assoc_len);
+  cipher.encrypt(dest + AEAD_NONCE_SIZE, src, src_len);
+  cipher.computeTag(dest + AEAD_NONCE_SIZE + src_len, AEAD_TAG_SIZE);
+  cipher.clear();
+  memset(msg_key, 0, 32);
+
+  return AEAD_NONCE_SIZE + src_len + AEAD_TAG_SIZE;
+}
+
+int Utils::aeadDecrypt(const uint8_t* shared_secret,
+                       uint8_t* dest,
+                       const uint8_t* src, int src_len,
+                       const uint8_t* assoc_data, int assoc_len,
+                       uint8_t dest_hash, uint8_t src_hash) {
+  // Minimum: nonce(2) + at least 1 byte ciphertext + tag(4)
+  if (src_len < AEAD_NONCE_SIZE + 1 + AEAD_TAG_SIZE) return 0;
+
+  int ct_len = src_len - AEAD_NONCE_SIZE - AEAD_TAG_SIZE;
+
+  // Derive per-message key: HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash)
+  uint8_t msg_key[32];
+  {
+    uint8_t kdf_input[AEAD_NONCE_SIZE + 2] = { src[0], src[1], dest_hash, src_hash };
+    SHA256 sha;
+    sha.resetHMAC(shared_secret, PUB_KEY_SIZE);
+    sha.update(kdf_input, sizeof(kdf_input));
+    sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, msg_key, 32);
+  }
+
+  // Build 12-byte IV from on-wire fields
+  uint8_t iv[12];
+  iv[0] = src[0];  // nonce_hi
+  iv[1] = src[1];  // nonce_lo
+  iv[2] = dest_hash;
+  iv[3] = src_hash;
+  memset(&iv[4], 0, 8);
+
+  ChaChaPoly cipher;
+  cipher.setKey(msg_key, 32);
+  cipher.setIV(iv, 12);
+  cipher.addAuthData(assoc_data, assoc_len);
+  cipher.decrypt(dest, src + AEAD_NONCE_SIZE, ct_len);
+
+  bool valid = cipher.checkTag(src + AEAD_NONCE_SIZE + ct_len, AEAD_TAG_SIZE);
+  cipher.clear();
+  memset(msg_key, 0, 32);
+  if (!valid) memset(dest, 0, ct_len);
+
+  return valid ? ct_len : 0;
 }
 
 static const char hex_chars[] = "0123456789ABCDEF";

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -55,6 +55,29 @@ public:
   static int MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len);
 
   /**
+   * \brief  Encrypt with ChaChaPoly AEAD. Derives per-message key via HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash).
+   *         Output: [nonce:2][ciphertext:src_len][tag:4]
+   * \returns  total output length (AEAD_NONCE_SIZE + src_len + AEAD_TAG_SIZE), or 0 on failure
+   */
+  static int aeadEncrypt(const uint8_t* shared_secret,
+                         uint8_t* dest,
+                         const uint8_t* src, int src_len,
+                         const uint8_t* assoc_data, int assoc_len,
+                         uint16_t nonce_counter,
+                         uint8_t dest_hash, uint8_t src_hash);
+
+  /**
+   * \brief  Decrypt with ChaChaPoly AEAD. Derives per-message key via HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash).
+   *         Input: [nonce:2][ciphertext:M][tag:4]
+   * \returns  plaintext length, or 0 if tag verification fails
+   */
+  static int aeadDecrypt(const uint8_t* shared_secret,
+                         uint8_t* dest,
+                         const uint8_t* src, int src_len,
+                         const uint8_t* assoc_data, int assoc_len,
+                         uint8_t dest_hash, uint8_t src_hash);
+
+  /**
    * \brief  converts 'src' bytes with given length to Hex representation, and null terminates.
   */
   static void toHex(char* dest, const uint8_t* src, size_t len);

--- a/src/helpers/ArduinoHelpers.h
+++ b/src/helpers/ArduinoHelpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Mesh.h>
+#include <MeshCore.h>
 #include <Arduino.h>
 
 class VolatileRTCClock : public mesh::RTCClock {
@@ -33,3 +34,17 @@ public:
     }
   }
 };
+
+// Returns true for dirty resets (power-on, watchdog, brownout, panic).
+// Returns false for clean wakes (deep sleep, software restart).
+inline bool wasDirtyReset(mesh::MainBoard& board) {
+#if defined(ESP32)
+  esp_reset_reason_t rst = esp_reset_reason();
+  return (rst != ESP_RST_DEEPSLEEP && rst != ESP_RST_SW);
+#elif defined(NRF52_PLATFORM)
+  return !(board.getResetReason() & POWER_RESETREAS_SREQ_Msk);
+#else
+  (void)board;
+  return true;
+#endif
+}

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -9,6 +9,50 @@
   #define TXT_ACK_DELAY     200
 #endif
 
+uint16_t BaseChatMesh::nextAeadNonceFor(const ContactInfo& contact) {
+  uint16_t nonce = contact.nextAeadNonce();
+  if (nonce != 0) {
+    int idx = &contact - contacts;
+    if (idx >= 0 && idx < num_contacts &&
+        (uint16_t)(contact.aead_nonce - nonce_at_last_persist[idx]) >= NONCE_PERSIST_INTERVAL) {
+      nonce_dirty = true;
+    }
+  }
+  return nonce;
+}
+
+bool BaseChatMesh::applyLoadedNonce(const uint8_t* pub_key_prefix, uint16_t nonce) {
+  for (int i = 0; i < num_contacts; i++) {
+    if (memcmp(contacts[i].id.pub_key, pub_key_prefix, 4) == 0) {
+      contacts[i].aead_nonce = nonce;
+      return true;
+    }
+  }
+  return false;
+}
+
+void BaseChatMesh::finalizeNonceLoad(bool needs_bump) {
+  for (int i = 0; i < num_contacts; i++) {
+    if (needs_bump) {
+      uint16_t old = contacts[i].aead_nonce;
+      contacts[i].aead_nonce += NONCE_BOOT_BUMP;
+      if (contacts[i].aead_nonce == 0) contacts[i].aead_nonce = 1;
+      if (contacts[i].aead_nonce < old) {
+        MESH_DEBUG_PRINTLN("AEAD nonce wrapped after boot bump for peer: %s", contacts[i].name);
+      }
+    }
+    nonce_at_last_persist[i] = contacts[i].aead_nonce;
+  }
+  nonce_dirty = false;
+}
+
+bool BaseChatMesh::getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) {
+  if (idx >= num_contacts) return false;
+  memcpy(pub_key_prefix, contacts[idx].id.pub_key, 4);
+  *nonce = contacts[idx].aead_nonce;
+  return true;
+}
+
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   sendFlood(pkt, delay_millis);
 }
@@ -118,6 +162,7 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
   getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
+  if (ci.aead_nonce == 0) ci.aead_nonce = 1;
   if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
     ci.flags |= CONTACT_FLAG_AEAD;
   }
@@ -185,7 +230,8 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
       return;
     }
     
-    populateContactFromAdvert(*from, id, parser, timestamp);
+    populateContactFromAdvert(*from, id, parser, timestamp);  // seeds aead_nonce from RNG
+    nonce_at_last_persist[from - contacts] = from->aead_nonce;
     from->sync_since = 0;
     from->shared_secret_valid = false;
   }
@@ -239,7 +285,7 @@ uint8_t BaseChatMesh::getPeerFlags(int peer_idx) {
 uint16_t BaseChatMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    return contacts[i].nextAeadNonce();
+    return nextAeadNonceFor(contacts[i]);
   }
   return 0;
 }
@@ -275,7 +321,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, from.nextAeadNonce());
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -286,7 +332,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect() (NOTE: no ACK as extra)
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len, 0, NULL, 0, from.nextAeadNonce());
+        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len, 0, NULL, 0, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path);
       }
     } else if (flags == TXT_TYPE_SIGNED_PLAIN) {
@@ -302,7 +348,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from.nextAeadNonce());
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -318,10 +364,10 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, from.nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, from.nextAeadNonce());
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, nextAeadNonceFor(from));
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -387,7 +433,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, contact.nextAeadNonce());
+  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, nextAeadNonceFor(contact));
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -463,7 +509,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, recipient.nextAeadNonce());
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, nextAeadNonceFor(recipient));
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -494,7 +540,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (TXT_TYPE_CLI_DATA << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, recipient.nextAeadNonce());
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, nextAeadNonceFor(recipient));
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -666,7 +712,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, recipient.nextAeadNonce());
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, nextAeadNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -693,7 +739,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), recipient.nextAeadNonce());
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), nextAeadNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -816,7 +862,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, contact->nextAeadNonce());
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, nextAeadNonceFor(*contact));
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }
@@ -878,9 +924,12 @@ ContactInfo* BaseChatMesh::lookupContactByPubKey(const uint8_t* pub_key, int pre
 bool BaseChatMesh::addContact(const ContactInfo& contact) {
   ContactInfo* dest = allocateContactSlot(contact.type == ADV_TYPE_NONE);
   if (dest) {
+    int idx = dest - contacts;
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
     getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
+    if (dest->aead_nonce == 0) dest->aead_nonce = 1;
+    nonce_at_last_persist[idx] = dest->aead_nonce;
     return true;  // success
   }
   return false;
@@ -893,10 +942,11 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
   }
   if (idx >= num_contacts) return false;   // not found
 
-  // remove from contacts array
+  // remove from contacts array and parallel nonce tracking
   num_contacts--;
   while (idx < num_contacts) {
     contacts[idx] = contacts[idx + 1];
+    nonce_at_last_persist[idx] = nonce_at_last_persist[idx + 1];
     idx++;
   }
   return true;  // Success

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -21,6 +21,7 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name) {
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     app_data_len = builder.encodeTo(app_data);
   }
 
@@ -32,6 +33,7 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, doubl
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name, lat, lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     app_data_len = builder.encodeTo(app_data);
   }
 
@@ -115,6 +117,10 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   }
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
+  getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
+  if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
+    ci.flags |= CONTACT_FLAG_AEAD;
+  }
 }
 
 void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) {
@@ -194,6 +200,11 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
   }
   from->last_advert_timestamp = timestamp;
   from->lastmod = getRTCClock()->getCurrentTime();
+  if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
+    from->flags |= CONTACT_FLAG_AEAD;
+  } else {
+    from->flags &= ~CONTACT_FLAG_AEAD;
+  }
 
   onDiscoveredContact(*from, is_new, packet->path_len, packet->path);       // let UI know
 }
@@ -853,6 +864,7 @@ bool BaseChatMesh::addContact(const ContactInfo& contact) {
   if (dest) {
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
+    getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
     return true;  // success
   }
   return false;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1345,7 +1345,10 @@ uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint
 
   // 4. Store in pool (dual-decode: new key active, old key still valid)
   auto entry = allocateSessionKey(from.id.pub_key);
-  if (!entry) return 0;
+  if (!entry) {
+    memset(new_session_key, 0, SESSION_KEY_SIZE);
+    return 0;
+  }
 
   if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
     memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1000,6 +1000,7 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
     nonce_at_last_persist[idx] = nonce_at_last_persist[idx + 1];
     idx++;
   }
+  memset(&contacts[num_contacts], 0, sizeof(ContactInfo));
   return true;  // Success
 }
 
@@ -1139,6 +1140,7 @@ SessionKeyEntry* BaseChatMesh::allocateSessionKey(const uint8_t* pub_key) {
 
 void BaseChatMesh::removeSessionKey(const uint8_t* pub_key) {
   session_keys.remove(pub_key);
+  session_keys_dirty = true;
 }
 
 // --- Session key support (Phase 2 — initiator) ---
@@ -1395,6 +1397,8 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
       // All retries exhausted — clean up
       memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
       memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+      memset(entry->session_key, 0, SESSION_KEY_SIZE);
+      memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
       entry->state = SESSION_STATE_NONE;
       entry->timeout_at = 0;
     }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1169,7 +1169,7 @@ uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
   uint16_t nonce = 0;
   auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
-    ++entry->nonce;
+    ++entry->nonce;  // may reach 65535 → canUseSessionKey() fails next call → falls back to static ECDH
     if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
     session_keys_dirty = true;
     nonce = entry->nonce;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -991,7 +991,7 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
   }
   if (idx >= num_contacts) return false;   // not found
 
-  session_keys.remove(contact.id.pub_key);  // also remove session key if any
+  removeSessionKey(contact.id.pub_key);  // also remove session key if any
 
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
@@ -1106,6 +1106,41 @@ void BaseChatMesh::loop() {
   }
 }
 
+// --- Session key flash-backed wrappers ---
+
+SessionKeyEntry* BaseChatMesh::findSessionKey(const uint8_t* pub_key) {
+  auto entry = session_keys.findByPrefix(pub_key);
+  if (entry) return entry;
+
+  // Cache miss — try flash
+  uint8_t flags; uint16_t nonce;
+  uint8_t sk[SESSION_KEY_SIZE], psk[SESSION_KEY_SIZE];
+  if (!loadSessionKeyRecordFromFlash(pub_key, &flags, &nonce, sk, psk)) return nullptr;
+
+  // Save dirty evictee before overwriting
+  if (session_keys.isFull() && session_keys_dirty) {
+    mergeAndSaveSessionKeys();
+  }
+  session_keys.applyLoaded(pub_key, flags, nonce, sk, psk);
+  return session_keys.findByPrefix(pub_key);
+}
+
+SessionKeyEntry* BaseChatMesh::allocateSessionKey(const uint8_t* pub_key) {
+  // Check RAM and flash first
+  auto entry = findSessionKey(pub_key);
+  if (entry) return entry;
+
+  // Not found anywhere — save dirty evictee before allocating
+  if (session_keys.isFull() && session_keys_dirty) {
+    mergeAndSaveSessionKeys();
+  }
+  return session_keys.allocate(pub_key);
+}
+
+void BaseChatMesh::removeSessionKey(const uint8_t* pub_key) {
+  session_keys.remove(pub_key);
+}
+
 // --- Session key support (Phase 2 — initiator) ---
 
 static bool canUseSessionKey(const SessionKeyEntry* entry) {
@@ -1121,7 +1156,7 @@ static bool canUseSessionKey(const SessionKeyEntry* entry) {
 }
 
 const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
     return entry->session_key;
   }
@@ -1130,7 +1165,7 @@ const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
 
 uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
   uint16_t nonce = 0;
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
     ++entry->nonce;
     if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
@@ -1144,7 +1179,7 @@ uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
       int idx = &contact - contacts;
       if (idx >= 0 && idx < num_contacts)
         contacts[idx].flags &= ~CONTACT_FLAG_AEAD;
-      session_keys.remove(contact.id.pub_key);
+      removeSessionKey(contact.id.pub_key);
       onSessionKeysUpdated();
       // nonce = 0 (ECB)
     } else if (entry->sends_since_last_recv >= SESSION_KEY_ECB_THRESHOLD) {
@@ -1173,7 +1208,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
   // Need a known path to send the request
   if (contact.out_path_len < 0) return false;
 
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
 
   // Don't trigger if negotiation already in progress
   if (entry && entry->state == SESSION_STATE_INIT_SENT) return false;
@@ -1209,7 +1244,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
 }
 
 bool BaseChatMesh::initiateSessionKeyNegotiation(const ContactInfo& contact) {
-  auto entry = session_keys.allocate(contact.id.pub_key);
+  auto entry = allocateSessionKey(contact.id.pub_key);
   if (!entry) return false;
 
   // Don't start a new negotiation if one is already pending
@@ -1245,7 +1280,7 @@ bool BaseChatMesh::handleSessionKeyResponse(ContactInfo& contact, const uint8_t*
   if (len < 5 + PUB_KEY_SIZE) return false;
   if (data[4] != RESP_TYPE_SESSION_KEY_ACCEPT) return false;
 
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (!entry || entry->state != SESSION_STATE_INIT_SENT) return false;
 
   const uint8_t* ephemeral_pub_B = &data[5];
@@ -1307,7 +1342,7 @@ uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint
   memset(ephemeral_secret, 0, PUB_KEY_SIZE);
 
   // 4. Store in pool (dual-decode: new key active, old key still valid)
-  auto entry = session_keys.allocate(from.id.pub_key);
+  auto entry = allocateSessionKey(from.id.pub_key);
   if (!entry) return 0;
 
   if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
@@ -1370,7 +1405,7 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
 const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     // Also try decode during INIT_SENT renegotiation (nonce > 1 means prior key exists)
     if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE
                   || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1)))
@@ -1382,7 +1417,7 @@ const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
 const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     if (entry && entry->state == SESSION_STATE_DUAL_DECODE)
       return entry->prev_session_key;
   }
@@ -1392,7 +1427,7 @@ const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
 void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     if (entry) {
       bool changed = (entry->state == SESSION_STATE_DUAL_DECODE);
       if (changed) {

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -993,6 +993,10 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
 
   removeSessionKey(contact.id.pub_key);  // also remove session key if any
 
+  // adjust pending rekey index before shifting array
+  if (_pending_rekey_idx == idx) _pending_rekey_idx = -1;
+  else if (_pending_rekey_idx > idx) _pending_rekey_idx--;
+
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
   while (idx < num_contacts) {

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -228,6 +228,22 @@ void BaseChatMesh::getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) {
   }
 }
 
+uint8_t BaseChatMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    return contacts[i].flags;
+  }
+  return 0;
+}
+
+uint16_t BaseChatMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    return contacts[i].nextAeadNonce();
+  }
+  return 0;
+}
+
 void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) {
   int i = matching_peer_indexes[sender_idx];
   if (i < 0 || i >= num_contacts) {
@@ -259,7 +275,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6);
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -270,7 +286,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect() (NOTE: no ACK as extra)
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len, 0, NULL, 0);
+        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len, 0, NULL, 0, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path);
       }
     } else if (flags == TXT_TYPE_SIGNED_PLAIN) {
@@ -286,7 +302,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -302,10 +318,10 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len);
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len);
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, from.nextAeadNonce());
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -371,7 +387,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0);
+  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, contact.nextAeadNonce());
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -447,7 +463,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len);
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, recipient.nextAeadNonce());
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -478,7 +494,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (TXT_TYPE_CLI_DATA << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len);
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, recipient.nextAeadNonce());
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -650,7 +666,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len);
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, recipient.nextAeadNonce());
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -677,7 +693,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), recipient.nextAeadNonce());
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -800,7 +816,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9);
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, contact->nextAeadNonce());
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1373,26 +1373,32 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
 
     if (entry->retries_left > 0) {
       // Retry: find the contact and resend INIT
+      ContactInfo* contact = nullptr;
       for (int j = 0; j < num_contacts; j++) {
         if (memcmp(contacts[j].id.pub_key, entry->peer_pub_prefix, 4) == 0) {
-          entry->retries_left--;
-          entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
-
-          // Regenerate ephemeral keypair for retry
-          uint8_t seed[SEED_SIZE];
-          getRNG()->random(seed, SEED_SIZE);
-          ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
-          memset(seed, 0, SEED_SIZE);
-
-          uint8_t req_data[1 + PUB_KEY_SIZE];
-          req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
-          memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
-
-          uint32_t tag, est_timeout;
-          sendRequest(contacts[j], req_data, sizeof(req_data), tag, est_timeout);
+          contact = &contacts[j];
           break;
         }
       }
+      if (!contact) {
+        entry->retries_left = 0;  // contact gone — fall through to cleanup on next tick
+        continue;
+      }
+      entry->retries_left--;
+      entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+
+      // Regenerate ephemeral keypair for retry
+      uint8_t seed[SEED_SIZE];
+      getRNG()->random(seed, SEED_SIZE);
+      ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+      memset(seed, 0, SEED_SIZE);
+
+      uint8_t req_data[1 + PUB_KEY_SIZE];
+      req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+      memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+      uint32_t tag, est_timeout;
+      sendRequest(*contact, req_data, sizeof(req_data), tag, est_timeout);
     } else {
       // All retries exhausted — clean up
       memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1,5 +1,7 @@
 #include <helpers/BaseChatMesh.h>
 #include <Utils.h>
+#include <SHA256.h>
+#include <ed_25519.h>
 
 #ifndef SERVER_RESPONSE_DELAY
   #define SERVER_RESPONSE_DELAY   300
@@ -44,6 +46,20 @@ void BaseChatMesh::finalizeNonceLoad(bool needs_bump) {
     nonce_at_last_persist[i] = contacts[i].aead_nonce;
   }
   nonce_dirty = false;
+
+  // Apply boot bump to session key nonces too
+  if (needs_bump) {
+    for (int i = 0; i < session_keys.getCount(); i++) {
+      auto entry = session_keys.getByIdx(i);
+      if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+        uint16_t old_nonce = entry->nonce;
+        entry->nonce += NONCE_BOOT_BUMP;
+        if (entry->nonce <= old_nonce) {
+          entry->nonce = 65535;  // wrapped — force exhaustion so renegotiation happens
+        }
+      }
+    }
+  }
 }
 
 bool BaseChatMesh::getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) {
@@ -161,8 +177,7 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   }
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
-  getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
-  if (ci.aead_nonce == 0) ci.aead_nonce = 1;
+  ci.aead_nonce = (uint16_t)getRNG()->nextInt(NONCE_INITIAL_MIN, NONCE_INITIAL_MAX + 1);
   if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
     ci.flags |= CONTACT_FLAG_AEAD;
   }
@@ -320,8 +335,8 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, getEncryptionKeyFor(from), packet->path, packet->path_len,
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, getEncryptionNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -332,7 +347,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect() (NOTE: no ACK as extra)
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len, 0, NULL, 0, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, getEncryptionKeyFor(from), packet->path, packet->path_len, 0, NULL, 0, getEncryptionNonceFor(from));
         if (path) sendFloodScoped(from, path);
       }
     } else if (flags == TXT_TYPE_SIGNED_PLAIN) {
@@ -347,8 +362,8 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, getEncryptionKeyFor(from), packet->path, packet->path_len,
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, getEncryptionNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -359,15 +374,37 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
   } else if (type == PAYLOAD_TYPE_REQ && len > 4) {
     uint32_t sender_timestamp;
     memcpy(&sender_timestamp, data, 4);
-    uint8_t reply_len = onContactRequest(from, sender_timestamp, &data[4], len - 4, temp_buf);
+
+    uint8_t reply_len = 0;
+    bool use_static_secret = false;
+
+    // Intercept session key INIT before subclass onContactRequest
+    if (len >= 5 + PUB_KEY_SIZE && data[4] == REQ_TYPE_SESSION_KEY_INIT) {
+      memcpy(temp_buf, &sender_timestamp, 4);
+      temp_buf[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+      uint8_t n = handleIncomingSessionKeyInit(from, &data[5], &temp_buf[5]);
+      if (n > 0) {
+        reply_len = 5 + n;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      }
+    }
+    if (reply_len == 0) {
+      reply_len = onContactRequest(from, sender_timestamp, &data[4], len - 4, temp_buf);
+    }
+
     if (reply_len > 0) {
+      // Session key ACCEPT must be encrypted with static ECDH secret, because
+      // the initiator hasn't derived the session key yet (they need our ephemeral_pub_B first).
+      const uint8_t* enc_key = use_static_secret ? from.getSharedSecret(self_id) : getEncryptionKeyFor(from);
+      uint16_t enc_nonce = use_static_secret ? nextAeadNonceFor(from) : getEncryptionNonceFor(from);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, enc_nonce);
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, nextAeadNonceFor(from));
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, enc_key, temp_buf, reply_len, enc_nonce);
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -378,7 +415,16 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       }
     }
   } else if (type == PAYLOAD_TYPE_RESPONSE && len > 0) {
-    onContactResponse(from, data, len);
+    // Intercept session key accept responses before passing to onContactResponse.
+    // Note: RESP_TYPE_SESSION_KEY_ACCEPT (0x08) could collide with a normal response whose
+    // 5th byte happens to be 0x08, but handleSessionKeyResponse has a secondary guard
+    // (requires INIT_SENT state for this peer) so false positives are extremely unlikely,
+    // and self-heal via session key invalidation if they ever occur.
+    if (len >= 5 && data[4] == RESP_TYPE_SESSION_KEY_ACCEPT && handleSessionKeyResponse(from, data, len)) {
+      // Session key response handled — don't pass to onContactResponse
+    } else {
+      onContactResponse(from, data, len);
+    }
     if (packet->isRouteFlood() && from.out_path_len != OUT_PATH_UNKNOWN) {
       // we have direct path, but other node is still sending flood response, so maybe they didn't receive reciprocal path properly(?)
       handleReturnPathRetry(from, packet->path, packet->path_len);
@@ -412,7 +458,11 @@ bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_
       txt_send_timeout = 0;   // matched one we're waiting for, cancel timeout timer
     }
   } else if (extra_type == PAYLOAD_TYPE_RESPONSE && extra_len > 0) {
-    onContactResponse(from, extra, extra_len);
+    if (extra_len >= 5 && extra[4] == RESP_TYPE_SESSION_KEY_ACCEPT && handleSessionKeyResponse(from, extra, extra_len)) {
+      // Session key response handled
+    } else {
+      onContactResponse(from, extra, extra_len);
+    }
   }
   return true;  // send reciprocal path if necessary
 }
@@ -433,7 +483,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, nextAeadNonceFor(contact));
+  mesh::Packet* rpath = createPathReturn(contact.id, getEncryptionKeyFor(contact), path, path_len, 0, NULL, 0, getEncryptionNonceFor(contact));
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -509,7 +559,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, nextAeadNonceFor(recipient));
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, getEncryptionKeyFor(recipient), temp, len, getEncryptionNonceFor(recipient));
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -540,7 +590,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (TXT_TYPE_CLI_DATA << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, nextAeadNonceFor(recipient));
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, getEncryptionKeyFor(recipient), temp, 5 + text_len, getEncryptionNonceFor(recipient));
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -712,7 +762,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, nextAeadNonceFor(recipient));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, getEncryptionKeyFor(recipient), temp, 4 + data_len, getEncryptionNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -739,7 +789,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), nextAeadNonceFor(recipient));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, getEncryptionKeyFor(recipient), temp, sizeof(temp), getEncryptionNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -862,7 +912,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, nextAeadNonceFor(*contact));
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, getEncryptionKeyFor(*contact), data, 9, getEncryptionNonceFor(*contact));
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }
@@ -927,8 +977,7 @@ bool BaseChatMesh::addContact(const ContactInfo& contact) {
     int idx = dest - contacts;
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
-    getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
-    if (dest->aead_nonce == 0) dest->aead_nonce = 1;
+    dest->aead_nonce = (uint16_t)getRNG()->nextInt(NONCE_INITIAL_MIN, NONCE_INITIAL_MAX + 1);
     nonce_at_last_persist[idx] = dest->aead_nonce;
     return true;  // success
   }
@@ -941,6 +990,8 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
     idx++;
   }
   if (idx >= num_contacts) return false;   // not found
+
+  session_keys.remove(contact.id.pub_key);  // also remove session key if any
 
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
@@ -1044,4 +1095,337 @@ void BaseChatMesh::loop() {
     releasePacket(_pendingLoopback);   // undo the obtainNewPacket()
     _pendingLoopback = NULL;
   }
+
+  checkSessionKeyTimeouts();
+
+  // Process deferred session key negotiation (set by getEncryptionNonceFor)
+  if (_pending_rekey_idx >= 0 && _pending_rekey_idx < num_contacts) {
+    int idx = _pending_rekey_idx;
+    _pending_rekey_idx = -1;
+    initiateSessionKeyNegotiation(contacts[idx]);
+  }
+}
+
+// --- Session key support (Phase 2 — initiator) ---
+
+static bool canUseSessionKey(const SessionKeyEntry* entry) {
+  if (!entry) return false;
+  // ACTIVE/DUAL_DECODE: normal session key use
+  // INIT_SENT with nonce > 1: renegotiation in progress, keep using old session key
+  //   (nonce == 0 means fresh allocation with no prior session key)
+  bool valid_state = (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)
+                     || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1);
+  return valid_state
+      && entry->sends_since_last_recv < SESSION_KEY_STALE_THRESHOLD
+      && entry->nonce < 65535;  // nonce exhausted → fall back to static ECDH
+}
+
+const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (canUseSessionKey(entry)) {
+    return entry->session_key;
+  }
+  return contact.getSharedSecret(self_id);
+}
+
+uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
+  uint16_t nonce = 0;
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (canUseSessionKey(entry)) {
+    ++entry->nonce;
+    if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
+    session_keys_dirty = true;
+    nonce = entry->nonce;
+  } else if (entry && entry->sends_since_last_recv < 255) {
+    // Progressive fallback: keep incrementing counter even when not using session key
+    entry->sends_since_last_recv++;
+    if (entry->sends_since_last_recv >= SESSION_KEY_ABANDON_THRESHOLD) {
+      // Give up: clear AEAD capability and remove session key
+      int idx = &contact - contacts;
+      if (idx >= 0 && idx < num_contacts)
+        contacts[idx].flags &= ~CONTACT_FLAG_AEAD;
+      session_keys.remove(contact.id.pub_key);
+      onSessionKeysUpdated();
+      // nonce = 0 (ECB)
+    } else if (entry->sends_since_last_recv >= SESSION_KEY_ECB_THRESHOLD) {
+      // nonce = 0 (ECB)
+    } else {
+      nonce = nextAeadNonceFor(contact);
+    }
+  } else {
+    nonce = nextAeadNonceFor(contact);
+  }
+
+  // Trigger session key negotiation on the next loop() tick.
+  // Checking here (the single funnel for all outgoing encryption) ensures no
+  // send path can silently skip a trigger — unlike the old per-call-site approach.
+  if (_pending_rekey_idx < 0 && shouldInitiateSessionKey(contact)) {
+    _pending_rekey_idx = &contact - contacts;
+  }
+
+  return nonce;
+}
+
+bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
+  // Only for AEAD-capable peers
+  if (!(contact.flags & CONTACT_FLAG_AEAD)) return false;
+
+  // Need a known path to send the request
+  if (contact.out_path_len < 0) return false;
+
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+
+  // Don't trigger if negotiation already in progress
+  if (entry && entry->state == SESSION_STATE_INIT_SENT) return false;
+
+  // Determine intervals based on hop count tier:
+  //   direct (0):  static=100, session=100
+  //   1–9 hops:    static=500, session=300
+  //   10+ hops:    static=1000, session=300
+  uint16_t static_interval, session_interval;
+  if (contact.out_path_len == 0) {
+    static_interval = 100;
+    session_interval = 100;
+  } else if (contact.out_path_len < 10) {
+    static_interval = 500;
+    session_interval = 300;
+  } else {
+    static_interval = 1000;
+    session_interval = 300;
+  }
+
+  if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+    if (entry->nonce < 65535) {
+      // Active session key with remaining nonces — renegotiate after nonce > 60000
+      if (entry->nonce <= NONCE_REKEY_THRESHOLD) return false;
+      return ((entry->nonce - NONCE_REKEY_THRESHOLD) % session_interval) == 0;
+    }
+    // Session key nonce exhausted — fall through to static ECDH trigger
+  }
+
+  // No session key (or state=NONE) — trigger based on static ECDH nonce vs interval
+  if (contact.aead_nonce == 0) return false;  // no messages sent yet
+  return (contact.aead_nonce % static_interval) == 0;
+}
+
+bool BaseChatMesh::initiateSessionKeyNegotiation(const ContactInfo& contact) {
+  auto entry = session_keys.allocate(contact.id.pub_key);
+  if (!entry) return false;
+
+  // Don't start a new negotiation if one is already pending
+  if (entry->state == SESSION_STATE_INIT_SENT) return false;
+
+  // Generate ephemeral keypair A
+  uint8_t seed[SEED_SIZE];
+  getRNG()->random(seed, SEED_SIZE);
+  ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+  memset(seed, 0, SEED_SIZE);
+
+  // Send REQ_TYPE_SESSION_KEY_INIT with ephemeral_pub_A
+  uint8_t req_data[1 + PUB_KEY_SIZE];
+  req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+  memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+  uint32_t tag, est_timeout;
+  int rc = sendRequest(contact, req_data, sizeof(req_data), tag, est_timeout);
+  if (rc == MSG_SEND_FAILED) {
+    memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+    memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+    return false;
+  }
+
+  entry->state = SESSION_STATE_INIT_SENT;
+  entry->retries_left = SESSION_KEY_MAX_RETRIES - 1;
+  entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+  return true;
+}
+
+bool BaseChatMesh::handleSessionKeyResponse(ContactInfo& contact, const uint8_t* data, uint8_t len) {
+  // Response format: [timestamp:4][RESP_TYPE_SESSION_KEY_ACCEPT:1][ephemeral_pub_B:32]
+  if (len < 5 + PUB_KEY_SIZE) return false;
+  if (data[4] != RESP_TYPE_SESSION_KEY_ACCEPT) return false;
+
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (!entry || entry->state != SESSION_STATE_INIT_SENT) return false;
+
+  const uint8_t* ephemeral_pub_B = &data[5];
+
+  // Compute ephemeral_secret via X25519
+  uint8_t ephemeral_secret[PUB_KEY_SIZE];
+  ed25519_key_exchange(ephemeral_secret, ephemeral_pub_B, entry->ephemeral_prv);
+  memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+  memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+
+  // Derive session_key = HMAC-SHA256(static_shared_secret, ephemeral_secret)
+  const uint8_t* static_secret = contact.getSharedSecret(self_id);
+  uint8_t new_session_key[SESSION_KEY_SIZE];
+  {
+    SHA256 sha;
+    sha.resetHMAC(static_secret, PUB_KEY_SIZE);
+    sha.update(ephemeral_secret, PUB_KEY_SIZE);
+    sha.finalizeHMAC(static_secret, PUB_KEY_SIZE, new_session_key, SESSION_KEY_SIZE);
+  }
+  memset(ephemeral_secret, 0, PUB_KEY_SIZE);
+
+  // Activate session key
+  memcpy(entry->session_key, new_session_key, SESSION_KEY_SIZE);
+  memset(new_session_key, 0, SESSION_KEY_SIZE);
+  entry->nonce = 1;
+  entry->state = SESSION_STATE_ACTIVE;
+  entry->sends_since_last_recv = 0;
+  entry->retries_left = 0;
+  entry->timeout_at = 0;
+
+  MESH_DEBUG_PRINTLN("Session key established with: %s", contact.name);
+  onSessionKeysUpdated();
+  return true;
+}
+
+uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf) {
+  // 1. Generate ephemeral keypair B
+  uint8_t seed[SEED_SIZE];
+  getRNG()->random(seed, SEED_SIZE);
+  uint8_t ephemeral_pub_B[PUB_KEY_SIZE];
+  uint8_t ephemeral_prv_B[PRV_KEY_SIZE];
+  ed25519_create_keypair(ephemeral_pub_B, ephemeral_prv_B, seed);
+  memset(seed, 0, SEED_SIZE);
+
+  // 2. Compute ephemeral_secret via X25519
+  uint8_t ephemeral_secret[PUB_KEY_SIZE];
+  ed25519_key_exchange(ephemeral_secret, ephemeral_pub_A, ephemeral_prv_B);
+  memset(ephemeral_prv_B, 0, PRV_KEY_SIZE);
+
+  // 3. Derive session_key = HMAC-SHA256(static_shared_secret, ephemeral_secret)
+  const uint8_t* static_secret = from.getSharedSecret(self_id);
+  uint8_t new_session_key[SESSION_KEY_SIZE];
+  {
+    SHA256 sha;
+    sha.resetHMAC(static_secret, PUB_KEY_SIZE);
+    sha.update(ephemeral_secret, PUB_KEY_SIZE);
+    sha.finalizeHMAC(static_secret, PUB_KEY_SIZE, new_session_key, SESSION_KEY_SIZE);
+  }
+  memset(ephemeral_secret, 0, PUB_KEY_SIZE);
+
+  // 4. Store in pool (dual-decode: new key active, old key still valid)
+  auto entry = session_keys.allocate(from.id.pub_key);
+  if (!entry) return 0;
+
+  if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
+    memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);
+  }
+  memcpy(entry->session_key, new_session_key, SESSION_KEY_SIZE);
+  entry->nonce = 1;
+  entry->state = SESSION_STATE_DUAL_DECODE;
+  entry->sends_since_last_recv = 0;
+  memset(new_session_key, 0, SESSION_KEY_SIZE);
+
+  // 5. Persist immediately
+  onSessionKeysUpdated();
+
+  // 6. Write ephemeral_pub_B to reply
+  memcpy(reply_buf, ephemeral_pub_B, PUB_KEY_SIZE);
+  MESH_DEBUG_PRINTLN("Session key INIT accepted from: %s", from.name);
+  return PUB_KEY_SIZE;
+}
+
+void BaseChatMesh::checkSessionKeyTimeouts() {
+  for (int i = 0; i < session_keys.getCount(); i++) {
+    auto entry = session_keys.getByIdx(i);
+    if (!entry || entry->state != SESSION_STATE_INIT_SENT) continue;
+    if (entry->timeout_at == 0 || !millisHasNowPassed(entry->timeout_at)) continue;
+
+    if (entry->retries_left > 0) {
+      // Retry: find the contact and resend INIT
+      for (int j = 0; j < num_contacts; j++) {
+        if (memcmp(contacts[j].id.pub_key, entry->peer_pub_prefix, 4) == 0) {
+          entry->retries_left--;
+          entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+
+          // Regenerate ephemeral keypair for retry
+          uint8_t seed[SEED_SIZE];
+          getRNG()->random(seed, SEED_SIZE);
+          ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+          memset(seed, 0, SEED_SIZE);
+
+          uint8_t req_data[1 + PUB_KEY_SIZE];
+          req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+          memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+          uint32_t tag, est_timeout;
+          sendRequest(contacts[j], req_data, sizeof(req_data), tag, est_timeout);
+          break;
+        }
+      }
+    } else {
+      // All retries exhausted — clean up
+      memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+      memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+      entry->state = SESSION_STATE_NONE;
+      entry->timeout_at = 0;
+    }
+  }
+}
+
+// Virtual overrides for session key decrypt path
+const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    // Also try decode during INIT_SENT renegotiation (nonce > 1 means prior key exists)
+    if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE
+                  || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1)))
+      return entry->session_key;
+  }
+  return nullptr;
+}
+
+const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    if (entry && entry->state == SESSION_STATE_DUAL_DECODE)
+      return entry->prev_session_key;
+  }
+  return nullptr;
+}
+
+void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    if (entry) {
+      bool changed = (entry->state == SESSION_STATE_DUAL_DECODE);
+      if (changed) {
+        memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
+        entry->state = SESSION_STATE_ACTIVE;
+      }
+      entry->sends_since_last_recv = 0;
+      if (changed) onSessionKeysUpdated();
+    }
+  }
+}
+
+const uint8_t* BaseChatMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts)
+    return getEncryptionKeyFor(contacts[i]);
+  return static_secret;
+}
+
+uint16_t BaseChatMesh::getPeerEncryptionNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts)
+    return getEncryptionNonceFor(contacts[i]);
+  return getPeerNextAeadNonce(peer_idx);
+}
+
+// Session key persistence helpers (delegated to subclass for file I/O)
+bool BaseChatMesh::applyLoadedSessionKey(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                                          const uint8_t* session_key, const uint8_t* prev_session_key) {
+  return session_keys.applyLoaded(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+}
+
+bool BaseChatMesh::getSessionKeyEntry(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                                       uint8_t* session_key, uint8_t* prev_session_key) {
+  return session_keys.getEntryForSave(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
 }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1208,7 +1208,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
   if (!(contact.flags & CONTACT_FLAG_AEAD)) return false;
 
   // Need a known path to send the request
-  if (contact.out_path_len < 0) return false;
+  if (contact.out_path_len == OUT_PATH_UNKNOWN) return false;
 
   auto entry = findSessionKey(contact.id.pub_key);
 
@@ -1443,9 +1443,9 @@ void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
       if (changed) {
         memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
         entry->state = SESSION_STATE_ACTIVE;
+        onSessionKeysUpdated();
       }
       entry->sends_since_last_recv = 0;
-      if (changed) onSessionKeysUpdated();
     }
   }
 }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1199,7 +1199,7 @@ uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
   uint16_t nonce = 0;
   auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
-    ++entry->nonce;
+    ++entry->nonce;  // may reach 65535 → canUseSessionKey() fails next call → falls back to static ECDH
     if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
     session_keys_dirty = true;
     nonce = entry->nonce;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1,5 +1,7 @@
 #include <helpers/BaseChatMesh.h>
 #include <Utils.h>
+#include <SHA256.h>
+#include <ed_25519.h>
 
 #ifndef SERVER_RESPONSE_DELAY
   #define SERVER_RESPONSE_DELAY   300
@@ -45,6 +47,20 @@ void BaseChatMesh::finalizeNonceLoad(bool needs_bump) {
     nonce_at_last_persist[i] = contacts[i].aead_nonce;
   }
   nonce_dirty = false;
+
+  // Apply boot bump to session key nonces too
+  if (needs_bump) {
+    for (int i = 0; i < session_keys.getCount(); i++) {
+      auto entry = session_keys.getByIdx(i);
+      if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+        uint16_t old_nonce = entry->nonce;
+        entry->nonce += NONCE_BOOT_BUMP;
+        if (entry->nonce <= old_nonce) {
+          entry->nonce = 65535;  // wrapped — force exhaustion so renegotiation happens
+        }
+      }
+    }
+  }
 }
 
 bool BaseChatMesh::getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) {
@@ -162,8 +178,7 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   }
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
-  getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
-  if (ci.aead_nonce == 0) ci.aead_nonce = 1;
+  ci.aead_nonce = (uint16_t)getRNG()->nextInt(NONCE_INITIAL_MIN, NONCE_INITIAL_MAX + 1);
   if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
     ci.flags |= CONTACT_FLAG_AEAD;
   }
@@ -321,8 +336,8 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, getEncryptionKeyFor(from), packet->path, packet->path_len,
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, getEncryptionNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -350,7 +365,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
         memcpy(temp, &timestamp, 4);
         temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, secret, temp, 5 + text_len, nextAeadNonceFor(from));
+        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, getEncryptionKeyFor(from), temp, 5 + text_len, getEncryptionNonceFor(from));
         if (reply_pkt) {
           if (from.out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodScoped(from, reply_pkt, CLI_REPLY_DELAY_MILLIS);
@@ -371,8 +386,8 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
 
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, getEncryptionKeyFor(from), packet->path, packet->path_len,
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, getEncryptionNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -383,15 +398,37 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
   } else if (type == PAYLOAD_TYPE_REQ && len > 4) {
     uint32_t sender_timestamp;
     memcpy(&sender_timestamp, data, 4);
-    uint8_t reply_len = onContactRequest(from, sender_timestamp, &data[4], len - 4, temp_buf);
+
+    uint8_t reply_len = 0;
+    bool use_static_secret = false;
+
+    // Intercept session key INIT before subclass onContactRequest
+    if (len >= 5 + PUB_KEY_SIZE && data[4] == REQ_TYPE_SESSION_KEY_INIT) {
+      memcpy(temp_buf, &sender_timestamp, 4);
+      temp_buf[4] = RESP_TYPE_SESSION_KEY_ACCEPT;
+      uint8_t n = handleIncomingSessionKeyInit(from, &data[5], &temp_buf[5]);
+      if (n > 0) {
+        reply_len = 5 + n;
+        use_static_secret = true;  // ACCEPT must use static secret (initiator doesn't have session key yet)
+      }
+    }
+    if (reply_len == 0) {
+      reply_len = onContactRequest(from, sender_timestamp, &data[4], len - 4, temp_buf);
+    }
+
     if (reply_len > 0) {
+      // Session key ACCEPT must be encrypted with static ECDH secret, because
+      // the initiator hasn't derived the session key yet (they need our ephemeral_pub_B first).
+      const uint8_t* enc_key = use_static_secret ? from.getSharedSecret(self_id) : getEncryptionKeyFor(from);
+      uint16_t enc_nonce = use_static_secret ? nextAeadNonceFor(from) : getEncryptionNonceFor(from);
+
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
-        mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, nextAeadNonceFor(from));
+        mesh::Packet* path = createPathReturn(from.id, enc_key, packet->path, packet->path_len,
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, enc_nonce);
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, nextAeadNonceFor(from));
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, enc_key, temp_buf, reply_len, enc_nonce);
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -402,7 +439,16 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       }
     }
   } else if (type == PAYLOAD_TYPE_RESPONSE && len > 0) {
-    onContactResponse(from, data, len);
+    // Intercept session key accept responses before passing to onContactResponse.
+    // Note: RESP_TYPE_SESSION_KEY_ACCEPT (0x08) could collide with a normal response whose
+    // 5th byte happens to be 0x08, but handleSessionKeyResponse has a secondary guard
+    // (requires INIT_SENT state for this peer) so false positives are extremely unlikely,
+    // and self-heal via session key invalidation if they ever occur.
+    if (len >= 5 && data[4] == RESP_TYPE_SESSION_KEY_ACCEPT && handleSessionKeyResponse(from, data, len)) {
+      // Session key response handled — don't pass to onContactResponse
+    } else {
+      onContactResponse(from, data, len);
+    }
     if (packet->isRouteFlood() && from.out_path_len != OUT_PATH_UNKNOWN) {
       // we have direct path, but other node is still sending flood response, so maybe they didn't receive reciprocal path properly(?)
       handleReturnPathRetry(from, packet->path, packet->path_len);
@@ -436,7 +482,11 @@ bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_
       txt_send_timeout = 0;   // matched one we're waiting for, cancel timeout timer
     }
   } else if (extra_type == PAYLOAD_TYPE_RESPONSE && extra_len > 0) {
-    onContactResponse(from, extra, extra_len);
+    if (extra_len >= 5 && extra[4] == RESP_TYPE_SESSION_KEY_ACCEPT && handleSessionKeyResponse(from, extra, extra_len)) {
+      // Session key response handled
+    } else {
+      onContactResponse(from, extra, extra_len);
+    }
   }
   return true;  // send reciprocal path if necessary
 }
@@ -457,7 +507,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, nextAeadNonceFor(contact));
+  mesh::Packet* rpath = createPathReturn(contact.id, getEncryptionKeyFor(contact), path, path_len, 0, NULL, 0, getEncryptionNonceFor(contact));
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -539,7 +589,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, nextAeadNonceFor(recipient));
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, getEncryptionKeyFor(recipient), temp, len, getEncryptionNonceFor(recipient));
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -570,7 +620,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (txt_type << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, nextAeadNonceFor(recipient));
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, getEncryptionKeyFor(recipient), temp, 5 + text_len, getEncryptionNonceFor(recipient));
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -742,7 +792,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, nextAeadNonceFor(recipient));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, getEncryptionKeyFor(recipient), temp, 4 + data_len, getEncryptionNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -769,7 +819,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), nextAeadNonceFor(recipient));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, getEncryptionKeyFor(recipient), temp, sizeof(temp), getEncryptionNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -892,7 +942,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, nextAeadNonceFor(*contact));
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, getEncryptionKeyFor(*contact), data, 9, getEncryptionNonceFor(*contact));
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }
@@ -957,8 +1007,7 @@ bool BaseChatMesh::addContact(const ContactInfo& contact) {
     int idx = dest - contacts;
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
-    getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
-    if (dest->aead_nonce == 0) dest->aead_nonce = 1;
+    dest->aead_nonce = (uint16_t)getRNG()->nextInt(NONCE_INITIAL_MIN, NONCE_INITIAL_MAX + 1);
     nonce_at_last_persist[idx] = dest->aead_nonce;
     return true;  // success
   }
@@ -971,6 +1020,8 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
     idx++;
   }
   if (idx >= num_contacts) return false;   // not found
+
+  session_keys.remove(contact.id.pub_key);  // also remove session key if any
 
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
@@ -1074,4 +1125,337 @@ void BaseChatMesh::loop() {
     releasePacket(_pendingLoopback);   // undo the obtainNewPacket()
     _pendingLoopback = NULL;
   }
+
+  checkSessionKeyTimeouts();
+
+  // Process deferred session key negotiation (set by getEncryptionNonceFor)
+  if (_pending_rekey_idx >= 0 && _pending_rekey_idx < num_contacts) {
+    int idx = _pending_rekey_idx;
+    _pending_rekey_idx = -1;
+    initiateSessionKeyNegotiation(contacts[idx]);
+  }
+}
+
+// --- Session key support (Phase 2 — initiator) ---
+
+static bool canUseSessionKey(const SessionKeyEntry* entry) {
+  if (!entry) return false;
+  // ACTIVE/DUAL_DECODE: normal session key use
+  // INIT_SENT with nonce > 1: renegotiation in progress, keep using old session key
+  //   (nonce == 0 means fresh allocation with no prior session key)
+  bool valid_state = (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)
+                     || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1);
+  return valid_state
+      && entry->sends_since_last_recv < SESSION_KEY_STALE_THRESHOLD
+      && entry->nonce < 65535;  // nonce exhausted → fall back to static ECDH
+}
+
+const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (canUseSessionKey(entry)) {
+    return entry->session_key;
+  }
+  return contact.getSharedSecret(self_id);
+}
+
+uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
+  uint16_t nonce = 0;
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (canUseSessionKey(entry)) {
+    ++entry->nonce;
+    if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
+    session_keys_dirty = true;
+    nonce = entry->nonce;
+  } else if (entry && entry->sends_since_last_recv < 255) {
+    // Progressive fallback: keep incrementing counter even when not using session key
+    entry->sends_since_last_recv++;
+    if (entry->sends_since_last_recv >= SESSION_KEY_ABANDON_THRESHOLD) {
+      // Give up: clear AEAD capability and remove session key
+      int idx = &contact - contacts;
+      if (idx >= 0 && idx < num_contacts)
+        contacts[idx].flags &= ~CONTACT_FLAG_AEAD;
+      session_keys.remove(contact.id.pub_key);
+      onSessionKeysUpdated();
+      // nonce = 0 (ECB)
+    } else if (entry->sends_since_last_recv >= SESSION_KEY_ECB_THRESHOLD) {
+      // nonce = 0 (ECB)
+    } else {
+      nonce = nextAeadNonceFor(contact);
+    }
+  } else {
+    nonce = nextAeadNonceFor(contact);
+  }
+
+  // Trigger session key negotiation on the next loop() tick.
+  // Checking here (the single funnel for all outgoing encryption) ensures no
+  // send path can silently skip a trigger — unlike the old per-call-site approach.
+  if (_pending_rekey_idx < 0 && shouldInitiateSessionKey(contact)) {
+    _pending_rekey_idx = &contact - contacts;
+  }
+
+  return nonce;
+}
+
+bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
+  // Only for AEAD-capable peers
+  if (!(contact.flags & CONTACT_FLAG_AEAD)) return false;
+
+  // Need a known path to send the request
+  if (contact.out_path_len < 0) return false;
+
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+
+  // Don't trigger if negotiation already in progress
+  if (entry && entry->state == SESSION_STATE_INIT_SENT) return false;
+
+  // Determine intervals based on hop count tier:
+  //   direct (0):  static=100, session=100
+  //   1–9 hops:    static=500, session=300
+  //   10+ hops:    static=1000, session=300
+  uint16_t static_interval, session_interval;
+  if (contact.out_path_len == 0) {
+    static_interval = 100;
+    session_interval = 100;
+  } else if (contact.out_path_len < 10) {
+    static_interval = 500;
+    session_interval = 300;
+  } else {
+    static_interval = 1000;
+    session_interval = 300;
+  }
+
+  if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+    if (entry->nonce < 65535) {
+      // Active session key with remaining nonces — renegotiate after nonce > 60000
+      if (entry->nonce <= NONCE_REKEY_THRESHOLD) return false;
+      return ((entry->nonce - NONCE_REKEY_THRESHOLD) % session_interval) == 0;
+    }
+    // Session key nonce exhausted — fall through to static ECDH trigger
+  }
+
+  // No session key (or state=NONE) — trigger based on static ECDH nonce vs interval
+  if (contact.aead_nonce == 0) return false;  // no messages sent yet
+  return (contact.aead_nonce % static_interval) == 0;
+}
+
+bool BaseChatMesh::initiateSessionKeyNegotiation(const ContactInfo& contact) {
+  auto entry = session_keys.allocate(contact.id.pub_key);
+  if (!entry) return false;
+
+  // Don't start a new negotiation if one is already pending
+  if (entry->state == SESSION_STATE_INIT_SENT) return false;
+
+  // Generate ephemeral keypair A
+  uint8_t seed[SEED_SIZE];
+  getRNG()->random(seed, SEED_SIZE);
+  ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+  memset(seed, 0, SEED_SIZE);
+
+  // Send REQ_TYPE_SESSION_KEY_INIT with ephemeral_pub_A
+  uint8_t req_data[1 + PUB_KEY_SIZE];
+  req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+  memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+  uint32_t tag, est_timeout;
+  int rc = sendRequest(contact, req_data, sizeof(req_data), tag, est_timeout);
+  if (rc == MSG_SEND_FAILED) {
+    memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+    memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+    return false;
+  }
+
+  entry->state = SESSION_STATE_INIT_SENT;
+  entry->retries_left = SESSION_KEY_MAX_RETRIES - 1;
+  entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+  return true;
+}
+
+bool BaseChatMesh::handleSessionKeyResponse(ContactInfo& contact, const uint8_t* data, uint8_t len) {
+  // Response format: [timestamp:4][RESP_TYPE_SESSION_KEY_ACCEPT:1][ephemeral_pub_B:32]
+  if (len < 5 + PUB_KEY_SIZE) return false;
+  if (data[4] != RESP_TYPE_SESSION_KEY_ACCEPT) return false;
+
+  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  if (!entry || entry->state != SESSION_STATE_INIT_SENT) return false;
+
+  const uint8_t* ephemeral_pub_B = &data[5];
+
+  // Compute ephemeral_secret via X25519
+  uint8_t ephemeral_secret[PUB_KEY_SIZE];
+  ed25519_key_exchange(ephemeral_secret, ephemeral_pub_B, entry->ephemeral_prv);
+  memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+  memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+
+  // Derive session_key = HMAC-SHA256(static_shared_secret, ephemeral_secret)
+  const uint8_t* static_secret = contact.getSharedSecret(self_id);
+  uint8_t new_session_key[SESSION_KEY_SIZE];
+  {
+    SHA256 sha;
+    sha.resetHMAC(static_secret, PUB_KEY_SIZE);
+    sha.update(ephemeral_secret, PUB_KEY_SIZE);
+    sha.finalizeHMAC(static_secret, PUB_KEY_SIZE, new_session_key, SESSION_KEY_SIZE);
+  }
+  memset(ephemeral_secret, 0, PUB_KEY_SIZE);
+
+  // Activate session key
+  memcpy(entry->session_key, new_session_key, SESSION_KEY_SIZE);
+  memset(new_session_key, 0, SESSION_KEY_SIZE);
+  entry->nonce = 1;
+  entry->state = SESSION_STATE_ACTIVE;
+  entry->sends_since_last_recv = 0;
+  entry->retries_left = 0;
+  entry->timeout_at = 0;
+
+  MESH_DEBUG_PRINTLN("Session key established with: %s", contact.name);
+  onSessionKeysUpdated();
+  return true;
+}
+
+uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf) {
+  // 1. Generate ephemeral keypair B
+  uint8_t seed[SEED_SIZE];
+  getRNG()->random(seed, SEED_SIZE);
+  uint8_t ephemeral_pub_B[PUB_KEY_SIZE];
+  uint8_t ephemeral_prv_B[PRV_KEY_SIZE];
+  ed25519_create_keypair(ephemeral_pub_B, ephemeral_prv_B, seed);
+  memset(seed, 0, SEED_SIZE);
+
+  // 2. Compute ephemeral_secret via X25519
+  uint8_t ephemeral_secret[PUB_KEY_SIZE];
+  ed25519_key_exchange(ephemeral_secret, ephemeral_pub_A, ephemeral_prv_B);
+  memset(ephemeral_prv_B, 0, PRV_KEY_SIZE);
+
+  // 3. Derive session_key = HMAC-SHA256(static_shared_secret, ephemeral_secret)
+  const uint8_t* static_secret = from.getSharedSecret(self_id);
+  uint8_t new_session_key[SESSION_KEY_SIZE];
+  {
+    SHA256 sha;
+    sha.resetHMAC(static_secret, PUB_KEY_SIZE);
+    sha.update(ephemeral_secret, PUB_KEY_SIZE);
+    sha.finalizeHMAC(static_secret, PUB_KEY_SIZE, new_session_key, SESSION_KEY_SIZE);
+  }
+  memset(ephemeral_secret, 0, PUB_KEY_SIZE);
+
+  // 4. Store in pool (dual-decode: new key active, old key still valid)
+  auto entry = session_keys.allocate(from.id.pub_key);
+  if (!entry) return 0;
+
+  if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
+    memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);
+  }
+  memcpy(entry->session_key, new_session_key, SESSION_KEY_SIZE);
+  entry->nonce = 1;
+  entry->state = SESSION_STATE_DUAL_DECODE;
+  entry->sends_since_last_recv = 0;
+  memset(new_session_key, 0, SESSION_KEY_SIZE);
+
+  // 5. Persist immediately
+  onSessionKeysUpdated();
+
+  // 6. Write ephemeral_pub_B to reply
+  memcpy(reply_buf, ephemeral_pub_B, PUB_KEY_SIZE);
+  MESH_DEBUG_PRINTLN("Session key INIT accepted from: %s", from.name);
+  return PUB_KEY_SIZE;
+}
+
+void BaseChatMesh::checkSessionKeyTimeouts() {
+  for (int i = 0; i < session_keys.getCount(); i++) {
+    auto entry = session_keys.getByIdx(i);
+    if (!entry || entry->state != SESSION_STATE_INIT_SENT) continue;
+    if (entry->timeout_at == 0 || !millisHasNowPassed(entry->timeout_at)) continue;
+
+    if (entry->retries_left > 0) {
+      // Retry: find the contact and resend INIT
+      for (int j = 0; j < num_contacts; j++) {
+        if (memcmp(contacts[j].id.pub_key, entry->peer_pub_prefix, 4) == 0) {
+          entry->retries_left--;
+          entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+
+          // Regenerate ephemeral keypair for retry
+          uint8_t seed[SEED_SIZE];
+          getRNG()->random(seed, SEED_SIZE);
+          ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+          memset(seed, 0, SEED_SIZE);
+
+          uint8_t req_data[1 + PUB_KEY_SIZE];
+          req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+          memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+          uint32_t tag, est_timeout;
+          sendRequest(contacts[j], req_data, sizeof(req_data), tag, est_timeout);
+          break;
+        }
+      }
+    } else {
+      // All retries exhausted — clean up
+      memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
+      memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+      entry->state = SESSION_STATE_NONE;
+      entry->timeout_at = 0;
+    }
+  }
+}
+
+// Virtual overrides for session key decrypt path
+const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    // Also try decode during INIT_SENT renegotiation (nonce > 1 means prior key exists)
+    if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE
+                  || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1)))
+      return entry->session_key;
+  }
+  return nullptr;
+}
+
+const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    if (entry && entry->state == SESSION_STATE_DUAL_DECODE)
+      return entry->prev_session_key;
+  }
+  return nullptr;
+}
+
+void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    if (entry) {
+      bool changed = (entry->state == SESSION_STATE_DUAL_DECODE);
+      if (changed) {
+        memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
+        entry->state = SESSION_STATE_ACTIVE;
+      }
+      entry->sends_since_last_recv = 0;
+      if (changed) onSessionKeysUpdated();
+    }
+  }
+}
+
+const uint8_t* BaseChatMesh::getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts)
+    return getEncryptionKeyFor(contacts[i]);
+  return static_secret;
+}
+
+uint16_t BaseChatMesh::getPeerEncryptionNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts)
+    return getEncryptionNonceFor(contacts[i]);
+  return getPeerNextAeadNonce(peer_idx);
+}
+
+// Session key persistence helpers (delegated to subclass for file I/O)
+bool BaseChatMesh::applyLoadedSessionKey(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                                          const uint8_t* session_key, const uint8_t* prev_session_key) {
+  return session_keys.applyLoaded(pub_key_prefix, flags, nonce, session_key, prev_session_key);
+}
+
+bool BaseChatMesh::getSessionKeyEntry(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                                       uint8_t* session_key, uint8_t* prev_session_key) {
+  return session_keys.getEntryForSave(idx, pub_key_prefix, flags, nonce, session_key, prev_session_key);
 }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1023,6 +1023,10 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
 
   removeSessionKey(contact.id.pub_key);  // also remove session key if any
 
+  // adjust pending rekey index before shifting array
+  if (_pending_rekey_idx == idx) _pending_rekey_idx = -1;
+  else if (_pending_rekey_idx > idx) _pending_rekey_idx--;
+
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
   while (idx < num_contacts) {

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -10,6 +10,49 @@
 #endif
 
 #define CLI_REPLY_DELAY_MILLIS      600
+uint16_t BaseChatMesh::nextAeadNonceFor(const ContactInfo& contact) {
+  uint16_t nonce = contact.nextAeadNonce();
+  if (nonce != 0) {
+    int idx = &contact - contacts;
+    if (idx >= 0 && idx < num_contacts &&
+        (uint16_t)(contact.aead_nonce - nonce_at_last_persist[idx]) >= NONCE_PERSIST_INTERVAL) {
+      nonce_dirty = true;
+    }
+  }
+  return nonce;
+}
+
+bool BaseChatMesh::applyLoadedNonce(const uint8_t* pub_key_prefix, uint16_t nonce) {
+  for (int i = 0; i < num_contacts; i++) {
+    if (memcmp(contacts[i].id.pub_key, pub_key_prefix, 4) == 0) {
+      contacts[i].aead_nonce = nonce;
+      return true;
+    }
+  }
+  return false;
+}
+
+void BaseChatMesh::finalizeNonceLoad(bool needs_bump) {
+  for (int i = 0; i < num_contacts; i++) {
+    if (needs_bump) {
+      uint16_t old = contacts[i].aead_nonce;
+      contacts[i].aead_nonce += NONCE_BOOT_BUMP;
+      if (contacts[i].aead_nonce == 0) contacts[i].aead_nonce = 1;
+      if (contacts[i].aead_nonce < old) {
+        MESH_DEBUG_PRINTLN("AEAD nonce wrapped after boot bump for peer: %s", contacts[i].name);
+      }
+    }
+    nonce_at_last_persist[i] = contacts[i].aead_nonce;
+  }
+  nonce_dirty = false;
+}
+
+bool BaseChatMesh::getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce) {
+  if (idx >= num_contacts) return false;
+  memcpy(pub_key_prefix, contacts[idx].id.pub_key, 4);
+  *nonce = contacts[idx].aead_nonce;
+  return true;
+}
 
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   sendFlood(pkt, delay_millis);
@@ -120,6 +163,7 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
   getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
+  if (ci.aead_nonce == 0) ci.aead_nonce = 1;
   if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
     ci.flags |= CONTACT_FLAG_AEAD;
   }
@@ -187,7 +231,8 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
       return;
     }
     
-    populateContactFromAdvert(*from, id, parser, timestamp);
+    populateContactFromAdvert(*from, id, parser, timestamp);  // seeds aead_nonce from RNG
+    nonce_at_last_persist[from - contacts] = from->aead_nonce;
     from->sync_since = 0;
     from->shared_secret_valid = false;
   }
@@ -241,7 +286,7 @@ uint8_t BaseChatMesh::getPeerFlags(int peer_idx) {
 uint16_t BaseChatMesh::getPeerNextAeadNonce(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    return contacts[i].nextAeadNonce();
+    return nextAeadNonceFor(contacts[i]);
   }
   return 0;
 }
@@ -277,7 +322,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, from.nextAeadNonce());
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -305,7 +350,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
         memcpy(temp, &timestamp, 4);
         temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, secret, temp, 5 + text_len, from.nextAeadNonce());
+        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, secret, temp, 5 + text_len, nextAeadNonceFor(from));
         if (reply_pkt) {
           if (from.out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodScoped(from, reply_pkt, CLI_REPLY_DELAY_MILLIS);
@@ -327,7 +372,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from.nextAeadNonce());
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -343,10 +388,10 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, from.nextAeadNonce());
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, nextAeadNonceFor(from));
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, from.nextAeadNonce());
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, nextAeadNonceFor(from));
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -412,7 +457,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, contact.nextAeadNonce());
+  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, nextAeadNonceFor(contact));
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -494,7 +539,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, recipient.nextAeadNonce());
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, nextAeadNonceFor(recipient));
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -525,7 +570,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (txt_type << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, recipient.nextAeadNonce());
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, nextAeadNonceFor(recipient));
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -697,7 +742,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, recipient.nextAeadNonce());
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, nextAeadNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -724,7 +769,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), recipient.nextAeadNonce());
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), nextAeadNonceFor(recipient));
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -847,7 +892,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, contact->nextAeadNonce());
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, nextAeadNonceFor(*contact));
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }
@@ -909,9 +954,12 @@ ContactInfo* BaseChatMesh::lookupContactByPubKey(const uint8_t* pub_key, int pre
 bool BaseChatMesh::addContact(const ContactInfo& contact) {
   ContactInfo* dest = allocateContactSlot(contact.type == ADV_TYPE_NONE);
   if (dest) {
+    int idx = dest - contacts;
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
     getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
+    if (dest->aead_nonce == 0) dest->aead_nonce = 1;
+    nonce_at_last_persist[idx] = dest->aead_nonce;
     return true;  // success
   }
   return false;
@@ -924,10 +972,11 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
   }
   if (idx >= num_contacts) return false;   // not found
 
-  // remove from contacts array
+  // remove from contacts array and parallel nonce tracking
   num_contacts--;
   while (idx < num_contacts) {
     contacts[idx] = contacts[idx + 1];
+    nonce_at_last_persist[idx] = nonce_at_last_persist[idx + 1];
     idx++;
   }
   return true;  // Success

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -230,6 +230,22 @@ void BaseChatMesh::getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) {
   }
 }
 
+uint8_t BaseChatMesh::getPeerFlags(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    return contacts[i].flags;
+  }
+  return 0;
+}
+
+uint16_t BaseChatMesh::getPeerNextAeadNonce(int peer_idx) {
+  int i = matching_peer_indexes[peer_idx];
+  if (i >= 0 && i < num_contacts) {
+    return contacts[i].nextAeadNonce();
+  }
+  return 0;
+}
+
 void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) {
   int i = matching_peer_indexes[sender_idx];
   if (i < 0 || i >= num_contacts) {
@@ -261,7 +277,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6);
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, ack_hash, 6);
@@ -289,7 +305,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
         memcpy(temp, &timestamp, 4);
         temp[4] = (TXT_TYPE_CLI_DATA << 2);
 
-        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, secret, temp, 5 + text_len);
+        auto reply_pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, from.id, secret, temp, 5 + text_len, from.nextAeadNonce());
         if (reply_pkt) {
           if (from.out_path_len == OUT_PATH_UNKNOWN) {
             sendFloodScoped(from, reply_pkt, CLI_REPLY_DELAY_MILLIS);
@@ -311,7 +327,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the ACK
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
+                                                PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
         sendAckTo(from, (uint8_t *) &ack_hash);
@@ -327,10 +343,10 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
       if (packet->isRouteFlood()) {
         // let this sender know path TO here, so they can use sendDirect(), and ALSO encode the response
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
-                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len);
+                                              PAYLOAD_TYPE_RESPONSE, temp_buf, reply_len, from.nextAeadNonce());
         if (path) sendFloodScoped(from, path, SERVER_RESPONSE_DELAY);
       } else {
-        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len);
+        mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, from.id, secret, temp_buf, reply_len, from.nextAeadNonce());
         if (reply) {
           if (from.out_path_len != OUT_PATH_UNKNOWN) {  // we have an out_path, so send DIRECT
             sendDirect(reply, from.out_path, from.out_path_len, SERVER_RESPONSE_DELAY);
@@ -396,7 +412,7 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
 void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len) {
   // NOTE: simplest impl is just to re-send a reciprocal return path to sender (DIRECTLY)
   //        override this method in various firmwares, if there's a better strategy
-  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0);
+  mesh::Packet* rpath = createPathReturn(contact.id, contact.getSharedSecret(self_id), path, path_len, 0, NULL, 0, contact.nextAeadNonce());
   if (rpath) sendDirect(rpath, contact.out_path, contact.out_path_len, 3000);   // 3 second delay
 }
 
@@ -478,7 +494,7 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
     temp[len++] = attempt;  // hide attempt number at tail end of payload
   }
 
-  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len);
+  return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len, recipient.nextAeadNonce());
 }
 
 int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
@@ -509,7 +525,7 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   temp[4] = (attempt & 3) | (txt_type << 2);
   memcpy(&temp[5], text, text_len + 1);
 
-  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len);
+  auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len, recipient.nextAeadNonce());
   if (pkt == NULL) return MSG_SEND_FAILED;
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -681,7 +697,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     memcpy(temp, &tag, 4);   // mostly an extra blob to help make packet_hash unique
     memcpy(&temp[4], req_data, data_len);
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len);
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len, recipient.nextAeadNonce());
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -708,7 +724,7 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     memset(&temp[5], 0, 4);  // reserved (possibly for 'since' param)
     getRNG()->random(&temp[9], 4);   // random blob to help make packet-hash unique
 
-    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp));
+    pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp), recipient.nextAeadNonce());
   }
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
@@ -831,7 +847,7 @@ void BaseChatMesh::checkConnections() {
       // calc expected ACK reply
       mesh::Utils::sha256((uint8_t *)&connections[i].expected_ack, 4, data, 9, self_id.pub_key, PUB_KEY_SIZE);
 
-      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9);
+      auto pkt = createDatagram(PAYLOAD_TYPE_REQ, contact->id, contact->getSharedSecret(self_id), data, 9, contact->nextAeadNonce());
       if (pkt) {
         sendDirect(pkt, contact->out_path, contact->out_path_len);
       }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1403,26 +1403,32 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
 
     if (entry->retries_left > 0) {
       // Retry: find the contact and resend INIT
+      ContactInfo* contact = nullptr;
       for (int j = 0; j < num_contacts; j++) {
         if (memcmp(contacts[j].id.pub_key, entry->peer_pub_prefix, 4) == 0) {
-          entry->retries_left--;
-          entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
-
-          // Regenerate ephemeral keypair for retry
-          uint8_t seed[SEED_SIZE];
-          getRNG()->random(seed, SEED_SIZE);
-          ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
-          memset(seed, 0, SEED_SIZE);
-
-          uint8_t req_data[1 + PUB_KEY_SIZE];
-          req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
-          memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
-
-          uint32_t tag, est_timeout;
-          sendRequest(contacts[j], req_data, sizeof(req_data), tag, est_timeout);
+          contact = &contacts[j];
           break;
         }
       }
+      if (!contact) {
+        entry->retries_left = 0;  // contact gone — fall through to cleanup on next tick
+        continue;
+      }
+      entry->retries_left--;
+      entry->timeout_at = futureMillis(SESSION_KEY_TIMEOUT_MS);
+
+      // Regenerate ephemeral keypair for retry
+      uint8_t seed[SEED_SIZE];
+      getRNG()->random(seed, SEED_SIZE);
+      ed25519_create_keypair(entry->ephemeral_pub, entry->ephemeral_prv, seed);
+      memset(seed, 0, SEED_SIZE);
+
+      uint8_t req_data[1 + PUB_KEY_SIZE];
+      req_data[0] = REQ_TYPE_SESSION_KEY_INIT;
+      memcpy(&req_data[1], entry->ephemeral_pub, PUB_KEY_SIZE);
+
+      uint32_t tag, est_timeout;
+      sendRequest(*contact, req_data, sizeof(req_data), tag, est_timeout);
     } else {
       // All retries exhausted — clean up
       memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1030,6 +1030,7 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
     nonce_at_last_persist[idx] = nonce_at_last_persist[idx + 1];
     idx++;
   }
+  memset(&contacts[num_contacts], 0, sizeof(ContactInfo));
   return true;  // Success
 }
 
@@ -1169,6 +1170,7 @@ SessionKeyEntry* BaseChatMesh::allocateSessionKey(const uint8_t* pub_key) {
 
 void BaseChatMesh::removeSessionKey(const uint8_t* pub_key) {
   session_keys.remove(pub_key);
+  session_keys_dirty = true;
 }
 
 // --- Session key support (Phase 2 — initiator) ---
@@ -1425,6 +1427,8 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
       // All retries exhausted — clean up
       memset(entry->ephemeral_prv, 0, PRV_KEY_SIZE);
       memset(entry->ephemeral_pub, 0, PUB_KEY_SIZE);
+      memset(entry->session_key, 0, SESSION_KEY_SIZE);
+      memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
       entry->state = SESSION_STATE_NONE;
       entry->timeout_at = 0;
     }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1238,7 +1238,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
   if (!(contact.flags & CONTACT_FLAG_AEAD)) return false;
 
   // Need a known path to send the request
-  if (contact.out_path_len < 0) return false;
+  if (contact.out_path_len == OUT_PATH_UNKNOWN) return false;
 
   auto entry = findSessionKey(contact.id.pub_key);
 
@@ -1473,9 +1473,9 @@ void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
       if (changed) {
         memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
         entry->state = SESSION_STATE_ACTIVE;
+        onSessionKeysUpdated();
       }
       entry->sends_since_last_recv = 0;
-      if (changed) onSessionKeysUpdated();
     }
   }
 }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -23,6 +23,7 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name) {
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     app_data_len = builder.encodeTo(app_data);
   }
 
@@ -34,6 +35,7 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, doubl
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name, lat, lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     app_data_len = builder.encodeTo(app_data);
   }
 
@@ -117,6 +119,10 @@ void BaseChatMesh::populateContactFromAdvert(ContactInfo& ci, const mesh::Identi
   }
   ci.last_advert_timestamp = timestamp;
   ci.lastmod = getRTCClock()->getCurrentTime();
+  getRNG()->random((uint8_t*)&ci.aead_nonce, sizeof(ci.aead_nonce));  // seed AEAD nonce from HW RNG
+  if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
+    ci.flags |= CONTACT_FLAG_AEAD;
+  }
 }
 
 void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) {
@@ -196,6 +202,11 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
   }
   from->last_advert_timestamp = timestamp;
   from->lastmod = getRTCClock()->getCurrentTime();
+  if (parser.getFeat1() & FEAT1_AEAD_SUPPORT) {
+    from->flags |= CONTACT_FLAG_AEAD;
+  } else {
+    from->flags &= ~CONTACT_FLAG_AEAD;
+  }
 
   onDiscoveredContact(*from, is_new, packet->path_len, packet->path);       // let UI know
 }
@@ -884,6 +895,7 @@ bool BaseChatMesh::addContact(const ContactInfo& contact) {
   if (dest) {
     *dest = contact;
     dest->shared_secret_valid = false; // mark shared_secret as needing calculation
+    getRNG()->random((uint8_t*)&dest->aead_nonce, sizeof(dest->aead_nonce));  // always seed fresh from HW RNG
     return true;  // success
   }
   return false;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1021,7 +1021,7 @@ bool BaseChatMesh::removeContact(ContactInfo& contact) {
   }
   if (idx >= num_contacts) return false;   // not found
 
-  session_keys.remove(contact.id.pub_key);  // also remove session key if any
+  removeSessionKey(contact.id.pub_key);  // also remove session key if any
 
   // remove from contacts array and parallel nonce tracking
   num_contacts--;
@@ -1136,6 +1136,41 @@ void BaseChatMesh::loop() {
   }
 }
 
+// --- Session key flash-backed wrappers ---
+
+SessionKeyEntry* BaseChatMesh::findSessionKey(const uint8_t* pub_key) {
+  auto entry = session_keys.findByPrefix(pub_key);
+  if (entry) return entry;
+
+  // Cache miss — try flash
+  uint8_t flags; uint16_t nonce;
+  uint8_t sk[SESSION_KEY_SIZE], psk[SESSION_KEY_SIZE];
+  if (!loadSessionKeyRecordFromFlash(pub_key, &flags, &nonce, sk, psk)) return nullptr;
+
+  // Save dirty evictee before overwriting
+  if (session_keys.isFull() && session_keys_dirty) {
+    mergeAndSaveSessionKeys();
+  }
+  session_keys.applyLoaded(pub_key, flags, nonce, sk, psk);
+  return session_keys.findByPrefix(pub_key);
+}
+
+SessionKeyEntry* BaseChatMesh::allocateSessionKey(const uint8_t* pub_key) {
+  // Check RAM and flash first
+  auto entry = findSessionKey(pub_key);
+  if (entry) return entry;
+
+  // Not found anywhere — save dirty evictee before allocating
+  if (session_keys.isFull() && session_keys_dirty) {
+    mergeAndSaveSessionKeys();
+  }
+  return session_keys.allocate(pub_key);
+}
+
+void BaseChatMesh::removeSessionKey(const uint8_t* pub_key) {
+  session_keys.remove(pub_key);
+}
+
 // --- Session key support (Phase 2 — initiator) ---
 
 static bool canUseSessionKey(const SessionKeyEntry* entry) {
@@ -1151,7 +1186,7 @@ static bool canUseSessionKey(const SessionKeyEntry* entry) {
 }
 
 const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
     return entry->session_key;
   }
@@ -1160,7 +1195,7 @@ const uint8_t* BaseChatMesh::getEncryptionKeyFor(const ContactInfo& contact) {
 
 uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
   uint16_t nonce = 0;
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (canUseSessionKey(entry)) {
     ++entry->nonce;
     if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
@@ -1174,7 +1209,7 @@ uint16_t BaseChatMesh::getEncryptionNonceFor(const ContactInfo& contact) {
       int idx = &contact - contacts;
       if (idx >= 0 && idx < num_contacts)
         contacts[idx].flags &= ~CONTACT_FLAG_AEAD;
-      session_keys.remove(contact.id.pub_key);
+      removeSessionKey(contact.id.pub_key);
       onSessionKeysUpdated();
       // nonce = 0 (ECB)
     } else if (entry->sends_since_last_recv >= SESSION_KEY_ECB_THRESHOLD) {
@@ -1203,7 +1238,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
   // Need a known path to send the request
   if (contact.out_path_len < 0) return false;
 
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
 
   // Don't trigger if negotiation already in progress
   if (entry && entry->state == SESSION_STATE_INIT_SENT) return false;
@@ -1239,7 +1274,7 @@ bool BaseChatMesh::shouldInitiateSessionKey(const ContactInfo& contact) {
 }
 
 bool BaseChatMesh::initiateSessionKeyNegotiation(const ContactInfo& contact) {
-  auto entry = session_keys.allocate(contact.id.pub_key);
+  auto entry = allocateSessionKey(contact.id.pub_key);
   if (!entry) return false;
 
   // Don't start a new negotiation if one is already pending
@@ -1275,7 +1310,7 @@ bool BaseChatMesh::handleSessionKeyResponse(ContactInfo& contact, const uint8_t*
   if (len < 5 + PUB_KEY_SIZE) return false;
   if (data[4] != RESP_TYPE_SESSION_KEY_ACCEPT) return false;
 
-  auto entry = session_keys.findByPrefix(contact.id.pub_key);
+  auto entry = findSessionKey(contact.id.pub_key);
   if (!entry || entry->state != SESSION_STATE_INIT_SENT) return false;
 
   const uint8_t* ephemeral_pub_B = &data[5];
@@ -1337,7 +1372,7 @@ uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint
   memset(ephemeral_secret, 0, PUB_KEY_SIZE);
 
   // 4. Store in pool (dual-decode: new key active, old key still valid)
-  auto entry = session_keys.allocate(from.id.pub_key);
+  auto entry = allocateSessionKey(from.id.pub_key);
   if (!entry) return 0;
 
   if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
@@ -1400,7 +1435,7 @@ void BaseChatMesh::checkSessionKeyTimeouts() {
 const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     // Also try decode during INIT_SENT renegotiation (nonce > 1 means prior key exists)
     if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE
                   || (entry->state == SESSION_STATE_INIT_SENT && entry->nonce > 1)))
@@ -1412,7 +1447,7 @@ const uint8_t* BaseChatMesh::getPeerSessionKey(int peer_idx) {
 const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     if (entry && entry->state == SESSION_STATE_DUAL_DECODE)
       return entry->prev_session_key;
   }
@@ -1422,7 +1457,7 @@ const uint8_t* BaseChatMesh::getPeerPrevSessionKey(int peer_idx) {
 void BaseChatMesh::onSessionKeyDecryptSuccess(int peer_idx) {
   int i = matching_peer_indexes[peer_idx];
   if (i >= 0 && i < num_contacts) {
-    auto entry = session_keys.findByPrefix(contacts[i].id.pub_key);
+    auto entry = findSessionKey(contacts[i].id.pub_key);
     if (entry) {
       bool changed = (entry->state == SESSION_STATE_DUAL_DECODE);
       if (changed) {

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1375,7 +1375,10 @@ uint8_t BaseChatMesh::handleIncomingSessionKeyInit(ContactInfo& from, const uint
 
   // 4. Store in pool (dual-decode: new key active, old key still valid)
   auto entry = allocateSessionKey(from.id.pub_key);
-  if (!entry) return 0;
+  if (!entry) {
+    memset(new_session_key, 0, SESSION_KEY_SIZE);
+    return 0;
+  }
 
   if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
     memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -8,6 +8,7 @@
 #define MAX_TEXT_LEN    (10*CIPHER_BLOCK_SIZE)  // must be LESS than (MAX_PACKET_PAYLOAD - 4 - CIPHER_MAC_SIZE - 1)
 
 #include "ContactInfo.h"
+#include "SessionKeyPool.h"
 
 #define MAX_SEARCH_RESULTS   8
 
@@ -78,6 +79,11 @@ class BaseChatMesh : public mesh::Mesh {
   uint16_t nonce_at_last_persist[MAX_CONTACTS];
   bool nonce_dirty;
 
+  // Session key pool (Phase 2)
+  SessionKeyPool session_keys;
+  bool session_keys_dirty;
+  int _pending_rekey_idx;  // contact index needing session key negotiation, -1 = none
+
   mesh::Packet* composeMsgPacket(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char *text, uint32_t& expected_ack);
   void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4);
 
@@ -96,6 +102,8 @@ protected:
     memset(connections, 0, sizeof(connections));
     memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
     nonce_dirty = false;
+    session_keys_dirty = false;
+    _pending_rekey_idx = -1;
   }
 
   void bootstrapRTCfromContacts();
@@ -149,12 +157,36 @@ protected:
     nonce_dirty = false;
   }
 
+  // Session key support (Phase 2 — initiator)
+  virtual void onSessionKeysUpdated() { session_keys_dirty = true; }  // called when session key pool changes; override to persist
+  const uint8_t* getEncryptionKeyFor(const ContactInfo& contact);
+  uint16_t getEncryptionNonceFor(const ContactInfo& contact);
+  bool shouldInitiateSessionKey(const ContactInfo& contact);
+  bool initiateSessionKeyNegotiation(const ContactInfo& contact);
+  bool handleSessionKeyResponse(ContactInfo& contact, const uint8_t* data, uint8_t len);
+  uint8_t handleIncomingSessionKeyInit(ContactInfo& from, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf);
+  void checkSessionKeyTimeouts();
+
+  // Session key persistence helpers (for subclass to call)
+  bool applyLoadedSessionKey(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                             const uint8_t* session_key, const uint8_t* prev_session_key);
+  bool getSessionKeyEntry(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                          uint8_t* session_key, uint8_t* prev_session_key);
+  int getSessionKeyCount() const { return session_keys.getCount(); }
+  bool isSessionKeysDirty() const { return session_keys_dirty; }
+  void clearSessionKeysDirty() { session_keys_dirty = false; }
+
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -74,6 +74,10 @@ class BaseChatMesh : public mesh::Mesh {
   uint8_t temp_buf[MAX_TRANS_UNIT];
   ConnectionInfo connections[MAX_CONNECTIONS];
 
+  // Nonce persistence state (parallel to contacts[])
+  uint16_t nonce_at_last_persist[MAX_CONTACTS];
+  bool nonce_dirty;
+
   mesh::Packet* composeMsgPacket(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char *text, uint32_t& expected_ack);
   void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4);
 
@@ -90,6 +94,8 @@ protected:
     txt_send_timeout = 0;
     _pendingLoopback = NULL;
     memset(connections, 0, sizeof(connections));
+    memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
+    nonce_dirty = false;
   }
 
   void bootstrapRTCfromContacts();
@@ -131,6 +137,17 @@ protected:
   // storage concepts, for sub-classes to override/implement
   virtual int  getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]) { return 0; }  // not implemented
   virtual bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], int len) { return false; }
+
+  // AEAD nonce persistence helpers
+  uint16_t nextAeadNonceFor(const ContactInfo& contact);  // wraps nextAeadNonce() with dirty-check
+  bool applyLoadedNonce(const uint8_t* pub_key_prefix, uint16_t nonce);
+  void finalizeNonceLoad(bool needs_bump);
+  bool getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce);
+  bool isNonceDirty() const { return nonce_dirty; }
+  void clearNonceDirty() {
+    for (int i = 0; i < num_contacts; i++) nonce_at_last_persist[i] = contacts[i].aead_nonce;
+    nonce_dirty = false;
+  }
 
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -136,6 +136,8 @@ protected:
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -159,6 +159,15 @@ protected:
 
   // Session key support (Phase 2 — initiator)
   virtual void onSessionKeysUpdated() { session_keys_dirty = true; }  // called when session key pool changes; override to persist
+  virtual bool loadSessionKeyRecordFromFlash(const uint8_t* pub_key_prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key) { return false; }
+  virtual void mergeAndSaveSessionKeys() {}  // merge RAM + flash, write back
+
+  // Wrappers that add flash fallback on cache miss
+  SessionKeyEntry* findSessionKey(const uint8_t* pub_key);
+  SessionKeyEntry* allocateSessionKey(const uint8_t* pub_key);
+  void removeSessionKey(const uint8_t* pub_key);
+
   const uint8_t* getEncryptionKeyFor(const ContactInfo& contact);
   uint16_t getEncryptionNonceFor(const ContactInfo& contact);
   bool shouldInitiateSessionKey(const ContactInfo& contact);
@@ -175,6 +184,9 @@ protected:
   int getSessionKeyCount() const { return session_keys.getCount(); }
   bool isSessionKeysDirty() const { return session_keys_dirty; }
   void clearSessionKeysDirty() { session_keys_dirty = false; }
+  bool isSessionKeyInRAMPool(const uint8_t* pub_key_prefix) { return session_keys.hasPrefix(pub_key_prefix); }
+  bool isSessionKeyRemovedFromPool(const uint8_t* pub_key_prefix) { return session_keys.isRemoved(pub_key_prefix); }
+  void clearSessionKeysRemoved() { session_keys.clearRemoved(); }
 
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -8,6 +8,7 @@
 #define MAX_TEXT_LEN    (10*CIPHER_BLOCK_SIZE)  // must be LESS than (MAX_PACKET_PAYLOAD - 4 - CIPHER_MAC_SIZE - 1)
 
 #include "ContactInfo.h"
+#include "SessionKeyPool.h"
 
 #define MAX_SEARCH_RESULTS   8
 
@@ -78,6 +79,11 @@ class BaseChatMesh : public mesh::Mesh {
   uint16_t nonce_at_last_persist[MAX_CONTACTS];
   bool nonce_dirty;
 
+  // Session key pool (Phase 2)
+  SessionKeyPool session_keys;
+  bool session_keys_dirty;
+  int _pending_rekey_idx;  // contact index needing session key negotiation, -1 = none
+
   mesh::Packet* composeMsgPacket(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char *text, uint32_t& expected_ack);
   void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4);
 
@@ -96,6 +102,8 @@ protected:
     memset(connections, 0, sizeof(connections));
     memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
     nonce_dirty = false;
+    session_keys_dirty = false;
+    _pending_rekey_idx = -1;
   }
 
   void bootstrapRTCfromContacts();
@@ -150,12 +158,36 @@ protected:
     nonce_dirty = false;
   }
 
+  // Session key support (Phase 2 — initiator)
+  virtual void onSessionKeysUpdated() { session_keys_dirty = true; }  // called when session key pool changes; override to persist
+  const uint8_t* getEncryptionKeyFor(const ContactInfo& contact);
+  uint16_t getEncryptionNonceFor(const ContactInfo& contact);
+  bool shouldInitiateSessionKey(const ContactInfo& contact);
+  bool initiateSessionKeyNegotiation(const ContactInfo& contact);
+  bool handleSessionKeyResponse(ContactInfo& contact, const uint8_t* data, uint8_t len);
+  uint8_t handleIncomingSessionKeyInit(ContactInfo& from, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf);
+  void checkSessionKeyTimeouts();
+
+  // Session key persistence helpers (for subclass to call)
+  bool applyLoadedSessionKey(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                             const uint8_t* session_key, const uint8_t* prev_session_key);
+  bool getSessionKeyEntry(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                          uint8_t* session_key, uint8_t* prev_session_key);
+  int getSessionKeyCount() const { return session_keys.getCount(); }
+  bool isSessionKeysDirty() const { return session_keys_dirty; }
+  void clearSessionKeysDirty() { session_keys_dirty = false; }
+
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
   uint8_t getPeerFlags(int peer_idx) override;
   uint16_t getPeerNextAeadNonce(int peer_idx) override;
+  const uint8_t* getPeerSessionKey(int peer_idx) override;
+  const uint8_t* getPeerPrevSessionKey(int peer_idx) override;
+  void onSessionKeyDecryptSuccess(int peer_idx) override;
+  const uint8_t* getPeerEncryptionKey(int peer_idx, const uint8_t* static_secret) override;
+  uint16_t getPeerEncryptionNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -74,6 +74,10 @@ class BaseChatMesh : public mesh::Mesh {
   uint8_t temp_buf[MAX_TRANS_UNIT];
   ConnectionInfo connections[MAX_CONNECTIONS];
 
+  // Nonce persistence state (parallel to contacts[])
+  uint16_t nonce_at_last_persist[MAX_CONTACTS];
+  bool nonce_dirty;
+
   mesh::Packet* composeMsgPacket(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char *text, uint32_t& expected_ack);
   void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4);
 
@@ -90,6 +94,8 @@ protected:
     txt_send_timeout = 0;
     _pendingLoopback = NULL;
     memset(connections, 0, sizeof(connections));
+    memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
+    nonce_dirty = false;
   }
 
   void bootstrapRTCfromContacts();
@@ -132,6 +138,17 @@ protected:
   // storage concepts, for sub-classes to override/implement
   virtual int  getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]) { return 0; }  // not implemented
   virtual bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], int len) { return false; }
+
+  // AEAD nonce persistence helpers
+  uint16_t nextAeadNonceFor(const ContactInfo& contact);  // wraps nextAeadNonce() with dirty-check
+  bool applyLoadedNonce(const uint8_t* pub_key_prefix, uint16_t nonce);
+  void finalizeNonceLoad(bool needs_bump);
+  bool getNonceEntry(int idx, uint8_t* pub_key_prefix, uint16_t* nonce);
+  bool isNonceDirty() const { return nonce_dirty; }
+  void clearNonceDirty() {
+    for (int i = 0; i < num_contacts; i++) nonce_at_last_persist[i] = contacts[i].aead_nonce;
+    nonce_dirty = false;
+  }
 
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -160,6 +160,15 @@ protected:
 
   // Session key support (Phase 2 — initiator)
   virtual void onSessionKeysUpdated() { session_keys_dirty = true; }  // called when session key pool changes; override to persist
+  virtual bool loadSessionKeyRecordFromFlash(const uint8_t* pub_key_prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key) { return false; }
+  virtual void mergeAndSaveSessionKeys() {}  // merge RAM + flash, write back
+
+  // Wrappers that add flash fallback on cache miss
+  SessionKeyEntry* findSessionKey(const uint8_t* pub_key);
+  SessionKeyEntry* allocateSessionKey(const uint8_t* pub_key);
+  void removeSessionKey(const uint8_t* pub_key);
+
   const uint8_t* getEncryptionKeyFor(const ContactInfo& contact);
   uint16_t getEncryptionNonceFor(const ContactInfo& contact);
   bool shouldInitiateSessionKey(const ContactInfo& contact);
@@ -176,6 +185,9 @@ protected:
   int getSessionKeyCount() const { return session_keys.getCount(); }
   bool isSessionKeysDirty() const { return session_keys_dirty; }
   void clearSessionKeysDirty() { session_keys_dirty = false; }
+  bool isSessionKeyInRAMPool(const uint8_t* pub_key_prefix) { return session_keys.hasPrefix(pub_key_prefix); }
+  bool isSessionKeyRemovedFromPool(const uint8_t* pub_key_prefix) { return session_keys.isRemoved(pub_key_prefix); }
+  void clearSessionKeysRemoved() { session_keys.clearRemoved(); }
 
   // Mesh overrides
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -137,6 +137,8 @@ protected:
   void onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, uint32_t timestamp, const uint8_t* app_data, size_t app_data_len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
+  uint8_t getPeerFlags(int peer_idx) override;
+  uint16_t getPeerNextAeadNonce(int peer_idx) override;
   void onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_idx, const uint8_t* secret, uint8_t* data, size_t len) override;
   bool onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint8_t* secret, uint8_t* path, uint8_t path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) override;
   void onAckRecv(mesh::Packet* packet, uint32_t ack_crc) override;

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -1,5 +1,7 @@
 #include "ClientACL.h"
 #include <MeshCore.h>
+#include <SHA256.h>
+#include <ed_25519.h>
 
 static File openWrite(FILESYSTEM* _fs, const char* filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
@@ -118,8 +120,7 @@ ClientInfo* ClientACL::putClient(const mesh::Identity& id, uint8_t init_perms) {
   c->id = id;
   c->out_path_len = OUT_PATH_UNKNOWN;
   if (_rng) {
-    _rng->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
-    if (c->aead_nonce == 0) c->aead_nonce = 1;
+    c->aead_nonce = (uint16_t)_rng->nextInt(NONCE_INITIAL_MIN, NONCE_INITIAL_MAX + 1);
   }
   nonce_at_last_persist[idx] = c->aead_nonce;
   return c;
@@ -191,6 +192,20 @@ void ClientACL::finalizeNonceLoad(bool needs_bump) {
     nonce_at_last_persist[i] = clients[i].aead_nonce;
   }
   nonce_dirty = false;
+
+  // Apply boot bump to session key nonces too
+  if (needs_bump) {
+    for (int i = 0; i < session_keys.getCount(); i++) {
+      auto entry = session_keys.getByIdx(i);
+      if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+        uint16_t old_nonce = entry->nonce;
+        entry->nonce += NONCE_BOOT_BUMP;
+        if (entry->nonce <= old_nonce) {
+          entry->nonce = 65535;  // wrapped — force exhaustion so renegotiation happens
+        }
+      }
+    }
+  }
 }
 
 bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8_t* pubkey, int key_len, uint8_t perms) {
@@ -198,6 +213,8 @@ bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8
   if ((perms & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST) {  // guest role is not persisted in contacts
     c = getClient(pubkey, key_len);
     if (c == NULL) return false;   // partial pubkey not found
+
+    session_keys.remove(c->id.pub_key);  // also remove session key if any
 
     num_clients--;   // delete from contacts[]
     int i = c - clients;
@@ -216,4 +233,199 @@ bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8
     self_id.calcSharedSecret(c->shared_secret, pubkey);
   }
   return true;
+}
+
+// --- Session key support (Phase 2) ---
+
+int ClientACL::handleSessionKeyInit(const ClientInfo* client, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf, mesh::RNG* rng) {
+  // 1. Generate ephemeral keypair B
+  uint8_t seed[SEED_SIZE];
+  rng->random(seed, SEED_SIZE);
+  uint8_t ephemeral_pub_B[PUB_KEY_SIZE];
+  uint8_t ephemeral_prv_B[PRV_KEY_SIZE];
+  ed25519_create_keypair(ephemeral_pub_B, ephemeral_prv_B, seed);
+  memset(seed, 0, SEED_SIZE);
+
+  // 2. Compute ephemeral_secret via X25519
+  uint8_t ephemeral_secret[PUB_KEY_SIZE];
+  ed25519_key_exchange(ephemeral_secret, ephemeral_pub_A, ephemeral_prv_B);
+  memset(ephemeral_prv_B, 0, PRV_KEY_SIZE);
+
+  // 3. Derive session_key = HMAC-SHA256(static_shared_secret, ephemeral_secret)
+  uint8_t new_session_key[SESSION_KEY_SIZE];
+  {
+    SHA256 sha;
+    sha.resetHMAC(client->shared_secret, PUB_KEY_SIZE);
+    sha.update(ephemeral_secret, PUB_KEY_SIZE);
+    sha.finalizeHMAC(client->shared_secret, PUB_KEY_SIZE, new_session_key, SESSION_KEY_SIZE);
+  }
+  memset(ephemeral_secret, 0, PUB_KEY_SIZE);
+
+  // 4. Store in pool (dual-decode: new key active, old key still valid)
+  auto entry = session_keys.allocate(client->id.pub_key);
+  if (!entry) return 0;
+
+  if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
+    memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);
+  }
+  memcpy(entry->session_key, new_session_key, SESSION_KEY_SIZE);
+  entry->nonce = 1;
+  entry->state = SESSION_STATE_DUAL_DECODE;
+  entry->sends_since_last_recv = 0;
+  memset(new_session_key, 0, SESSION_KEY_SIZE);
+
+  // 5. Persist immediately
+  saveSessionKeys();
+
+  // 6. Write ephemeral_pub_B to reply
+  memcpy(reply_buf, ephemeral_pub_B, PUB_KEY_SIZE);
+  return PUB_KEY_SIZE;
+}
+
+const uint8_t* ClientACL::getSessionKey(const uint8_t* pub_key) {
+  auto entry = session_keys.findByPrefix(pub_key);
+  if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)) {
+    return entry->session_key;
+  }
+  return nullptr;
+}
+
+const uint8_t* ClientACL::getPrevSessionKey(const uint8_t* pub_key) {
+  auto entry = session_keys.findByPrefix(pub_key);
+  if (entry && entry->state == SESSION_STATE_DUAL_DECODE) {
+    return entry->prev_session_key;
+  }
+  return nullptr;
+}
+
+const uint8_t* ClientACL::getEncryptionKey(const ClientInfo& client) {
+  auto entry = session_keys.findByPrefix(client.id.pub_key);
+  if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)
+      && entry->sends_since_last_recv < SESSION_KEY_STALE_THRESHOLD
+      && entry->nonce < 65535) {
+    return entry->session_key;
+  }
+  return client.shared_secret;
+}
+
+uint16_t ClientACL::getEncryptionNonce(const ClientInfo& client) {
+  auto entry = session_keys.findByPrefix(client.id.pub_key);
+  if (entry && (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE)
+      && entry->sends_since_last_recv < SESSION_KEY_STALE_THRESHOLD
+      && entry->nonce < 65535) {
+    ++entry->nonce;
+    if (entry->sends_since_last_recv < 255) entry->sends_since_last_recv++;
+    _session_keys_dirty = true;
+    return entry->nonce;
+  }
+  // Progressive fallback: keep incrementing counter even when not using session key
+  if (entry && entry->sends_since_last_recv < 255) {
+    entry->sends_since_last_recv++;
+    if (entry->sends_since_last_recv >= SESSION_KEY_ABANDON_THRESHOLD) {
+      int idx = &client - clients;
+      if (idx >= 0 && idx < num_clients)
+        clients[idx].flags &= ~CONTACT_FLAG_AEAD;
+      session_keys.remove(client.id.pub_key);
+      saveSessionKeys();
+      return 0;  // ECB
+    }
+    if (entry->sends_since_last_recv >= SESSION_KEY_ECB_THRESHOLD) {
+      return 0;  // ECB
+    }
+  }
+  return nextAeadNonceFor(client);
+}
+
+void ClientACL::onSessionConfirmed(const uint8_t* pub_key) {
+  auto entry = session_keys.findByPrefix(pub_key);
+  if (entry) {
+    if (entry->state == SESSION_STATE_DUAL_DECODE) {
+      memset(entry->prev_session_key, 0, SESSION_KEY_SIZE);
+      entry->state = SESSION_STATE_ACTIVE;
+      saveSessionKeys();
+    }
+    entry->sends_since_last_recv = 0;
+  }
+}
+
+// --- Peer-index forwarding helpers ---
+
+ClientInfo* ClientACL::resolveClient(int peer_idx, const int* matching_indexes) {
+  int i = matching_indexes[peer_idx];
+  if (i >= 0 && i < num_clients) return &clients[i];
+  return nullptr;
+}
+
+uint16_t ClientACL::peerNextAeadNonce(int peer_idx, const int* matching_indexes) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  return c ? nextAeadNonceFor(*c) : 0;
+}
+
+const uint8_t* ClientACL::peerSessionKey(int peer_idx, const int* matching_indexes) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  return c ? getSessionKey(c->id.pub_key) : nullptr;
+}
+
+const uint8_t* ClientACL::peerPrevSessionKey(int peer_idx, const int* matching_indexes) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  return c ? getPrevSessionKey(c->id.pub_key) : nullptr;
+}
+
+void ClientACL::peerSessionKeyDecryptSuccess(int peer_idx, const int* matching_indexes) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  if (c) onSessionConfirmed(c->id.pub_key);
+}
+
+const uint8_t* ClientACL::peerEncryptionKey(int peer_idx, const int* matching_indexes, const uint8_t* fallback) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  return c ? getEncryptionKey(*c) : fallback;
+}
+
+uint16_t ClientACL::peerEncryptionNonce(int peer_idx, const int* matching_indexes) {
+  auto* c = resolveClient(peer_idx, matching_indexes);
+  return c ? getEncryptionNonce(*c) : 0;
+}
+
+void ClientACL::loadSessionKeys() {
+  if (!_fs) return;
+#if defined(RP2040_PLATFORM)
+  File file = _fs->open("/s_sess_keys", "r");
+#elif defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  File file = _fs->open("/s_sess_keys", FILE_O_READ);
+#else
+  File file = _fs->open("/s_sess_keys", "r", false);
+#endif
+  if (file) {
+    uint8_t rec[71];  // [pub_prefix:4][flags:1][nonce:2][session_key:32][prev_session_key:32]
+    while (file.read(rec, 71) == 71) {
+      uint8_t flags = rec[4];
+      uint16_t nonce;
+      memcpy(&nonce, &rec[5], 2);
+      session_keys.applyLoaded(rec, flags, nonce, &rec[7], &rec[39]);
+    }
+    file.close();
+  }
+}
+
+void ClientACL::saveSessionKeys() {
+  _session_keys_dirty = false;
+  if (!_fs) return;
+  File file = openWrite(_fs, "/s_sess_keys");
+  if (file) {
+    for (int i = 0; i < session_keys.getCount(); i++) {
+      uint8_t pub_key_prefix[4];
+      uint8_t flags;
+      uint16_t nonce;
+      uint8_t session_key[SESSION_KEY_SIZE];
+      uint8_t prev_session_key[SESSION_KEY_SIZE];
+      if (session_keys.getEntryForSave(i, pub_key_prefix, &flags, &nonce, session_key, prev_session_key)) {
+        file.write(pub_key_prefix, 4);
+        file.write(&flags, 1);
+        file.write((uint8_t*)&nonce, 2);
+        file.write(session_key, SESSION_KEY_SIZE);
+        file.write(prev_session_key, SESSION_KEY_SIZE);
+      }
+    }
+    file.close();
+  }
 }

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -1,4 +1,5 @@
 #include "ClientACL.h"
+#include <MeshCore.h>
 
 static File openWrite(FILESYSTEM* _fs, const char* filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
@@ -111,11 +112,85 @@ ClientInfo* ClientACL::putClient(const mesh::Identity& id, uint8_t init_perms) {
   } else {
     c = oldest;  // evict least active contact
   }
+  int idx = c - clients;
   memset(c, 0, sizeof(*c));
   c->permissions = init_perms;
   c->id = id;
   c->out_path_len = OUT_PATH_UNKNOWN;
+  if (_rng) {
+    _rng->random((uint8_t*)&c->aead_nonce, sizeof(c->aead_nonce));
+    if (c->aead_nonce == 0) c->aead_nonce = 1;
+  }
+  nonce_at_last_persist[idx] = c->aead_nonce;
   return c;
+}
+
+uint16_t ClientACL::nextAeadNonceFor(const ClientInfo& client) {
+  uint16_t nonce = client.nextAeadNonce();
+  if (nonce != 0) {
+    int idx = &client - clients;
+    if (idx >= 0 && idx < num_clients &&
+        (uint16_t)(client.aead_nonce - nonce_at_last_persist[idx]) >= NONCE_PERSIST_INTERVAL) {
+      nonce_dirty = true;
+    }
+  }
+  return nonce;
+}
+
+void ClientACL::loadNonces() {
+  if (!_fs) return;
+#if defined(RP2040_PLATFORM)
+  File file = _fs->open("/s_nonces", "r");
+#elif defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  File file = _fs->open("/s_nonces", FILE_O_READ);
+#else
+  File file = _fs->open("/s_nonces", "r", false);
+#endif
+  if (file) {
+    uint8_t rec[6];  // 4-byte pub_key prefix + 2-byte nonce
+    while (file.read(rec, 6) == 6) {
+      uint16_t nonce;
+      memcpy(&nonce, &rec[4], 2);
+      for (int i = 0; i < num_clients; i++) {
+        if (memcmp(clients[i].id.pub_key, rec, 4) == 0) {
+          clients[i].aead_nonce = nonce;
+          break;
+        }
+      }
+    }
+    file.close();
+  }
+}
+
+void ClientACL::saveNonces() {
+  if (!_fs) return;
+  File file = openWrite(_fs, "/s_nonces");
+  if (file) {
+    for (int i = 0; i < num_clients; i++) {
+      file.write(clients[i].id.pub_key, 4);
+      file.write((uint8_t*)&clients[i].aead_nonce, 2);
+      nonce_at_last_persist[i] = clients[i].aead_nonce;
+    }
+    file.close();
+    nonce_dirty = false;
+  }
+}
+
+void ClientACL::finalizeNonceLoad(bool needs_bump) {
+  for (int i = 0; i < num_clients; i++) {
+    if (needs_bump) {
+      uint16_t old = clients[i].aead_nonce;
+      clients[i].aead_nonce += NONCE_BOOT_BUMP;
+      if (clients[i].aead_nonce == 0) clients[i].aead_nonce = 1;
+      if (clients[i].aead_nonce < old) {
+        MESH_DEBUG_PRINTLN("AEAD nonce wrapped after boot bump for client: %02x%02x%02x%02x",
+          clients[i].id.pub_key[0], clients[i].id.pub_key[1],
+          clients[i].id.pub_key[2], clients[i].id.pub_key[3]);
+      }
+    }
+    nonce_at_last_persist[i] = clients[i].aead_nonce;
+  }
+  nonce_dirty = false;
 }
 
 bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8_t* pubkey, int key_len, uint8_t perms) {
@@ -128,6 +203,7 @@ bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8
     int i = c - clients;
     while (i < num_clients) {
       clients[i] = clients[i + 1];
+      nonce_at_last_persist[i] = nonce_at_last_persist[i + 1];
       i++;
     }
   } else {

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -223,6 +223,7 @@ bool ClientACL::applyPermissions(const mesh::LocalIdentity& self_id, const uint8
       nonce_at_last_persist[i] = nonce_at_last_persist[i + 1];
       i++;
     }
+    memset(&clients[num_clients], 0, sizeof(ClientInfo));
   } else {
     if (key_len < PUB_KEY_SIZE) return false;   // need complete pubkey when adding/modifying
 
@@ -460,6 +461,7 @@ SessionKeyEntry* ClientACL::allocateSessionKey(const uint8_t* pub_key) {
 
 void ClientACL::removeSessionKey(const uint8_t* pub_key) {
   session_keys.remove(pub_key);
+  _session_keys_dirty = true;
 }
 
 void ClientACL::loadSessionKeys() {

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -264,7 +264,10 @@ int ClientACL::handleSessionKeyInit(const ClientInfo* client, const uint8_t* eph
 
   // 4. Store in pool (dual-decode: new key active, old key still valid)
   auto entry = allocateSessionKey(client->id.pub_key);
-  if (!entry) return 0;
+  if (!entry) {
+    memset(new_session_key, 0, SESSION_KEY_SIZE);
+    return 0;
+  }
 
   if (entry->state == SESSION_STATE_ACTIVE || entry->state == SESSION_STATE_DUAL_DECODE) {
     memcpy(entry->prev_session_key, entry->session_key, SESSION_KEY_SIZE);

--- a/src/helpers/ClientACL.h
+++ b/src/helpers/ClientACL.h
@@ -15,6 +15,8 @@
 struct ClientInfo {
   mesh::Identity id;
   uint8_t permissions;
+  uint8_t flags;                    // transient — includes CONTACT_FLAG_AEAD
+  mutable uint16_t aead_nonce;      // transient — per-peer nonce counter
   uint8_t out_path_len;
   uint8_t out_path[MAX_PATH_SIZE];
   uint8_t shared_secret[PUB_KEY_SIZE];
@@ -30,6 +32,13 @@ struct ClientInfo {
     } room;
   } extra;
   
+  uint16_t nextAeadNonce() const {
+    if (flags & CONTACT_FLAG_AEAD) {
+      if (++aead_nonce == 0) ++aead_nonce;  // skip 0 (means ECB)
+      return aead_nonce;
+    }
+    return 0;
+  }
   bool isAdmin() const { return (permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_ADMIN; }
 };
 

--- a/src/helpers/ClientACL.h
+++ b/src/helpers/ClientACL.h
@@ -105,6 +105,16 @@ public:
   void loadSessionKeys();
   void saveSessionKeys();
 
+private:
+  // Flash-backed session key wrappers
+  SessionKeyEntry* findSessionKey(const uint8_t* pub_key);
+  SessionKeyEntry* allocateSessionKey(const uint8_t* pub_key);
+  void removeSessionKey(const uint8_t* pub_key);
+  bool loadSessionKeyRecordFromFlash(const uint8_t* pub_key_prefix,
+      uint8_t* flags, uint16_t* nonce, uint8_t* session_key, uint8_t* prev_session_key);
+
+public:
+
   // Peer-index forwarding helpers for server-side Mesh overrides.
   // These resolve peer_idx → ClientInfo via matching_indexes[], then delegate
   // to the corresponding method above.  Eliminates repeated boilerplate in

--- a/src/helpers/ClientACL.h
+++ b/src/helpers/ClientACL.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>   // needed for PlatformIO
 #include <Mesh.h>
 #include <helpers/IdentityStore.h>
+#include <helpers/SessionKeyPool.h>
 
 #define PERM_ACL_ROLE_MASK     3   // lower 2 bits
 #define PERM_ACL_GUEST         0
@@ -54,7 +55,11 @@ class ClientACL {
   // Nonce persistence state (parallel to clients[])
   uint16_t nonce_at_last_persist[MAX_CLIENTS];
   bool nonce_dirty;
+  bool _session_keys_dirty;
   mesh::RNG* _rng;
+
+  // Session key pool (Phase 2)
+  SessionKeyPool session_keys;
 
 public:
   ClientACL() {
@@ -62,6 +67,7 @@ public:
     memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
     num_clients = 0;
     nonce_dirty = false;
+    _session_keys_dirty = false;
     _rng = NULL;
   }
   void load(FILESYSTEM* _fs, const mesh::LocalIdentity& self_id);
@@ -74,6 +80,7 @@ public:
 
   int getNumClients() const { return num_clients; }
   ClientInfo* getClientByIdx(int idx) { return &clients[idx]; }
+  int getSessionKeyCount() const { return session_keys.getCount(); }
 
   // AEAD nonce persistence
   void setRNG(mesh::RNG* rng) { _rng = rng; }
@@ -86,4 +93,27 @@ public:
     for (int i = 0; i < num_clients; i++) nonce_at_last_persist[i] = clients[i].aead_nonce;
     nonce_dirty = false;
   }
+
+  // Session key support (Phase 2)
+  int handleSessionKeyInit(const ClientInfo* client, const uint8_t* ephemeral_pub_A, uint8_t* reply_buf, mesh::RNG* rng);
+  const uint8_t* getSessionKey(const uint8_t* pub_key);
+  const uint8_t* getPrevSessionKey(const uint8_t* pub_key);
+  const uint8_t* getEncryptionKey(const ClientInfo& client);
+  uint16_t getEncryptionNonce(const ClientInfo& client);
+  void onSessionConfirmed(const uint8_t* pub_key);
+  bool isSessionKeysDirty() const { return _session_keys_dirty; }
+  void loadSessionKeys();
+  void saveSessionKeys();
+
+  // Peer-index forwarding helpers for server-side Mesh overrides.
+  // These resolve peer_idx → ClientInfo via matching_indexes[], then delegate
+  // to the corresponding method above.  Eliminates repeated boilerplate in
+  // repeater/room/sensor examples.
+  ClientInfo* resolveClient(int peer_idx, const int* matching_indexes);
+  uint16_t peerNextAeadNonce(int peer_idx, const int* matching_indexes);
+  const uint8_t* peerSessionKey(int peer_idx, const int* matching_indexes);
+  const uint8_t* peerPrevSessionKey(int peer_idx, const int* matching_indexes);
+  void peerSessionKeyDecryptSuccess(int peer_idx, const int* matching_indexes);
+  const uint8_t* peerEncryptionKey(int peer_idx, const int* matching_indexes, const uint8_t* fallback);
+  uint16_t peerEncryptionNonce(int peer_idx, const int* matching_indexes);
 };

--- a/src/helpers/ClientACL.h
+++ b/src/helpers/ClientACL.h
@@ -31,7 +31,7 @@ struct ClientInfo {
       uint8_t  push_failures;
     } room;
   } extra;
-  
+
   uint16_t nextAeadNonce() const {
     if (flags & CONTACT_FLAG_AEAD) {
       if (++aead_nonce == 0) ++aead_nonce;  // skip 0 (means ECB)
@@ -51,10 +51,18 @@ class ClientACL {
   ClientInfo clients[MAX_CLIENTS];
   int num_clients;
 
+  // Nonce persistence state (parallel to clients[])
+  uint16_t nonce_at_last_persist[MAX_CLIENTS];
+  bool nonce_dirty;
+  mesh::RNG* _rng;
+
 public:
-  ClientACL() { 
+  ClientACL() {
     memset(clients, 0, sizeof(clients));
+    memset(nonce_at_last_persist, 0, sizeof(nonce_at_last_persist));
     num_clients = 0;
+    nonce_dirty = false;
+    _rng = NULL;
   }
   void load(FILESYSTEM* _fs, const mesh::LocalIdentity& self_id);
   void save(FILESYSTEM* _fs, bool (*filter)(ClientInfo*)=NULL);
@@ -66,4 +74,16 @@ public:
 
   int getNumClients() const { return num_clients; }
   ClientInfo* getClientByIdx(int idx) { return &clients[idx]; }
+
+  // AEAD nonce persistence
+  void setRNG(mesh::RNG* rng) { _rng = rng; }
+  uint16_t nextAeadNonceFor(const ClientInfo& client);
+  void loadNonces();
+  void saveNonces();
+  void finalizeNonceLoad(bool needs_bump);
+  bool isNonceDirty() const { return nonce_dirty; }
+  void clearNonceDirty() {
+    for (int i = 0; i < num_clients; i++) nonce_at_last_persist[i] = clients[i].aead_nonce;
+    nonce_dirty = false;
+  }
 };

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -185,10 +185,12 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     if (memcmp(command, "poweroff", 8) == 0 || memcmp(command, "shutdown", 8) == 0) {
       _board->powerOff();  // doesn't return
     } else if (memcmp(command, "reboot", 6) == 0) {
+      _callbacks->onBeforeReboot();
       _board->reboot();  // doesn't return
     } else if (memcmp(command, "clkreboot", 9) == 0) {
       // Reset clock
       getRTCClock()->setCurrentTime(1715770351);  // 15 May 2024, 8:50pm
+      _callbacks->onBeforeReboot();
       _board->reboot();  // doesn't return
      } else if (memcmp(command, "advert.zerohop", 14) == 0 && (command[14] == 0 || command[14] == ' ')) {
       // send zerohop advert

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -444,6 +444,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       _callbacks->formatRadioStatsReply(reply);
     } else if (sender_timestamp == 0 && memcmp(command, "stats-core", 10) == 0 && (command[10] == 0 || command[10] == ' ')) {
       _callbacks->formatStatsReply(reply);
+    } else if (memcmp(command, "rekey", 5) == 0) {
+      strcpy(reply, "rekey is client-initiated");
     } else {
       strcpy(reply, "Unknown command");
     }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -168,12 +168,15 @@ void CommonCLI::savePrefs() {
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
   if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   } else {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   }
 }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -170,12 +170,15 @@ void CommonCLI::savePrefs() {
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
   if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   } else {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
+    builder.setFeat1(FEAT1_AEAD_SUPPORT);
     return builder.encodeTo(app_data);
   }
 }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -197,10 +197,12 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     if (memcmp(command, "poweroff", 8) == 0 || memcmp(command, "shutdown", 8) == 0) {
       _board->powerOff();  // doesn't return
     } else if (memcmp(command, "reboot", 6) == 0) {
+      _callbacks->onBeforeReboot();
       _board->reboot();  // doesn't return
     } else if (memcmp(command, "clkreboot", 9) == 0) {
       // Reset clock
       getRTCClock()->setCurrentTime(1715770351);  // 15 May 2024, 8:50pm
+      _callbacks->onBeforeReboot();
       _board->reboot();  // doesn't return
      } else if (memcmp(command, "advert.zerohop", 14) == 0 && (command[14] == 0 || command[14] == ' ')) {
       // send zerohop advert

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -456,6 +456,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       _callbacks->formatRadioStatsReply(reply);
     } else if (sender_timestamp == 0 && memcmp(command, "stats-core", 10) == 0 && (command[10] == 0 || command[10] == ' ')) {
       _callbacks->formatStatsReply(reply);
+    } else if (memcmp(command, "rekey", 5) == 0) {
+      strcpy(reply, "rekey is client-initiated");
     } else {
       strcpy(reply, "Unknown command");
     }

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -243,8 +243,12 @@ public:
   #if defined(USE_LR2021)
   virtual bool configSideDetectors(const uint8_t sideDetSFs[], uint8_t num, float bw) {
     return false; // Override in wrapper
-  } 
+  }
   #endif
+
+  virtual void onBeforeReboot() {
+    // no op by default — override to flush nonces, etc.
+  };
 };
 
 class CommonCLI {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -291,8 +291,12 @@ public:
   #if defined(USE_LR2021)
   virtual bool configSideDetectors(const uint8_t sideDetSFs[], uint8_t num, float bw) {
     return false; // Override in wrapper
-  } 
+  }
   #endif
+
+  virtual void onBeforeReboot() {
+    // no op by default — override to flush nonces, etc.
+  };
 };
 
 class CommonCLI {

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -17,7 +17,14 @@ struct ContactInfo {
   uint32_t lastmod;  // by OUR clock
   int32_t gps_lat, gps_lon;    // 6 dec places
   uint32_t sync_since;
-  uint16_t aead_nonce;  // per-peer AEAD nonce counter for DMs (not used for group messages), seeded from HW RNG
+  mutable uint16_t aead_nonce;  // per-peer AEAD nonce counter for DMs (not used for group messages), seeded from HW RNG
+
+  // Returns next AEAD nonce (post-increment) if peer supports AEAD, 0 otherwise.
+  // When 0, callers use ECB encryption.
+  uint16_t nextAeadNonce() const {
+    if (flags & CONTACT_FLAG_AEAD) return ++aead_nonce;
+    return 0;
+  }
 
   const uint8_t* getSharedSecret(const mesh::LocalIdentity& self_id) const {
     if (!shared_secret_valid) {

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -27,6 +27,10 @@ struct ContactInfo {
         ++aead_nonce;  // skip 0 (sentinel for ECB)
         MESH_DEBUG_PRINTLN("AEAD nonce wrapped for peer: %s", name);
       }
+      if (aead_nonce < NONCE_INITIAL_MIN) {
+        aead_nonce = 1;  // stay stuck in exhaustion zone, always return ECB
+        return 0;
+      }
       return aead_nonce;
     }
     return 0;

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -17,6 +17,7 @@ struct ContactInfo {
   uint32_t lastmod;  // by OUR clock
   int32_t gps_lat, gps_lon;    // 6 dec places
   uint32_t sync_since;
+  uint16_t aead_nonce;  // per-peer AEAD nonce counter for DMs (not used for group messages), seeded from HW RNG
 
   const uint8_t* getSharedSecret(const mesh::LocalIdentity& self_id) const {
     if (!shared_secret_valid) {

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -22,7 +22,10 @@ struct ContactInfo {
   // Returns next AEAD nonce (post-increment) if peer supports AEAD, 0 otherwise.
   // When 0, callers use ECB encryption.
   uint16_t nextAeadNonce() const {
-    if (flags & CONTACT_FLAG_AEAD) return ++aead_nonce;
+    if (flags & CONTACT_FLAG_AEAD) {
+      if (++aead_nonce == 0) ++aead_nonce;  // skip 0 (sentinel for ECB)
+      return aead_nonce;
+    }
     return 0;
   }
 

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -23,7 +23,10 @@ struct ContactInfo {
   // When 0, callers use ECB encryption.
   uint16_t nextAeadNonce() const {
     if (flags & CONTACT_FLAG_AEAD) {
-      if (++aead_nonce == 0) ++aead_nonce;  // skip 0 (sentinel for ECB)
+      if (++aead_nonce == 0) {
+        ++aead_nonce;  // skip 0 (sentinel for ECB)
+        MESH_DEBUG_PRINTLN("AEAD nonce wrapped for peer: %s", name);
+      }
       return aead_nonce;
     }
     return 0;

--- a/src/helpers/SessionKeyPool.h
+++ b/src/helpers/SessionKeyPool.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <string.h>
+
+#define SESSION_STATE_NONE        0
+#define SESSION_STATE_INIT_SENT   1  // initiator: INIT sent, waiting for ACCEPT
+#define SESSION_STATE_DUAL_DECODE 2  // responder: new key active, old key still valid
+#define SESSION_STATE_ACTIVE      3  // session key confirmed and in use
+
+#define SESSION_FLAG_PREV_VALID   0x01  // prev_session_key is valid for dual-decode
+
+struct SessionKeyEntry {
+  uint8_t peer_pub_prefix[4];       // first 4 bytes of peer's public key
+  uint8_t session_key[SESSION_KEY_SIZE];
+  uint8_t prev_session_key[SESSION_KEY_SIZE];
+  uint16_t nonce;                    // session key nonce counter (starts at 1)
+  uint8_t state;                     // SESSION_STATE_*
+  uint8_t sends_since_last_recv;     // RAM-only counter, threshold SESSION_KEY_STALE_THRESHOLD
+  uint8_t retries_left;              // remaining INIT retries this round
+  unsigned long timeout_at;          // millis timestamp for INIT timeout
+  uint8_t ephemeral_prv[PRV_KEY_SIZE]; // initiator-only: ephemeral private key (zeroed after use)
+  uint8_t ephemeral_pub[PUB_KEY_SIZE]; // initiator-only: ephemeral public key
+};
+
+class SessionKeyPool {
+  SessionKeyEntry entries[MAX_SESSION_KEYS];
+  int count;
+
+public:
+  SessionKeyPool() : count(0) {
+    memset(entries, 0, sizeof(entries));
+  }
+
+  SessionKeyEntry* findByPrefix(const uint8_t* pub_key) {
+    for (int i = 0; i < count; i++) {
+      if (memcmp(entries[i].peer_pub_prefix, pub_key, 4) == 0) {
+        return &entries[i];
+      }
+    }
+    return nullptr;
+  }
+
+  SessionKeyEntry* allocate(const uint8_t* pub_key) {
+    // Check if already exists
+    auto existing = findByPrefix(pub_key);
+    if (existing) return existing;
+
+    // Find free slot or evict oldest
+    if (count < MAX_SESSION_KEYS) {
+      auto e = &entries[count++];
+      memset(e, 0, sizeof(*e));
+      memcpy(e->peer_pub_prefix, pub_key, 4);
+      return e;
+    }
+    // Pool full — evict the entry with state NONE, or the first one
+    for (int i = 0; i < MAX_SESSION_KEYS; i++) {
+      if (entries[i].state == SESSION_STATE_NONE) {
+        memset(&entries[i], 0, sizeof(entries[i]));
+        memcpy(entries[i].peer_pub_prefix, pub_key, 4);
+        return &entries[i];
+      }
+    }
+    // All slots active — evict first entry
+    memset(&entries[0], 0, sizeof(entries[0]));
+    memcpy(entries[0].peer_pub_prefix, pub_key, 4);
+    return &entries[0];
+  }
+
+  void remove(const uint8_t* pub_key) {
+    for (int i = 0; i < count; i++) {
+      if (memcmp(entries[i].peer_pub_prefix, pub_key, 4) == 0) {
+        // Shift remaining entries down
+        count--;
+        for (int j = i; j < count; j++) {
+          entries[j] = entries[j + 1];
+        }
+        memset(&entries[count], 0, sizeof(entries[count]));
+        return;
+      }
+    }
+  }
+
+  int getCount() const { return count; }
+  SessionKeyEntry* getByIdx(int idx) { return (idx >= 0 && idx < count) ? &entries[idx] : nullptr; }
+
+  // Persistence helpers — 71-byte records: [pub_prefix:4][flags:1][nonce:2][session_key:32][prev_session_key:32]
+  // Returns false when idx is past end
+  bool getEntryForSave(int idx, uint8_t* pub_key_prefix, uint8_t* flags, uint16_t* nonce,
+                       uint8_t* session_key, uint8_t* prev_session_key) {
+    if (idx >= count) return false;
+    auto& e = entries[idx];
+    if (e.state == SESSION_STATE_NONE || e.state == SESSION_STATE_INIT_SENT) return false; // don't persist pending negotiations
+    memcpy(pub_key_prefix, e.peer_pub_prefix, 4);
+    *flags = (e.state == SESSION_STATE_DUAL_DECODE) ? SESSION_FLAG_PREV_VALID : 0;
+    *nonce = e.nonce;
+    memcpy(session_key, e.session_key, SESSION_KEY_SIZE);
+    memcpy(prev_session_key, e.prev_session_key, SESSION_KEY_SIZE);
+    return true;
+  }
+
+  bool applyLoaded(const uint8_t* pub_key_prefix, uint8_t flags, uint16_t nonce,
+                   const uint8_t* session_key, const uint8_t* prev_session_key) {
+    auto e = allocate(pub_key_prefix);
+    if (!e) return false;
+    e->nonce = nonce;
+    e->state = (flags & SESSION_FLAG_PREV_VALID) ? SESSION_STATE_DUAL_DECODE : SESSION_STATE_ACTIVE;
+    e->sends_since_last_recv = 0;
+    e->retries_left = 0;
+    e->timeout_at = 0;
+    memcpy(e->session_key, session_key, SESSION_KEY_SIZE);
+    memcpy(e->prev_session_key, prev_session_key, SESSION_KEY_SIZE);
+    memset(e->ephemeral_prv, 0, sizeof(e->ephemeral_prv));
+    memset(e->ephemeral_pub, 0, sizeof(e->ephemeral_pub));
+    return true;
+  }
+};


### PR DESCRIPTION
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=feature/aead-4-encryption)

### Testing

- Current testling on Heltec v4 companion and Heltec v4 repeater. It's working so far. Would be great if others can try with different devices, especially more constrained devices with less ram/flash storage.

## Summary

Adds ChaCha20-Poly1305 (AEAD-4) encryption alongside the existing AES-128-ECB + HMAC-2 scheme, plus session key negotiation for Perfect Forward Secrecy. Updated nodes send AEAD-4 to peers that advertise support and fall back to ECB for legacy peers. All nodes can decode both formats. Old nodes continue to work unchanged.

Nonces are persisted to flash so they survive reboots without risk of reuse. Session keys are negotiated via ephemeral X25519 Diffie-Hellman and persisted immediately on establishment.

Relates to #259.

## What This Means in Practical Terms

The current encryption has a few weaknesses that this PR addresses:

- **Message tampering is too easy to attempt.** The existing 2-byte authentication code means an attacker only needs about 65,000 guesses to forge a valid-looking message. At LoRa speeds that's roughly 9 hours of continuous attempts. The new 4-byte tag raises this to over 4 billion guesses — at LoRa rates, that would take over a century.

- **Identical messages look identical on the air.** The current block cipher (ECB mode) produces the same ciphertext for the same plaintext, which can reveal patterns — for example, you could tell when someone sends the same message twice. The new scheme produces completely different ciphertext every time, even for identical messages.

- **Addressing fields are now protected.** Currently, only the message body is authenticated. With AEAD, the payload type and addressing hashes (which identify sender and recipient) are included in the authentication check, so an attacker cannot swap or modify them without detection. Outer routing fields like TTL and hop path are intentionally left unauthenticated so repeaters can still forward packets through the mesh.

- **Messages get slightly smaller.** ECB pads every message up to a 16-byte boundary, wasting airtime. The new scheme has no padding, so most messages shrink by a few bytes on the wire.

- **Compromise of a node doesn't reveal past messages.** Session key negotiation establishes fresh shared secrets via ephemeral key exchange. Even if a node's long-term private key is later compromised, previously recorded traffic cannot be decrypted (Perfect Forward Secrecy).

- **Nothing breaks.** Updated nodes send AEAD-4 to peers that advertise support, and fall back to ECB for legacy peers. Old nodes are completely unaffected — they never receive AEAD-4 messages because the sender checks their capability first.

- **Nodes advertise their capabilities.** Updated nodes include a flag in their advertisements saying "I understand the new encryption." When two updated nodes discover each other, they automatically start using AEAD-4 for their communication.

- **Nonces survive reboots.** Per-peer nonce counters are saved to flash periodically and before clean reboots. After a dirty reset (power loss, watchdog, brownout), nonces are bumped forward by a safety margin to guarantee no reuse.

## Wire Format

Current ECB:
```
[HMAC:2] [ECB_ciphertext:N×16]     (padded to block boundary)
```

New AEAD-4 (same position in payload):
```
[nonce:2] [ciphertext:M] [tag:4]    (exact plaintext length, no padding)
```

Average overhead: ~6 bytes (AEAD) vs ~9.5 bytes (ECB). Most messages get smaller.

## Cryptographic Design

**Per-message key derivation** (eliminates nonce-reuse catastrophe):
```
msg_key[32] = HMAC-SHA256(shared_secret, nonce || dest_hash || src_hash)
```

The `shared_secret` is either the static ECDH secret or a session key (see Session Key Negotiation below).

Including `dest_hash || src_hash` makes keys direction-dependent — Alice→Bob and Bob→Alice derive different keys even with the same nonce value (for 255/256 peer pairs; the 1/256 where dest_hash == src_hash is a residual limitation of 1-byte hashes).

**IV construction** (12 bytes, from on-wire fields):
```
iv[12] = { nonce_hi, nonce_lo, dest_hash, src_hash, 0, 0, 0, 0, 0, 0, 0, 0 }
```

**Associated data** (authenticated but not encrypted):
- Peer messages: `header || dest_hash || src_hash`
- Anonymous requests: `header || dest_hash`
- Group messages: `header || channel_hash`

Route type bits are masked out of the header in associated data (`header & ~PH_ROUTE_MASK`), since routing mode changes per hop as repeaters forward packets.

**Nonce management**: 16-bit counter per peer, persisted to flash. See "Nonce Persistence" section below.

## Session Key Negotiation (Perfect Forward Secrecy)

Session keys provide Perfect Forward Secrecy by establishing fresh shared secrets via ephemeral X25519 Diffie-Hellman. Compromise of either node's long-term private key cannot recover traffic encrypted with a session key.

### Protocol (2 messages + implicit confirmation)

```
Initiator                                   Responder
    |  1. REQ [REQ_TYPE_SESSION_KEY_INIT]        |
    |     [ephemeral_pub_A:32] (AEAD-4)          |
    | -----------------------------------------> |  derive session_key, persist, dual-decode
    |  2. RESPONSE [RESP_TYPE_SESSION_KEY_ACCEPT] |
    |     [ephemeral_pub_B:32] (static ECDH)     |
    | <----------------------------------------- |
    |  derive session_key, persist, nonce=1       |
    |  3. Any normal message (session key)       |
    | -----------------------------------------> |  confirm: drop old key
```

The INIT is encrypted with AEAD-4 (static ECDH or existing session key). The ACCEPT is always encrypted with the static ECDH secret, because the initiator hasn't derived the session key yet.

### Key Derivation

```
ephemeral_secret = X25519(their_ephemeral_pub, my_ephemeral_prv)
session_key[32]  = HMAC-SHA256(static_shared_secret, ephemeral_secret)
```

Uses existing `ed25519_key_exchange()` (X25519 Montgomery ladder) from `lib/ed25519`. No new dependencies.

### Who Initiates

- **Companion ↔ Repeater/Room/Sensor**: Companion initiates, server responds
- **Companion ↔ Companion**: Either side can initiate, both can respond

Repeaters, room servers, and sensors only implement the responder role — they never initiate session key negotiation.

### Automatic Triggers

Session key negotiation is triggered automatically based on message count. The trigger check runs inside `getEncryptionNonceFor()` — the single funnel all encrypted sends pass through — so no send path can silently skip it. Negotiation is deferred to the next `loop()` tick to avoid re-entrancy.

| Hop count | Current key | Trigger | Retry after failure |
|---|---|---|---|
| 0 (direct) | Static ECDH | Every 100 msgs | 100 msgs |
| 0 (direct) | Session key | nonce > 60000, then every 100 msgs | 100 msgs |
| 1–9 | Static ECDH | Every 500 msgs | 500 msgs |
| 1–9 | Session key | nonce > 60000, then every 300 msgs | 300 msgs |
| 10+ | Static ECDH | Every 1000 msgs | 1000 msgs |
| 10+ | Session key | nonce > 60000, then every 300 msgs | 300 msgs |

3 INIT attempts per negotiation (3-minute timeout each).

### Nonce Lifecycle

- **New contacts**: Static ECDH nonce seeded from RNG in range 1000–50000
- **Session key nonce**: Starts at 1 on establishment, full 65535 budget per session
- **Nonce exhaustion**: Fall back to static ECDH, keep retrying negotiation at tier intervals

### Encryption Key Selection

All node types use paired `getEncryptionKey()` / `getEncryptionNonce()` functions that return the correct key and nonce based on current session state:

```
has_session_key && sends_since_last_recv < 50  → AEAD with session key
has_session_key && sends_since_last_recv >= 50 → AEAD with static ECDH (stale probe)
CONTACT_FLAG_AEAD && nonce OK                  → AEAD with static ECDH
CONTACT_FLAG_AEAD && nonce exhausted           → ECB (pending renegotiation)
else                                           → ECB (legacy peer)
```

### Decode Order

```
has_session_key: session_key → prev_session_key (dual-decode) → static ECDH → ECB
CONTACT_FLAG_AEAD: static ECDH → ECB
else: ECB → static ECDH
```

### Dual-Decode Window

When the responder accepts a session key INIT, it enters DUAL_DECODE state: the new session key is active for sending, but both old and new keys are accepted for decoding. Once the initiator sends a message encrypted with the new session key (message 3), the responder confirms the transition and drops the old key.

This makes ACCEPT packet loss safe — the responder stays in dual-decode, the initiator times out and retries, and no messages are lost.

### Stale Session Detection

If a node sends 50 consecutive messages without receiving any session-key-encrypted reply, it falls back to static ECDH for sending (the peer may have lost the session key). At 100 unanswered sends, falls back to ECB. At 255, clears the AEAD capability flag and removes the session key entirely. The counter resets to 0 on any successful session-key-encrypted message from the peer.

### Session Key Persistence

Session keys use a two-tier storage model: a small RAM pool for active sessions and a larger flash-backed store for less recently used entries.

**RAM pool**: 8 slots (`MAX_SESSION_KEYS_RAM`), managed as an LRU cache. Each access touches a counter so the least-recently-used entry can be evicted when the pool is full. Entries in `INIT_SENT` state (ephemeral keys only) are never evicted — they must complete or time out.

**Flash store**: Up to 48 entries (`MAX_SESSION_KEYS_FLASH`), persisted to `/sess_keys` (companion) or `/s_sess_keys` (server firmware).

**Variable-length records**: Entries without a previous session key (no dual-decode) use 39 bytes (`SESSION_KEY_RECORD_MIN_SIZE`); entries with a previous key use 71 bytes (`SESSION_KEY_RECORD_SIZE`). The `SESSION_FLAG_PREV_VALID` flag bit distinguishes the two.

```
Without prev_key: [pub_key_prefix:4] [flags:1] [nonce:2] [session_key:32]         = 39 bytes
With prev_key:    [pub_key_prefix:4] [flags:1] [nonce:2] [session_key:32] [prev_session_key:32] = 71 bytes
```

**On-demand flash lookup**: When `findSessionKey()` misses the RAM pool, it reads the flash file to look for a matching entry. If found, the entry is loaded into RAM (evicting LRU if needed) and returned.

**Merge-save strategy**: When persisting, the code reads existing flash entries, filters out any that are already in the RAM pool or have been explicitly removed, then writes the merged result (RAM entries + surviving flash-only entries). This prevents flash from resurrecting deleted entries while preserving entries that were evicted from RAM.

**Removed-entry tracking**: When a session key is explicitly removed (e.g., invalidation after static ECDH fallback), its prefix is recorded in a small tracking array. The merge-save step skips these prefixes so the deleted entry doesn't reappear from stale flash data. The tracking array is cleared after each successful save.

## Nonce Persistence

Nonces are persisted to a dedicated file on flash (`/nonces` for companion radios, `/s_nonces` for server firmware).

**Periodic saves**: After every `NONCE_PERSIST_INTERVAL` (50) messages to a given peer, the nonce file is written. A dirty flag tracks whether any nonce has advanced since the last save.

**Clean reboot**: Software restarts and deep sleep wakes load the persisted nonces as-is. A `onBeforeReboot()` callback in CommonCLI flushes any dirty nonces before the restart.

**Dirty reboot**: Power-on, watchdog, and brownout resets are detected via `wasDirtyReset()` (platform-specific: `esp_reset_reason()` on ESP32, `RESETREAS` register on NRF52). After a dirty reset, all loaded nonces are bumped forward by `NONCE_BOOT_BUMP` (50), which is at least the persist interval, guaranteeing that even the worst-case unpersisted nonce is safely skipped. Session key nonces also receive the boot bump; if the bump causes a wrap, the nonce is forced to 65535 to trigger renegotiation.

**Format**: Simple array of `{pub_key_prefix[6], nonce[2]}` entries, matched to in-memory contacts/clients on load.

## Security Comparison

| Property | ECB + HMAC-2 (current) | AEAD-4 (new) | AEAD-4 + Session Key |
|---|---|---|---|
| Confidentiality | Identical blocks → identical ciphertext | Unique keystream per message | Same |
| Forgery resistance | 1/65K (~9 hours at LoRa rates) | 1/4.3B (~136 years) | Same |
| Key usage | 16 of 32 bytes (AES-128) | Full 32 bytes (ChaCha20-256) | Same |
| Addressing authentication | None | Payload type & address hashes via AAD | Same |
| MAC timing | `memcmp` (timing side-channel) | `secure_compare` (constant-time) | Same |
| Padding waste | 0-15 bytes per message | None | None |
| Perfect Forward Secrecy | No | No | Yes |
| Nonce reuse on reboot | N/A (no nonces) | Mitigated by persistence + boot bump | Same |

## Scope

| Payload type | AEAD-4 decode | AEAD-4 send | Session keys | Notes |
|---|---|---|---|---|
| TXT_MSG, REQ, RESPONSE, PATH | Yes | Yes (if peer advertises AEAD) | Yes | Per-peer secret, no collision risk |
| ANON_REQ | Yes | No (no prior capability exchange) | No | Ephemeral ECDH secret |
| GRP_TXT, GRP_DATA | Yes | No (see group considerations) | No | Shared channel key |

All node types (companion radio, repeater, room server, sensor) support AEAD-4 decode, AEAD-4 send, and session key negotiation (companion initiates or responds; server firmware responds only).

## Group Message Considerations

Group channels share a single key among all members. With a 2-byte nonce and multiple senders, cross-sender nonce collisions follow the birthday bound (~300 messages for 50% probability on an active channel). A collision leaks `P1 ⊕ P2` for that specific message pair via crib-dragging, but:

- **No key recovery** — per-message key derivation via HMAC-SHA256 is one-way
- **No cascade** — each collision is isolated, doesn't affect other messages
- **Bounded threat model** — the attacker must not have the channel PSK (if they do, they can already read everything)

This is mainly beneficial for public/hashtag channels where the PSK is already widely known and the ECB pattern leakage and weak MAC are a greater concern than the bounded nonce collision risk.

Potential future mitigations explored and deferred:
- **Per-sender derived keys** (`HMAC(channel_secret, sender_pub_key)`) — eliminates cross-sender collisions but requires receivers to know all senders' public keys, changing the group security model from "know the PSK = full access" to "know the PSK + sender discovery = access." Ruled out as a usability regression.
- **Expanded nonce** (4 bytes instead of 2) — pushes birthday bound to ~65,000 messages (~2 years at 100 msgs/day). Costs 2 extra bytes of airtime and creates a different wire format for groups vs peers.
- **Sender hash byte on wire** — differentiates senders for key derivation at 1 byte cost, but leaks sender identity metadata (traffic correlation, identification via adverts) that is currently hidden inside the encrypted payload.

## Decode Order

Adaptive per-peer: for peers with `CONTACT_FLAG_AEAD` set, try AEAD-4 first then ECB fallback. For unknown/legacy peers, try ECB first then AEAD-4 fallback. When a session key exists, decode order is: session key → prev session key (dual-decode window) → static ECDH → ECB. This avoids the 1/65536 ECB false-positive rate on AEAD packets (nonce bytes matching truncated HMAC) for known AEAD peers, while minimizing wasted CPU for legacy peers.

## Capability Advertisement

- `feat1` bit 0 (`FEAT1_AEAD_SUPPORT`) is set in adverts for all node types (chat, repeater, room, sensor)
- Receivers record peer capability in `ContactInfo.flags` bit 1 (`CONTACT_FLAG_AEAD`)
- Old nodes parse `feat1` but ignore the value (forward-compatible via existing `AdvertDataParser`)

## Files Changed

### Core Library

- **`src/MeshCore.h`** — AEAD constants, session key constants (`SESSION_KEY_SIZE`, `REQ_TYPE_SESSION_KEY_INIT`, `RESP_TYPE_SESSION_KEY_ACCEPT`, `NONCE_REKEY_THRESHOLD`, `SESSION_KEY_*` thresholds and limits), two-tier pool sizing (`MAX_SESSION_KEYS_RAM=8`, `MAX_SESSION_KEYS_FLASH=48`), variable-length record sizes (`SESSION_KEY_RECORD_SIZE`, `SESSION_KEY_RECORD_MIN_SIZE`), `SESSION_FLAG_PREV_VALID`
- **`src/Utils.h` / `src/Utils.cpp`** — `aeadEncrypt()` and `aeadDecrypt()` using ChaChaPoly
- **`src/Mesh.h`** — `getPeerFlags()`, `getPeerNextAeadNonce()`, `getPeerSessionKey()`, `getPeerPrevSessionKey()`, `onSessionKeyDecryptSuccess()`, `getPeerEncryptionKey()`, `getPeerEncryptionNonce()` virtuals; `aead_nonce` param on `createDatagram`/`createPathReturn`
- **`src/Mesh.cpp`** — AEAD send path in `createDatagram`/`createPathReturn`; session key → prev session key → static ECDH → ECB adaptive decode order
- **`src/helpers/ContactInfo.h`** — `uint16_t aead_nonce` field, `nextAeadNonce()` helper
- **`src/helpers/SessionKeyPool.h`** — `SessionKeyEntry` struct and `SessionKeyPool` class (LRU-managed RAM pool with `last_used` tracking, eviction that skips `INIT_SENT` entries, removed-entry tracking for merge-save safety)

### Companion Radio (BaseChatMesh)

- **`src/helpers/BaseChatMesh.h` / `BaseChatMesh.cpp`** — Advertise AEAD, track peer capability, AEAD send for all peer message types, nonce persistence, session key negotiation (both initiator and responder roles), encryption key/nonce funnel (`getEncryptionKeyFor`/`getEncryptionNonceFor`), deferred rekey trigger via `_pending_rekey_idx`

### Server-Side (ClientACL + examples)

- **`src/helpers/ClientACL.h` / `ClientACL.cpp`** — Server-side AEAD nonce tracking and persistence, session key responder (`handleSessionKeyInit`), paired encryption key/nonce selection (`getEncryptionKey`/`getEncryptionNonce`), flash-backed session key wrappers with merge-save, peer-index forwarding helpers
- **`src/helpers/CommonCLI.h` / `CommonCLI.cpp`** — Advertise AEAD for repeaters/rooms/sensors; `onBeforeReboot()` callback for nonce/session key flush
- **`examples/simple_repeater/MyMesh.h` / `MyMesh.cpp`** — AEAD + session key support, nonce persistence, session key INIT handling in `onPeerDataRecv`
- **`examples/simple_room_server/MyMesh.h` / `MyMesh.cpp`** — Same
- **`examples/simple_sensor/SensorMesh.h` / `SensorMesh.cpp`** — Same

### Platform Support

- **`src/helpers/ArduinoHelpers.h`** — `wasDirtyReset()` helper (ESP32/NRF52 reset reason detection)
- **`examples/companion_radio/DataStore.h` / `DataStore.cpp`** — Nonce and session key file I/O, variable-length session key records, merge-save with flash-backed lookup (`loadSessionKeyByPrefix`)
- **`examples/companion_radio/MyMesh.h` / `MyMesh.cpp`** — Wire up nonce/session key persistence and reboot callback, flash-backed session key overrides (`loadSessionKeyRecordFromFlash`, `mergeAndSaveSessionKeys`)

## Build Verification

- ESP32 (`Heltec_v3_companion_radio_ble`): builds successfully
- ESP32 (`Heltec_v3_repeater`): builds successfully
- ESP32 (`Heltec_v3_room_server`): builds successfully
- NRF52 (`Xiao_nrf52_companion_radio_ble`): builds successfully

## Future Work

- Group messages: send AEAD-4 (all updated nodes can already decode it)
- ANON_REQ: remain ECB (no prior capability exchange possible)
- `rekey <peer>` CLI command for manual session key renegotiation

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=feature/aead-4-encryption)