### PR TITLE
nrf52: allow companion to sleep when idle

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -225,4 +225,9 @@ void loop() {
   ui_task.loop();
 #endif
   rtc_clock.tick();
+
+#if defined(NRF52_PLATFORM)
+  board.sleep(1800);
+#endif
+
 }


### PR DESCRIPTION
Following on from the [NRF52 repeater power savings](https://github.com/meshcore-dev/MeshCore/pull/1562), this adds the same for NRF52 companions.

I've been running it on WioTrackerL1/ThinkNode M1/Heltec T114/Meshtiny for the last week with no issues.
