### PR TITLE
 Refactor: Move buzzer sound handling to class members, tune sounds, 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "PlatformIO Build",
+			"type": "shell",
+			"command": "platformio",
+			"args": [
+				"run"
+			],
+			"isBackground": false,
+			"problemMatcher": [
+				"$platformio"
+			],
+			"group": "build"
+		}
+	]
+}

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -603,14 +603,14 @@ void UITask::notify(UIEventType t) {
 #if defined(PIN_BUZZER)
 switch(t){
   case UIEventType::contactMessage:
-    // gemini's pick
-    buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7");
+    // Play message sound using class member
+    buzzer.play(buzzer.message_song);
     break;
   case UIEventType::channelMessage:
-    buzzer.play("kerplop:d=16,o=6,b=120:32g#,32c#");
+    buzzer.play(buzzer.channel_song); // Play channel message sound
     break;
   case UIEventType::ack:
-    buzzer.play("ack:d=32,o=8,b=120:c");
+    buzzer.play(buzzer.ack_song); // Play ack sound
     break;
   case UIEventType::roomMessage:
   case UIEventType::newContactMessage:

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -93,14 +93,14 @@ void UITask::notify(UIEventType t) {
 #if defined(PIN_BUZZER)
 switch(t){
   case UIEventType::contactMessage:
-    // gemini's pick
-    buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7");
+    // Play message sound using class member
+    buzzer.play(buzzer.message_song);
     break;
   case UIEventType::channelMessage:
-    buzzer.play("kerplop:d=16,o=6,b=120:32g#,32c#");
+    buzzer.play(buzzer.channel_song); // Play channel message sound
     break;
   case UIEventType::ack:
-    buzzer.play("ack:d=32,o=8,b=120:c");
+    buzzer.play(buzzer.ack_song); // Play ack sound
     break;
   case UIEventType::roomMessage:
   case UIEventType::newContactMessage:

--- a/src/helpers/ui/buzzer.h
+++ b/src/helpers/ui/buzzer.h
@@ -28,6 +28,14 @@ class genericBuzzer
         void quiet(bool buzzer_state);  // enables or disables the buzzer
         bool isQuiet();  // get buzzer state on/off
 
+
+        // Example RTTTL melodies for startup/shutdown/message/discovery
+        const char *startup_song    = "Startup:d=4,o=5,b=160:16c6,16e6,8g6";
+        const char *shutdown_song   = "Shutdown:d=4,o=5,b=100:8g5,16e5,16c5";
+        const char *message_song    = "MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7";
+        const char *discovery_song  = "Discovery:d=4,o=5,b=180:8e6,8d6,8c6";
+        const char *channel_song    = "kerplop:d=16,o=6,b=120:32g#,16c#"; // more of a "plop" sound for channel change
+        const char *ack_song        = "ack:d=16,o=8,b=120:c8,c6"; // Two beeps: first high (C8), then low (C6)
     private:
         // gemini's picks:
         const char *startup_song = "Startup:d=4,o=5,b=160:16c6,16e6,8g6";

--- a/src/helpers/ui/buzzer.h
+++ b/src/helpers/ui/buzzer.h
@@ -5,14 +5,20 @@
 
 /* class abstracts underlying RTTTL library 
 
-    Just a simple imlementation to start.  At the moment use same
-    melody for message and discovery
-    Suggest enum type for different sounds
-    - on message
-    - on discovery
+
+
+    Just a simple implementation to start. Use RTTTL strings directly for different events.
+
+    Example usage:
+        genericBuzzer buzzer;
+        buzzer.begin();
+        buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7"); // Play message sound
+        buzzer.play("Discovery:d=4,o=5,b=180:8e6,8d6,8c6"); // Play discovery sound
+
+    You can configure the melodies by changing the RTTTL strings in your code.
 
     TODO
-    - make message ring tone configurable
+    - make message ring tone configurable at runtime
 
 */
 
@@ -20,14 +26,13 @@ class genericBuzzer
 {
     public:
         void begin();  // set up buzzer port
-        void play(const char *melody); // Generic play function
+        void play(const char *melody); // Play RTTTL melody
         void loop();  // loop driven-nonblocking
         void startup();  // play startup sound
         void shutdown();  // play shutdown sound
         bool isPlaying();  // returns true if a sound is still playing else false
         void quiet(bool buzzer_state);  // enables or disables the buzzer
         bool isQuiet();  // get buzzer state on/off
-
 
         // Example RTTTL melodies for startup/shutdown/message/discovery
         const char *startup_song    = "Startup:d=4,o=5,b=160:16c6,16e6,8g6";
@@ -36,10 +41,7 @@ class genericBuzzer
         const char *discovery_song  = "Discovery:d=4,o=5,b=180:8e6,8d6,8c6";
         const char *channel_song    = "kerplop:d=16,o=6,b=120:32g#,16c#"; // more of a "plop" sound for channel change
         const char *ack_song        = "ack:d=16,o=8,b=120:c8,c6"; // Two beeps: first high (C8), then low (C6)
-    private:
-        // gemini's picks:
-        const char *startup_song = "Startup:d=4,o=5,b=160:16c6,16e6,8g6";
-        const char *shutdown_song = "Shutdown:d=4,o=5,b=100:8g5,16e5,16c5";
 
+    private:
         bool _is_quiet = true;
 };


### PR DESCRIPTION
This PR introduces the following improvements:


- Refactored buzzer sound handling: all RTTTL melodies are now class members (startup_song, shutdown_song, message_song, discovery_song, channel_song, ack_song) in the buzzer class for better maintainability and reuse.
- Slightly tuned the channel and ack buzzer sounds for clearer and more consistent user feedback.
- Added a PlatformIO build task to [tasks.json](vscode-file://vscode-app/c:/Users/ahvan/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for convenient building directly from within VS Code.
- Replaced all hardcoded RTTTL strings in the codebase with these class members, allowing centralized management and easier future adjustments of buzzer sounds.

No changes to board configuration files are included in this PR. This refactor improves code clarity, maintainability, and user experience.