### PR TITLE
Add discussion templates and disable blank issues (5/5)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,29 @@
+title: "[Idea]: "
+labels: ["enhancement"]
+body:
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware (if applicable)
+      description: Which hardware does this apply to? Leave blank if not hardware-specific.
+      placeholder: "e.g., T1000-E, Heltec LoRa32 v3, all ESP32 boards"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your idea
+      description: What would you like to see? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, mockups, or references.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,35 @@
+title: "[Q&A]: "
+body:
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic Area
+      options:
+        - Getting Started / Setup
+        - BLE / Companion App
+        - LoRa / Mesh Networking
+        - Build System / Compilation
+        - Hardware / Wiring
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware (if applicable)
+      placeholder: "e.g., T1000-E, RAK4631"
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: Describe what you need help with.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What have you tried?
+      description: Steps you have already taken or documentation you have read.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/meshcore-dev/MeshCore/discussions/categories/q-a
+    about: Use GitHub Discussions for questions and support.
+  - name: Feature Request / Idea
+    url: https://github.com/meshcore-dev/MeshCore/discussions/categories/ideas
+    about: Suggest features and improvements in Discussions.
+  - name: Discord Community
+    url: https://discord.gg/BMwCtwHj5V
+    about: Join the Discord for real-time help and chat.


### PR DESCRIPTION
> This is **PR 5 of 5** in a series adding GitHub issue, PR, and discussion templates to MeshCore.

**New files:**

**`.github/DISCUSSION_TEMPLATE/ideas.yml`**

**`.github/DISCUSSION_TEMPLATE/q-a.yml`**

**Updated file:**

**`.github/ISSUE_TEMPLATE/config.yml`** — Sets `blank_issues_enabled: false`