### PR TITLE
Initialise BME680 with TELEM_WIRE

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -12,7 +12,7 @@
 #endif
 #define TELEM_BME680_SEALEVELPRESSURE_HPA (1013.25)
 #include <Adafruit_BME680.h>
-static Adafruit_BME680 BME680;
+static Adafruit_BME680 BME680(TELEM_WIRE);
 #endif
 
 #ifdef ENV_INCLUDE_BMP085


### PR DESCRIPTION
Initialise BME680 with TELEM_WIRE, fixes BME680 not being able to begin despite being detected.

In my case with a Heltec V3:
```
  -D ENV_PIN_SDA=41
  -D ENV_PIN_SCL=42
  -D TELEM_BME680_ADDRESS=0x77
  -D ENV_INCLUDE_BME680=1
  ```