### PR TITLE
Fix stack buffer overflow in MACThenDecrypt

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -74,16 +74,17 @@ int Utils::encryptThenMAC(const uint8_t* shared_secret, uint8_t* dest, const uin
 int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len) {
   if (src_len <= CIPHER_MAC_SIZE) return 0;  // invalid src bytes
 
+  int enc_len = src_len - CIPHER_MAC_SIZE;
+  if (enc_len % CIPHER_BLOCK_SIZE != 0) return 0;  // reject non-block-aligned ciphertext
+
   uint8_t hmac[CIPHER_MAC_SIZE];
   {
     SHA256 sha;
     sha.resetHMAC(shared_secret, PUB_KEY_SIZE);
-    sha.update(src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
+    sha.update(src + CIPHER_MAC_SIZE, enc_len);
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
   if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
-    int enc_len = src_len - CIPHER_MAC_SIZE;
-    if (enc_len % CIPHER_BLOCK_SIZE != 0) return 0;  // reject non-block-aligned ciphertext
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, enc_len);
   }
   return 0; // invalid HMAC

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -82,7 +82,9 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
   if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
-    return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
+    int enc_len = src_len - CIPHER_MAC_SIZE;
+    if (enc_len % CIPHER_BLOCK_SIZE != 0) return 0;  // reject non-block-aligned ciphertext
+    return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, enc_len);
   }
   return 0; // invalid HMAC
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -50,7 +50,7 @@ public:
 
   /**
    * \brief  checks the MAC (in leading bytes of 'src'), then if valid, decrypts remaining bytes in src.
-   * \returns  zero if MAC is invalid, otherwise the length of decrypted bytes in 'dest'
+   * \returns  zero if MAC is invalid or ciphertext is not block-aligned, otherwise the length of decrypted bytes in 'dest'
   */
   static int MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len);
 


### PR DESCRIPTION
## Summary

Add block-alignment validation in `MACThenDecrypt` to prevent a stack buffer overflow in `decrypt()` caused by crafted packets with non-16-aligned ciphertext.

## Vulnerability

`Utils::decrypt()` processes input in fixed 16-byte AES blocks:

```cpp
while (sp - src < src_len) {
    aes.decryptBlock(dp, sp);   // always reads/writes 16 bytes
    dp += 16; sp += 16;
}
```

When `src_len` is not a multiple of 16, this loop rounds **up** to the next block boundary, writing up to 15 extra bytes beyond what the caller allocated. All callers use a stack-allocated `uint8_t data[MAX_PACKET_PAYLOAD]` (184 bytes) as the destination buffer.

For example, with peer messages (TXT_MSG, REQ, RESPONSE, PATH), the value reaching `decrypt()` is `payload_len - 4`. If an attacker crafts a packet with `payload_len = 184`, decrypt receives 180 bytes (not a multiple of 16), processes 12 full blocks (192 bytes), and writes **8 bytes past the end** of the 184-byte stack buffer. The same overflow applies to group messages (GRP_TXT, GRP_DATA) with up to 8 bytes of overflow.

## Affected Code Path

```
Radio hardware (LoRa / ESP-NOW)
  → Dispatcher::checkRecv()          — parses raw bytes, sets payload_len (validated ≤ 184)
    → Dispatcher::processRecvPacket()
      → Mesh::onRecvPacket()         — dispatches by payload type
        → Utils::MACThenDecrypt()    — verifies 2-byte HMAC, then calls decrypt()
          → Utils::decrypt()         — rounds src_len up to next 16-byte boundary ← OVERFLOW
```

Affected call sites in `Mesh::onRecvPacket()`:

| Payload type | Offset `i` | Max decrypt input | Decrypt writes | Buffer size | Overflow |
|---|---|---|---|---|---|
| TXT_MSG / REQ / RESPONSE / PATH | 2 | 180 bytes | 192 bytes | 184 bytes | **8 bytes** |
| GRP_TXT / GRP_DATA | 1 | 181 bytes | 192 bytes | 184 bytes | **8 bytes** |
| ANON_REQ | 33 | 149 bytes | 160 bytes | 184 bytes | None |

## Exploitation

Under **normal operation**, this is never triggered. `encryptThenMAC()` always produces ciphertext that is an exact multiple of 16 bytes, so legitimate packets are always block-aligned.

An attacker triggers the overflow by sending a crafted packet with non-16-aligned ciphertext that passes the 2-byte HMAC check (`CIPHER_MAC_SIZE = 2`, i.e. 16 bits of authentication):

- **Without knowing the shared secret**: Each packet has a 1-in-65,536 chance of the random HMAC colliding. The attacker sends packets continuously until one passes.
- **With a compromised shared secret** (malicious peer): Deterministic on the first attempt.

Estimated time to trigger by brute-forcing the HMAC:

| Transport | Throughput | Avg time to crash |
|---|---|---|
| LoRa | ~1 pkt/sec | ~18 hours |
| LoRa (4 matching contacts) | ~1 pkt/sec | ~4.5 hours |
| ESP-NOW bridge | ~100 pkt/sec | ~11 minutes |

The attack is **repeatable** — after the device reboots, the attacker continues sending, crashing it again for a persistent denial of service.

## Impact

The 8 bytes of AES-decrypted garbage overwrite the stack frame of `onRecvPacket()`. On ESP32 and nRF52 targets (no ASLR, no stack canaries), this reliably causes:

- Hard fault from corrupted return address → watchdog reboot
- Or unpredictable behavior from corrupted local variables → crash

**Primary impact**: Persistent DoS against any node that attempts decryption (repeaters, room servers, sensors). The attacker only needs to observe the target's 1-byte public key hash from its advertisements to direct packets at it.

**Secondary impact**: Each reboot disrupts mesh routing for all nodes relying on the target as a relay, and clears the target's in-memory deduplication table.

## The Fix

A single validation added to `MACThenDecrypt()` before calling `decrypt()`:

```cpp
int enc_len = src_len - CIPHER_MAC_SIZE;
if (enc_len % CIPHER_BLOCK_SIZE != 0) return 0;  // reject non-block-aligned ciphertext
return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, enc_len);
```

This rejects any ciphertext whose length is not a multiple of 16. Since `encryptThenMAC()` always produces block-aligned output, no legitimate packet can ever have non-aligned ciphertext. The check catches malformed or crafted packets before they reach `decrypt()`.

## Performance

**Negligible.** The fix adds a single integer modulo operation (`enc_len % 16`) per `MACThenDecrypt` call. This executes in nanoseconds — orders of magnitude less than the AES decryption and HMAC-SHA256 computation that follow it. No additional memory, no extra crypto operations.

## Power Consumption

**No impact.** The check runs entirely in CPU with no additional radio activity, no extra flash reads, and no changes to sleep/wake behavior. For the rejection path (malformed packets), it actually *saves* power by skipping the unnecessary `decrypt()` call.

## Backwards Compatibility

**Fully backwards compatible.** This change only affects the *receiving* side — no wire format changes, no new packet fields, no version bump required.

- Packets from older firmware: Always block-aligned (produced by `encryptThenMAC`), pass the check.
- Packets from newer firmware: Identical wire format, pass the check.
- Mixed networks: No interoperability issues. Old and new firmware versions communicate without any changes.

The only packets rejected by this check are ones that could never have been produced by any version of `encryptThenMAC()` — they are by definition malformed or crafted.

## Testing

- **Legitimate traffic**: All existing message types (text, requests, responses, paths, group messages, anonymous requests, advertisements) are unaffected. Their ciphertext lengths are always multiples of 16.
- **Malformed packets**: Any packet where `(payload_encrypted_len % 16) != 0` is now rejected with return value 0 (same as an HMAC failure), before `decrypt()` is called.