### PR TITLE
XIAO esp32c6: fix for esp_efuse_mac_get_default is not declared failure

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -1,4 +1,5 @@
 #include "SerialBLEInterface.h"
+#include <esp_mac.h>
 
 // See the following for generating UUIDs:
 // https://www.uuidgenerator.net/


### PR DESCRIPTION
`esp_efuse_mac_get_default` is not transitively included via BLE headers on ESP32-C6