### PR TITLE
Short sleeps when phone disconnects

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2257,7 +2257,7 @@ bool MyMesh::advert() {
   }
 }
 
-// To check if there is pending work
+// Check if there is pending work (packets to send or pending contacts write)
 bool MyMesh::hasPendingWork() const {
   return _mgr->getOutboundTotal() > 0 || dirty_contacts_expiry != 0;
 }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2418,7 +2418,7 @@ bool MyMesh::advert() {
   }
 }
 
-// To check if there is pending work
+// Check if there is pending work (packets to send or pending contacts write)
 bool MyMesh::hasPendingWork() const {
   return _mgr->getOutboundTotal() > 0 || dirty_contacts_expiry != 0;
 }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -101,6 +101,11 @@ MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables, store
    #endif
 );
 
+// Power saving timing variables
+unsigned long lastActive = 0;           // Last time there was activity
+unsigned long nextSleepInSecs = 120;    // Wait 2 minutes before first sleep
+const unsigned long WORK_TIME_SECS = 5; // Stay awake 5 seconds after wake/activity
+
 /* END GLOBAL OBJECTS */
 
 void halt() {
@@ -242,6 +247,9 @@ void setup() {
 #endif
 
   board.onBootComplete();
+
+  // Initialize power saving timer
+  lastActive = millis();
 }
 
 void loop() {
@@ -271,4 +279,31 @@ void loop() {
     last_wifi_reconnect_attempt = millis();
   }
 #endif
+
+  // Power saving when BLE/WiFi is disabled
+  // Don't sleep if GPS is enabled - it needs continuous operation to maintain fix
+  // Note: Disabling BLE/WiFi via UI actually turns off the radio to save power
+  if (!serial_interface.isEnabled() && !the_mesh.getNodePrefs()->gps_enabled) {
+    // Check for pending work and update activity timer
+    if (the_mesh.hasPendingWork()) {
+      lastActive = millis();
+      if (nextSleepInSecs < 10) {
+        nextSleepInSecs += 5; // Extend work time by 5s if still busy
+      }
+    }
+
+    // Only sleep if enough time has passed since last activity
+    if (millis() >= lastActive + (nextSleepInSecs * 1000)) {
+#ifdef PIN_USER_BTN
+      // Sleep for 30 minutes, wake on LoRa packet, timer, or button press
+      board.enterLightSleep(1800, PIN_USER_BTN);
+#else
+      // Sleep for 30 minutes, wake on LoRa packet or timer
+      board.enterLightSleep(1800);
+#endif
+      // Just woke up - reset timers
+      lastActive = millis();
+      nextSleepInSecs = WORK_TIME_SECS; // Stay awake for 5s after wake
+    }
+  }
 }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -293,7 +293,7 @@ void loop() {
     }
 
     // Only sleep if enough time has passed since last activity
-    if (millis() >= lastActive + (nextSleepInSecs * 1000)) {
+    if (the_mesh.millisHasNowPassed(lastActive + (nextSleepInSecs * 1000))) {
 #ifdef PIN_USER_BTN
       // Sleep for 30 minutes, wake on LoRa packet, timer, or button press
       board.enterLightSleep(1800, PIN_USER_BTN);

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -106,6 +106,13 @@ unsigned long lastActive = 0;           // Last time there was activity
 unsigned long nextSleepInSecs = 120;    // Wait 2 minutes before first sleep
 const unsigned long WORK_TIME_SECS = 5; // Stay awake 5 seconds after wake/activity
 
+// Short-sleep cycle when phone is disconnected but BLE is enabled
+const unsigned long DISCONNECT_SLEEP_TIMEOUT_MS = 60000;  // 60s before short-sleep cycle
+const unsigned long SHORT_SLEEP_SECS = 12;                // sleep duration per cycle
+const unsigned long RECONNECT_WINDOW_MS = 3000;           // awake time for BLE advertising
+unsigned long disconnectTime = 0;   // when phone disconnected (0 = connected/N/A)
+unsigned long lastSleepWake = 0;    // when we last woke from short sleep (0 = not in cycle)
+
 /* END GLOBAL OBJECTS */
 
 void halt() {
@@ -281,6 +288,32 @@ void loop() {
 #endif
 
 #if defined(BLE_PIN_CODE) && !defined(WIFI_SSID) && !defined(ETHERNET_ENABLED)
+  // Track phone connection state for disconnect sleep
+  if (bluetooth_interface.hasPendingConnection()) {
+    disconnectTime = 0;
+    lastSleepWake = 0;
+  } else if (bluetooth_interface.isEnabled() && disconnectTime == 0) {
+    disconnectTime = millis();
+    if (disconnectTime == 0) disconnectTime = 1;  // avoid 0 sentinel collision
+  }
+  // Short-sleep cycle when BLE is enabled but phone is disconnected
+  if (bluetooth_interface.isEnabled() && disconnectTime != 0
+      && !the_mesh.getNodePrefs()->gps_enabled
+      && the_mesh.millisHasNowPassed(disconnectTime + DISCONNECT_SLEEP_TIMEOUT_MS)
+      && !the_mesh.hasPendingWork()
+      && (lastSleepWake == 0 || the_mesh.millisHasNowPassed(lastSleepWake + RECONNECT_WINDOW_MS))) {
+#ifdef PIN_USER_BTN
+    board.enterLightSleep(SHORT_SLEEP_SECS, PIN_USER_BTN);
+#else
+    board.enterLightSleep(SHORT_SLEEP_SECS);
+#endif
+    // Restart BLE advertising after light sleep powers down the radio
+    bluetooth_interface.disable();
+    bluetooth_interface.enable();
+    lastSleepWake = millis();
+    if (lastSleepWake == 0) lastSleepWake = 1;
+  }
+
   // Power saving when BLE is disabled
   // Don't sleep if GPS is enabled - it needs continuous operation to maintain fix
   // Note: Disabling BLE via UI actually turns off the radio to save power

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -280,10 +280,11 @@ void loop() {
   }
 #endif
 
-  // Power saving when BLE/WiFi is disabled
+#if defined(BLE_PIN_CODE) && !defined(WIFI_SSID) && !defined(ETHERNET_ENABLED)
+  // Power saving when BLE is disabled
   // Don't sleep if GPS is enabled - it needs continuous operation to maintain fix
-  // Note: Disabling BLE/WiFi via UI actually turns off the radio to save power
-  if (!serial_interface.isEnabled() && !the_mesh.getNodePrefs()->gps_enabled) {
+  // Note: Disabling BLE via UI actually turns off the radio to save power
+  if (!bluetooth_interface.isEnabled() && !the_mesh.getNodePrefs()->gps_enabled) {
     // Check for pending work and update activity timer
     if (the_mesh.hasPendingWork()) {
       lastActive = millis();
@@ -306,4 +307,5 @@ void loop() {
       nextSleepInSecs = WORK_TIME_SECS; // Stay awake for 5s after wake
     }
   }
+#endif
 }

--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -15,6 +15,7 @@ public:
 
   virtual bool isConnected() const = 0;
   virtual void loop() {};
+  virtual bool hasPendingConnection() const { return isConnected(); }
 
   virtual bool isWriteBusy() const = 0;
   virtual size_t writeFrame(const uint8_t src[], size_t len) = 0;

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -15,6 +15,7 @@
 #include "soc/rtc.h"
 #include "esp_system.h"
 #include <driver/rtc_io.h>
+#include <driver/gpio.h>
 
 class ESP32Board : public mesh::MainBoard {
 protected:
@@ -68,6 +69,28 @@ public:
 
   uint32_t getIRQGpio() override {
     return P_LORA_DIO_1; // default for SX1262
+  }
+
+  void enterLightSleep(uint32_t secs, int pin_wake_btn = -1) {
+#if defined(CONFIG_IDF_TARGET_ESP32S3) && defined(P_LORA_DIO_1) // Supported ESP32 variants
+    if (rtc_gpio_is_valid_gpio((gpio_num_t)P_LORA_DIO_1)) { // Only enter sleep mode if P_LORA_DIO_1 is RTC pin
+      esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+      esp_sleep_enable_ext1_wakeup((1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // Wake on LoRa packet
+
+      // Wake on button press (active-LOW: pin is HIGH when idle, LOW when pressed)
+      if (pin_wake_btn >= 0) {
+        gpio_wakeup_enable((gpio_num_t)pin_wake_btn, GPIO_INTR_LOW_LEVEL);
+        esp_sleep_enable_gpio_wakeup();
+      }
+
+      if (secs > 0) {
+        esp_sleep_enable_timer_wakeup(secs * 1000000); // To wake up every hour to do periodically jobs
+      }
+
+      esp_light_sleep_start(); // CPU enters light sleep
+    }
+#endif
   }
 
   void sleep(uint32_t secs) override {

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -16,6 +16,7 @@
 #include "esp_system.h"
 #include <driver/rtc_io.h>
 #include <helpers/KeyValueStore.h>
+#include <driver/gpio.h>
 
 class ESP32Board : public mesh::MainBoard {
 protected:
@@ -71,6 +72,28 @@ public:
 
   uint32_t getIRQGpio() override {
     return P_LORA_DIO_1; // default for SX1262
+  }
+
+  void enterLightSleep(uint32_t secs, int pin_wake_btn = -1) {
+#if defined(CONFIG_IDF_TARGET_ESP32S3) && defined(P_LORA_DIO_1) // Supported ESP32 variants
+    if (rtc_gpio_is_valid_gpio((gpio_num_t)P_LORA_DIO_1)) { // Only enter sleep mode if P_LORA_DIO_1 is RTC pin
+      esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+      esp_sleep_enable_ext1_wakeup((1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // Wake on LoRa packet
+
+      // Wake on button press (active-LOW: pin is HIGH when idle, LOW when pressed)
+      if (pin_wake_btn >= 0) {
+        gpio_wakeup_enable((gpio_num_t)pin_wake_btn, GPIO_INTR_LOW_LEVEL);
+        esp_sleep_enable_gpio_wakeup();
+      }
+
+      if (secs > 0) {
+        esp_sleep_enable_timer_wakeup(secs * 1000000); // To wake up every hour to do periodically jobs
+      }
+
+      esp_light_sleep_start(); // CPU enters light sleep
+    }
+#endif
   }
 
   void sleep(uint32_t secs) override {

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -56,6 +56,7 @@ public:
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
   virtual void sleep(uint32_t secs) override;
   bool isExternalPowered() override;
+  void enterLightSleep(uint32_t secs, int pin_wake_btn = -1) { sleep(secs); }
 
 #ifdef NRF52_POWER_MANAGEMENT
   uint16_t getBootVoltage() override { return boot_voltage_mv; }

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -57,6 +57,7 @@ public:
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
   virtual void sleep(uint32_t secs) override;
   bool isExternalPowered() override;
+  void enterLightSleep(uint32_t secs, int pin_wake_btn = -1) { sleep(secs); }
 
   void attachDynamicPrefs(KeyValueStore* prefs) { }  // no-op
 

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -249,3 +249,7 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
 bool SerialBLEInterface::isConnected() const {
   return deviceConnected;  //pServer != NULL && pServer->getConnectedCount() > 0;
 }
+
+bool SerialBLEInterface::hasPendingConnection() const {
+  return pServer != NULL && pServer->getConnectedCount() > 0;
+}

--- a/src/helpers/esp32/SerialBLEInterface.h
+++ b/src/helpers/esp32/SerialBLEInterface.h
@@ -81,6 +81,7 @@ public:
   bool isEnabled() const override { return _isEnabled; }
 
   bool isConnected() const override;
+  bool hasPendingConnection() const override;
 
   bool isWriteBusy() const override;
   size_t writeFrame(const uint8_t src[], size_t len) override;

--- a/src/helpers/esp32/SerialWifiInterface.cpp
+++ b/src/helpers/esp32/SerialWifiInterface.cpp
@@ -4,18 +4,38 @@
 void SerialWifiInterface::begin(int port) {
   // wifi setup is handled outside of this class, only starts the server
   server.begin(port);
+
+  // Store WiFi credentials for re-enable
+#ifdef WIFI_SSID
+  _ssid = WIFI_SSID;
+  _password = WIFI_PWD;
+  _isEnabled = true;  // WiFi starts enabled
+#else
+  _ssid = nullptr;
+  _password = nullptr;
+#endif
 }
 
 // ---------- public methods
-void SerialWifiInterface::enable() { 
+void SerialWifiInterface::enable() {
   if (_isEnabled) return;
 
   _isEnabled = true;
   clearBuffers();
+
+  // Re-enable WiFi with stored credentials
+  if (_ssid != nullptr && _password != nullptr) {
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(_ssid, _password);
+  }
 }
 
 void SerialWifiInterface::disable() {
   _isEnabled = false;
+
+  // Actually turn off WiFi to save power
+  WiFi.disconnect(true);  // Disconnect and clear config
+  WiFi.mode(WIFI_OFF);    // Turn off WiFi radio
 }
 
 size_t SerialWifiInterface::writeFrame(const uint8_t src[], size_t len) {

--- a/src/helpers/esp32/SerialWifiInterface.h
+++ b/src/helpers/esp32/SerialWifiInterface.h
@@ -8,6 +8,8 @@ class SerialWifiInterface : public BaseSerialInterface {
   bool _isEnabled;
   unsigned long _last_write;
   unsigned long adv_restart_time;
+  const char* _ssid;
+  const char* _password;
 
   WiFiServer server;
   WiFiClient client;
@@ -39,6 +41,8 @@ public:
     deviceConnected = false;
     _isEnabled = false;
     _last_write = 0;
+    _ssid = nullptr;
+    _password = nullptr;
     send_queue_len = recv_queue_len = 0;
     received_frame_header.type = 0;
     received_frame_header.length = 0;


### PR DESCRIPTION
PR #1347 adds power saving for companion radios when BLE is manually disabled by the user. But when the phone simply walks away or goes to sleep, BLE stays enabled and advertising, and the radio stays fully awake. This is wasted power in a common scenario.

This adds a second power-saving mode: when BLE is enabled but no phone has been connected for 60 seconds, enter a 12s sleep / 3s awake cycle. On each wake, BLE advertising is restarted (light sleep powers down the BLE radio) so phones can reconnect. The cycle exits immediately when a connection is detected.

Tested on my Heltec v4 companion and it works. Would be good if other people can test.

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=short-sleeps-when-phone-disconnects)