### PR TITLE
Prevent repeater from adding itself to flood path multiple times

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -336,6 +336,13 @@ void Mesh::removeSelfFromPath(Packet* pkt) {
 DispatcherAction Mesh::routeRecvPacket(Packet* packet) {
   if (packet->isRouteFlood() && !packet->isMarkedDoNotRetransmit()
     && packet->path_len + PATH_HASH_SIZE <= MAX_PATH_SIZE && allowPacketForward(packet)) {
+    // prevent this repeater from being added to the path multiple times
+    uint8_t my_hash = self_id.pub_key[0];
+    if (packet->path_len >= 2
+        && packet->path[packet->path_len - 1] == my_hash
+        && packet->path[packet->path_len - 2] == my_hash) {
+      return ACTION_RELEASE;
+    }
     // append this node's hash to 'path'
     packet->path_len += self_id.copyHashTo(&packet->path[packet->path_len]);
 


### PR DESCRIPTION
## Summary
- When a repeater goes rogue, it can inject its own id into the path multiple times.
- Before appending this node's hash to the path in `routeRecvPacket()`, check if the last 2 path entries already match — if so, drop the packet instead of retransmitting
- Allows up to 2 consecutive identical hashes (legitimate collision) but blocks 3+ (loop indicator)

## Test plan
- [ ] Verify build compiles cleanly (confirmed with PlatformIO `Heltec_v3_repeater`)
- [ ] Trace attack scenario: packet with path `[... 20 20]` arriving at repeater with hash `0x20` is correctly dropped
- [ ] Verify normal forwarding: packet with path `[... AB]` at repeater `0x20` forwards as `[... AB 20]`
- [ ] Verify single collision: packet with path `[... 20]` at repeater `0x20` forwards as `[... 20 20]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Description updated by myself to clarify the underlying issue as a rogue repeater injecting itself into the path multiple times, nearly exhausting max path, and transmitting corrupted messages.

example:

```
05 16 56 AB 86 7E 75 20 20 20 20 20 20 20 20 20 75 07 24 BE 53 A5 2D 6B 7C 9E 06 CD 97 A3 AD C0 FC 68 41 AC
```

https://discord.com/channels/1343693475589263471/1391673743453192242/1474609553533440020