### PR TITLE
adding support for waveshare esp32-C6 and power states

### DIFF
--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -9,6 +9,10 @@
 #include <sys/time.h>
 #include <Wire.h>
 #include "driver/rtc_io.h"
+#if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(WAVESHARE_ESP32_C6_LP_BASELINE)
+  #include "esp_sleep.h"
+  #include "driver/gpio.h"
+#endif
 
 class ESP32Board : public mesh::MainBoard {
 protected:
@@ -19,6 +23,13 @@ public:
   void begin() {
     // for future use, sub-classes SHOULD call this from their begin()
     startup_reason = BD_STARTUP_NORMAL;
+
+#if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(WAVESHARE_ESP32_C6_LP_BASELINE)
+    esp_sleep_wakeup_cause_t wakeup = esp_sleep_get_wakeup_cause();
+    if (wakeup == ESP_SLEEP_WAKEUP_EXT1 || wakeup == ESP_SLEEP_WAKEUP_GPIO) {
+      startup_reason = BD_STARTUP_RX_PACKET;
+    }
+#endif
 
   #ifdef ESP32_CPU_FREQ
     setCpuFrequencyMhz(ESP32_CPU_FREQ);
@@ -60,20 +71,65 @@ public:
 #if defined(CONFIG_IDF_TARGET_ESP32S3) && defined(P_LORA_DIO_1) // Supported ESP32 variants
     if (rtc_gpio_is_valid_gpio((gpio_num_t)P_LORA_DIO_1)) { // Only enter sleep mode if P_LORA_DIO_1 is RTC pin
       esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-      esp_sleep_enable_ext1_wakeup((1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // To wake up when receiving a LoRa packet
+      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // To wake up when receiving a LoRa packet
 
       if (secs > 0) {
-        esp_sleep_enable_timer_wakeup(secs * 1000000); // To wake up every hour to do periodically jobs
+        esp_sleep_enable_timer_wakeup((uint64_t)secs * 1000000ULL); // To wake up every hour to do periodically jobs
       }
 
       esp_light_sleep_start(); // CPU enters light sleep
     }
+#elif defined(CONFIG_IDF_TARGET_ESP32C6) && defined(WAVESHARE_ESP32_C6_LP_BASELINE)
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
+  #ifdef P_LORA_DIO_1
+    // Prefer EXT1 wake on LP/RTC GPIOs (0..7 on C6); fallback to digital GPIO wake.
+    if (esp_sleep_is_valid_wakeup_gpio((gpio_num_t)P_LORA_DIO_1)) {
+      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);
+    } else {
+      gpio_wakeup_enable((gpio_num_t)P_LORA_DIO_1, GPIO_INTR_HIGH_LEVEL);
+      esp_sleep_enable_gpio_wakeup(); // Wake up when receiving a LoRa IRQ pulse
+    }
+  #endif
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup((uint64_t)secs * 1000000ULL); // Timer fallback wake
+    }
+
+    esp_light_sleep_start();
+#endif
+  }
+
+  void enterDeepSleep(uint32_t secs) {
+#if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(WAVESHARE_ESP32_C6_LP_BASELINE)
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
+  #ifdef P_LORA_DIO_1
+    // Deep sleep wake on C6 requires LP/RTC-capable GPIOs (0..7).
+    if (esp_sleep_is_valid_wakeup_gpio((gpio_num_t)P_LORA_DIO_1)) {
+      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);
+    }
+  #endif
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup((uint64_t)secs * 1000000ULL);
+    }
+
+    esp_deep_sleep_start();
 #endif
   }
 
   void sleep(uint32_t secs) override {
     if (!inhibit_sleep) {
+  #if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(WAVESHARE_ESP32_C6_LP_BASELINE)
+  #if defined(WAVESHARE_ESP32_C6_USE_DEEP_SLEEP) && (WAVESHARE_ESP32_C6_USE_DEEP_SLEEP == 1)
+      enterDeepSleep(secs);
+  #else
+      enterLightSleep(secs);
+  #endif
+  #else
       enterLightSleep(secs);      // To wake up after "secs" seconds or when receiving a LoRa packet
+  #endif
     }
   }
 


### PR DESCRIPTION
**PR Summary**
This PR adds minimal ESP32-C6 sleep support required for Waveshare C6 enablement groundwork, while keeping behavior unchanged for all existing non-target boards.

**Scope**
Only file changed: [ESP32Board.h](https://file+.vscode-resource.vscode-cdn.net/Users/andy/.vscode/extensions/openai.chatgpt-0.4.74-darwin-arm64/webview/#)
No variant additions in this PR
No LR1121 integration in this PR (deferred to follow-up)

**What Changed**
Added C6-only includes and logic behind:
CONFIG_IDF_TARGET_ESP32C6
WAVESHARE_ESP32_C6_LP_BASELINE
Added C6 wake-cause mapping in begin() so GPIO/EXT1 wake can report BD_STARTUP_RX_PACKET.
Added C6 sleep implementations:
enterLightSleep() with EXT1/GPIO wake handling and timer wake.
enterDeepSleep() (optional path via macro).
Updated C6 sleep() path to use light/deep sleep based on WAVESHARE_ESP32_C6_USE_DEEP_SLEEP.
Kept legacy behavior for all other ESP32 targets:
setInhibitSleep() retained.
sleep() still uses existing enterLightSleep() behavior when not in the C6 guarded path.
Small safety/type fixes in existing code path:
1L -> 1ULL
timer math cast to uint64_t.

**Behavioral Impact**
Non-C6 boards: no behavior change intended.
C6 Waveshare-gated builds: gain guarded low-power wake/sleep support needed for future board enablement.

**Follow-up PRs**
Add Waveshare ESP32-C6 variant/build envs.
Add LR1121 support and TX power handling (2.4 GHz vs sub-GHz limits).