### PR TITLE
add waveshare esp32-c6 sx1262 variant (no lr1121)

### DIFF
--- a/variants/waveshare_esp32_c6/WaveshareESP32C6Board.h
+++ b/variants/waveshare_esp32_c6/WaveshareESP32C6Board.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+
+class WaveshareESP32C6Board : public ESP32Board {
+public:
+  const char* getManufacturerName() const override {
+    return "Waveshare ESP32-C6";
+  }
+};

--- a/variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.cpp
+++ b/variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.cpp
@@ -1,0 +1,162 @@
+#include "WaveshareESP32C6LCDDisplay.h"
+
+#include <Arduino.h>
+#include <math.h>
+
+static constexpr uint16_t COLOR_BLACK = 0x0000;
+static constexpr uint16_t COLOR_WHITE = 0xFFFF;
+
+WaveshareESP32C6LCDDisplay::WaveshareESP32C6LCDDisplay()
+  : DisplayDriver(128, 64),
+    _bus(new Arduino_HWSPI(15 /* DC */, 14 /* CS */, 7 /* SCK */, 6 /* MOSI */, 5 /* MISO */)),
+    _display(new Arduino_ST7789(
+      _bus,
+      21 /* RST */,
+      DISPLAY_ROTATION,
+      true /* IPS */,
+      TFT_WIDTH,
+      TFT_HEIGHT,
+      34 /* col offset 1 */,
+      0 /* row offset 1 */,
+      34 /* col offset 2 */,
+      0 /* row offset 2 */)),
+    _is_on(false),
+    _color(COLOR_WHITE) {
+}
+
+int WaveshareESP32C6LCDDisplay::sx(int x) const {
+  return DISPLAY_OFFSET_X + (int)lroundf(x * DISPLAY_SCALE_X);
+}
+
+int WaveshareESP32C6LCDDisplay::sy(int y) const {
+  return DISPLAY_OFFSET_Y + (int)lroundf(y * DISPLAY_SCALE_Y);
+}
+
+int WaveshareESP32C6LCDDisplay::sw(int w) const {
+  int v = (int)lroundf(w * DISPLAY_SCALE_X);
+  return (v < 1) ? 1 : v;
+}
+
+int WaveshareESP32C6LCDDisplay::sh(int h) const {
+  int v = (int)lroundf(h * DISPLAY_SCALE_Y);
+  return (v < 1) ? 1 : v;
+}
+
+bool WaveshareESP32C6LCDDisplay::begin() {
+  if (_is_on) return true;
+
+  // Disable SD to avoid sharing issues on the SPI bus used by the LCD.
+  pinMode(4, OUTPUT);
+  digitalWrite(4, HIGH);
+
+  pinMode(22, OUTPUT);
+  digitalWrite(22, HIGH);  // backlight on
+
+  _display->begin(40000000);
+  _display->fillScreen(COLOR_BLACK);
+  _display->setTextColor(COLOR_WHITE);
+  _display->setTextSize(1);
+  _is_on = true;
+
+  return true;
+}
+
+void WaveshareESP32C6LCDDisplay::turnOn() {
+  if (!_is_on) begin();
+  digitalWrite(22, HIGH);
+  _is_on = true;
+}
+
+void WaveshareESP32C6LCDDisplay::turnOff() {
+  digitalWrite(22, LOW);
+  _is_on = false;
+}
+
+void WaveshareESP32C6LCDDisplay::clear() {
+  _display->fillScreen(COLOR_BLACK);
+}
+
+void WaveshareESP32C6LCDDisplay::startFrame(Color bkg) {
+  _display->fillScreen((bkg == DARK) ? COLOR_BLACK : COLOR_WHITE);
+  _display->setTextColor((bkg == DARK) ? COLOR_WHITE : COLOR_BLACK);
+}
+
+void WaveshareESP32C6LCDDisplay::setTextSize(int sz) {
+  int text_scale = (int)lroundf(sz * DISPLAY_SCALE_X);
+  if (text_scale < 1) text_scale = 1;
+  _display->setTextSize(text_scale);
+}
+
+void WaveshareESP32C6LCDDisplay::setColor(Color c) {
+  switch (c) {
+    case DARK:
+      _color = COLOR_BLACK;
+      break;
+    case LIGHT:
+      _color = COLOR_WHITE;
+      break;
+    case RED:
+      _color = _display->color565(255, 0, 0);
+      break;
+    case GREEN:
+      _color = _display->color565(0, 255, 0);
+      break;
+    case BLUE:
+      _color = _display->color565(0, 0, 255);
+      break;
+    case YELLOW:
+      _color = _display->color565(255, 255, 0);
+      break;
+    case ORANGE:
+      _color = _display->color565(255, 165, 0);
+      break;
+    default:
+      _color = COLOR_WHITE;
+      break;
+  }
+  _display->setTextColor(_color);
+}
+
+void WaveshareESP32C6LCDDisplay::setCursor(int x, int y) {
+  _display->setCursor(sx(x), sy(y));
+}
+
+void WaveshareESP32C6LCDDisplay::print(const char* str) {
+  _display->print(str);
+}
+
+void WaveshareESP32C6LCDDisplay::fillRect(int x, int y, int w, int h) {
+  _display->fillRect(sx(x), sy(y), sw(w), sh(h), _color);
+}
+
+void WaveshareESP32C6LCDDisplay::drawRect(int x, int y, int w, int h) {
+  _display->drawRect(sx(x), sy(y), sw(w), sh(h), _color);
+}
+
+void WaveshareESP32C6LCDDisplay::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+  int pixel_w = sw(1);
+  int pixel_h = sh(1);
+  int base_x = sx(x);
+  int base_y = sy(y);
+  int byte_width = (w + 7) / 8;
+
+  for (int row = 0; row < h; row++) {
+    for (int col = 0; col < w; col++) {
+      uint8_t byte = bits[row * byte_width + (col / 8)];
+      if (byte & (0x80 >> (col & 7))) {
+        _display->fillRect(base_x + col * pixel_w, base_y + row * pixel_h, pixel_w, pixel_h, _color);
+      }
+    }
+  }
+}
+
+uint16_t WaveshareESP32C6LCDDisplay::getTextWidth(const char* str) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  _display->getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+  return (uint16_t)lroundf(w / DISPLAY_SCALE_X);
+}
+
+void WaveshareESP32C6LCDDisplay::endFrame() {
+  // Immediate-mode driver, no explicit flush needed.
+}

--- a/variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.h
+++ b/variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <helpers/ui/DisplayDriver.h>
+#include <Arduino_GFX_Library.h>
+
+#ifndef DISPLAY_ROTATION
+  #define DISPLAY_ROTATION 0
+#endif
+
+#ifndef DISPLAY_SCALE_X
+  #define DISPLAY_SCALE_X 1.34375f  // 172 / 128
+#endif
+
+#ifndef DISPLAY_SCALE_Y
+  #define DISPLAY_SCALE_Y 5.0f      // 320 / 64
+#endif
+
+#ifndef DISPLAY_OFFSET_X
+  #define DISPLAY_OFFSET_X 0
+#endif
+
+#ifndef DISPLAY_OFFSET_Y
+  #define DISPLAY_OFFSET_Y 0
+#endif
+
+class WaveshareESP32C6LCDDisplay : public DisplayDriver {
+  Arduino_DataBus* _bus;
+  Arduino_GFX* _display;
+  bool _is_on;
+  uint16_t _color;
+
+  static constexpr int TFT_WIDTH = 172;
+  static constexpr int TFT_HEIGHT = 320;
+
+  int sx(int x) const;
+  int sy(int y) const;
+  int sw(int w) const;
+  int sh(int h) const;
+
+public:
+  WaveshareESP32C6LCDDisplay();
+
+  bool begin();
+
+  bool isOn() override { return _is_on; }
+  void turnOn() override;
+  void turnOff() override;
+  void clear() override;
+  void startFrame(Color bkg = DARK) override;
+  void setTextSize(int sz) override;
+  void setColor(Color c) override;
+  void setCursor(int x, int y) override;
+  void print(const char* str) override;
+  void fillRect(int x, int y, int w, int h) override;
+  void drawRect(int x, int y, int w, int h) override;
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
+  void endFrame() override;
+};

--- a/variants/waveshare_esp32_c6/platformio.ini
+++ b/variants/waveshare_esp32_c6/platformio.ini
@@ -1,0 +1,91 @@
+[Waveshare_ESP32_C6]
+extends = esp32c6_base
+board = esp32-c6-devkitm-1
+board_build.partitions = min_spiffs.csv ; get around 4MB flash limit
+monitor_dtr = 0
+monitor_rts = 0
+build_flags =
+  ${esp32c6_base.build_flags}
+  -I variants/waveshare_esp32_c6
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+  ; Reference SX1262 wiring profile for ESP32-C6-LCD-1.47.
+  ; Keep radio pins away from LCD pins (GPIO15 DC, GPIO21 reset).
+  -D P_LORA_TX_NEOPIXEL_LED=8
+  -D P_LORA_SCLK=19
+  -D P_LORA_MISO=20
+  -D P_LORA_MOSI=18
+  -D P_LORA_NSS=23
+  -D P_LORA_DIO_1=1
+  -D P_LORA_BUSY=2
+  -D P_LORA_RESET=9
+  -D PIN_BOARD_SDA=16
+  -D PIN_BOARD_SCL=17
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D DISPLAY_CLASS=WaveshareESP32C6LCDDisplay
+  -D DISPLAY_ROTATION=1
+  ; Rounded corners on this LCD can clip UI edges; shrink/inset the 128x64 canvas.
+  -D DISPLAY_OFFSET_X=20
+  -D DISPLAY_OFFSET_Y=20
+  -D DISPLAY_SCALE_X=1.3125f
+  -D DISPLAY_SCALE_Y=4.9375f
+  -D LORA_TX_POWER=22
+  -D DISABLE_WIFI_OTA=1
+build_src_filter = ${esp32c6_base.build_src_filter}
+  +<../variants/waveshare_esp32_c6>
+lib_deps =
+  ${esp32c6_base.lib_deps}
+  moononournation/GFX Library for Arduino @ ^1.5.9
+
+[env:Waveshare_ESP32_C6_repeater_]
+extends = Waveshare_ESP32_C6
+build_src_filter = ${Waveshare_ESP32_C6.build_src_filter}
+  +<../examples/simple_repeater/*.cpp>
+build_flags =
+  ${Waveshare_ESP32_C6.build_flags}
+  -D ADVERT_NAME='"Waveshare C6 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+lib_deps =
+  ${Waveshare_ESP32_C6.lib_deps}
+
+[env:Waveshare_ESP32_C6_room_server_]
+extends = Waveshare_ESP32_C6
+build_src_filter = ${Waveshare_ESP32_C6.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${Waveshare_ESP32_C6.build_flags}
+  -D ADVERT_NAME='"Waveshare C6 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+lib_deps =
+  ${Waveshare_ESP32_C6.lib_deps}
+
+[env:Waveshare_ESP32_C6_companion_radio_ble_]
+extends = Waveshare_ESP32_C6
+build_flags = ${Waveshare_ESP32_C6.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+  -D ENABLE_PRIVATE_KEY_IMPORT=1
+  -D ENABLE_PRIVATE_KEY_EXPORT=1
+build_src_filter = ${Waveshare_ESP32_C6.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  -<helpers/esp32/ESPNOWRadio.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Waveshare_ESP32_C6.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/waveshare_esp32_c6/target.cpp
+++ b/variants/waveshare_esp32_c6/target.cpp
@@ -1,0 +1,52 @@
+#include <Arduino.h>
+#include "target.h"
+
+WaveshareESP32C6Board board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi(0);
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/waveshare_esp32_c6/target.h
+++ b/variants/waveshare_esp32_c6/target.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <WaveshareESP32C6Board.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <WaveshareESP32C6LCDDisplay.h>
+#endif
+
+extern WaveshareESP32C6Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
## Summary

This PR adds a new **Waveshare ESP32-C6 (SX1262)** board variant with display support, while intentionally excluding LR1121-specific logic/wiring.

The goal is to provide an upstream-safe, buildable Waveshare C6 target without introducing custom external-radio assumptions.

## What’s Included

- New variant: `variants/waveshare_esp32_c6/`
- Board class:
  - `variants/waveshare_esp32_c6/WaveshareESP32C6Board.h`
- Display driver for the ESP32-C6-LCD-1.47 form factor:
  - `variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.h`
  - `variants/waveshare_esp32_c6/WaveshareESP32C6LCDDisplay.cpp`
- Variant target wiring/runtime glue:
  - `variants/waveshare_esp32_c6/target.h`
  - `variants/waveshare_esp32_c6/target.cpp`
- Variant build environments:
  - `variants/waveshare_esp32_c6/platformio.ini`
  - `env:Waveshare_ESP32_C6_repeater_`
  - `env:Waveshare_ESP32_C6_room_server_`
  - `env:Waveshare_ESP32_C6_companion_radio_ble_`

## Scope / Non-Goals

- No LR1121 support in this PR.
- No LR1121 wrappers or dual-band TX-power handling in this PR.
- No custom-wired external radio profiles added to upstream variants.

## Notes

- Radio path in this PR uses the existing SX1262 stack (`CustomSX1262` + `CustomSX1262Wrapper`) with variant-local pin mapping.
- Display scaling/offset macros are exposed in variant flags to account for panel geometry/corner clipping.

## Validation

- PlatformIO recognizes all new `Waveshare_ESP32_C6_*` environments.
