### PR TITLE
T114 variant fix to removed file system flush and BlurFruit LED activity

### DIFF
--- a/variants/heltec_t114/variant.h
+++ b/variants/heltec_t114/variant.h
@@ -77,7 +77,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin LEDs
 
-#define LED_BUILTIN             (35)
+// We set LED_BUILTIN to -1 to indicate the LED are not present.
+#define LED_BUILTIN             (-1)
 #define PIN_LED                 LED_BUILTIN
 #define LED_RED                 LED_BUILTIN
 #define LED_BLUE                (-1)            // No blue led, prevents Bluefruit flashing the green LED during advertising


### PR DESCRIPTION
T114 variant fix to removed file system flush and BlurFruit LED activity from the single onboard LED. 
This leaves only LORA TX LED, and reduces confusion of what the node is doing.