### PR TITLE
fix: JSON parsing regression in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,7 @@ get_pio_envs_ending_with_string() {
 # $1 should be the environment name
 get_platform_for_env() {
   local env_name=$1
-  echo "$PIO_CONFIG_JSON" | python3 -c "
+  printf '%s' "$PIO_CONFIG_JSON" | python3 -c "
 import sys, json, re
 data = json.load(sys.stdin)
 for section, options in data:


### PR DESCRIPTION
This PR fixes a build regression introduced in https://github.com/meshcore-dev/MeshCore/commit/5df139f3d634a9666e3b2d4d9fb40116ac3e0960 that was causing the error:

```
json.decoder.JSONDecodeError: Invalid control character at: line 1 column 157 (char 156)
```

Swapped `echo`, for `printf '%s'` because `printf` never interprets its argument for escape sequences.