### PR TITLE
Increase the delay when powering up the T1000-E to avoid hangs on boot

### DIFF
--- a/variants/t1000-e/T1000eBoard.cpp
+++ b/variants/t1000-e/T1000eBoard.cpp
@@ -19,5 +19,5 @@ void T1000eBoard::begin() {
 
   Wire.begin();
 
-  delay(10);   // give sx1262 some time to power up
+  delay(150);  // give LR1110 some time to power up
 }


### PR DESCRIPTION
It seems that 10ms is too short to allow the LR1110 to power up and stabilize before we call `radio_init()`.
This increases the delay to 150ms which seems to work fine on my devices.

Fixes #1780 