### PR TITLE
Advertise repeat capability via FEAT1 flags

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1111,11 +1111,12 @@ void MyMesh::handleCmdFrame(size_t len) {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
     }
   } else if (cmd_frame[0] == CMD_SEND_SELF_ADVERT) {
+    uint16_t caps = _prefs.client_repeat ? ADVERT_CAP_REPEAT : 0;
     mesh::Packet* pkt;
     if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {
-      pkt = createSelfAdvert(_prefs.node_name);
+      pkt = createSelfAdvert(_prefs.node_name, caps);
     } else {
-      pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon);
+      pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon, caps);
     }
     if (pkt) {
       if (len >= 2 && cmd_frame[1] == 1) { // optional param (1 = flood, 0 = zero hop)
@@ -1193,11 +1194,12 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_EXPORT_CONTACT) {
     if (len < 1 + PUB_KEY_SIZE) {
       // export SELF
+      uint16_t caps = _prefs.client_repeat ? ADVERT_CAP_REPEAT : 0;
       mesh::Packet* pkt;
       if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {
-        pkt = createSelfAdvert(_prefs.node_name);
+        pkt = createSelfAdvert(_prefs.node_name, caps);
       } else {
-        pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon);
+        pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon, caps);
       }
       if (pkt) {
         pkt->header |= ROUTE_TYPE_FLOOD; // would normally be sent in this mode
@@ -2041,11 +2043,12 @@ void MyMesh::loop() {
 }
 
 bool MyMesh::advert() {
+  uint16_t caps = _prefs.client_repeat ? ADVERT_CAP_REPEAT : 0;
   mesh::Packet* pkt;
   if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {
-    pkt = createSelfAdvert(_prefs.node_name);
+    pkt = createSelfAdvert(_prefs.node_name, caps);
   } else {
-    pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon);
+    pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon, caps);
   }
   if (pkt) {
     sendZeroHop(pkt);

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -381,7 +381,8 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
 
 mesh::Packet *MyMesh::createSelfAdvert() {
   uint8_t app_data[MAX_ADVERT_DATA_SIZE];
-  uint8_t app_data_len = _cli.buildAdvertData(ADV_TYPE_REPEATER, app_data);
+  uint16_t caps = _prefs.disable_fwd ? 0 : ADVERT_CAP_REPEAT;
+  uint8_t app_data_len = _cli.buildAdvertData(ADV_TYPE_REPEATER, app_data, caps);
 
   return createAdvert(self_id, app_data, app_data_len);
 }

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -116,7 +116,8 @@ bool MyMesh::processAck(const uint8_t *data) {
 
 mesh::Packet *MyMesh::createSelfAdvert() {
   uint8_t app_data[MAX_ADVERT_DATA_SIZE];
-  uint8_t app_data_len = _cli.buildAdvertData(ADV_TYPE_ROOM, app_data);
+  uint16_t caps = _prefs.disable_fwd ? 0 : ADVERT_CAP_REPEAT;
+  uint8_t app_data_len = _cli.buildAdvertData(ADV_TYPE_ROOM, app_data, caps);
 
   return createAdvert(self_id, app_data, app_data_len);
 }

--- a/src/helpers/AdvertDataHelpers.h
+++ b/src/helpers/AdvertDataHelpers.h
@@ -12,9 +12,12 @@
 //FUTURE: 5..15
 
 #define ADV_LATLON_MASK       0x10
-#define ADV_FEAT1_MASK        0x20   // FUTURE
+#define ADV_FEAT1_MASK        0x20
 #define ADV_FEAT2_MASK        0x40   // FUTURE
 #define ADV_NAME_MASK         0x80
+
+// FEAT1 bits
+#define ADVERT_CAP_REPEAT     0x0001  // node forwards packets
 
 class AdvertDataBuilder {
   uint8_t _type;
@@ -26,7 +29,7 @@ class AdvertDataBuilder {
 public:
   AdvertDataBuilder(uint8_t adv_type) : _type(adv_type), _name(NULL), _has_loc(false) { }
   AdvertDataBuilder(uint8_t adv_type, const char* name) : _type(adv_type), _name(name), _has_loc(false) { }
-  AdvertDataBuilder(uint8_t adv_type, const char* name, double lat, double lon) : 
+  AdvertDataBuilder(uint8_t adv_type, const char* name, double lat, double lon) :
       _type(adv_type), _name(name), _has_loc(true), _lat(lat * 1E6), _lon(lon * 1E6)  { }
 
   void setFeat1(uint16_t extra) { _extra1 = extra; }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -16,22 +16,24 @@ void BaseChatMesh::sendFloodScoped(const mesh::GroupChannel& channel, mesh::Pack
   sendFlood(pkt, delay_millis);
 }
 
-mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name) {
+mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, uint16_t feat1) {
   uint8_t app_data[MAX_ADVERT_DATA_SIZE];
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name);
+    if (feat1) builder.setFeat1(feat1);
     app_data_len = builder.encodeTo(app_data);
   }
 
   return createAdvert(self_id, app_data, app_data_len);
 }
 
-mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, double lon) {
+mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, double lon, uint16_t feat1) {
   uint8_t app_data[MAX_ADVERT_DATA_SIZE];
   uint8_t app_data_len;
   {
     AdvertDataBuilder builder(ADV_TYPE_CHAT, name, lat, lon);
+    if (feat1) builder.setFeat1(feat1);
     app_data_len = builder.encodeTo(app_data);
   }
 

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -143,8 +143,8 @@ protected:
   void checkConnections();
 
 public:
-  mesh::Packet* createSelfAdvert(const char* name);
-  mesh::Packet* createSelfAdvert(const char* name, double lat, double lon);
+  mesh::Packet* createSelfAdvert(const char* name, uint16_t feat1 = 0);
+  mesh::Packet* createSelfAdvert(const char* name, double lat, double lon, uint16_t feat1 = 0);
   int  sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout);
   int  sendCommandData(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& est_timeout);
   bool sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len);

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -183,15 +183,18 @@ void CommonCLI::savePrefs() {
   _callbacks->savePrefs();
 }
 
-uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
+uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data, uint16_t feat1) {
   if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name);
+    if (feat1) builder.setFeat1(feat1);
     return builder.encodeTo(app_data);
   } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
+    if (feat1) builder.setFeat1(feat1);
     return builder.encodeTo(app_data);
   } else {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
+    if (feat1) builder.setFeat1(feat1);
     return builder.encodeTo(app_data);
   }
 }

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -110,5 +110,5 @@ public:
   void loadPrefs(FILESYSTEM* _fs);
   void savePrefs(FILESYSTEM* _fs);
   void handleCommand(uint32_t sender_timestamp, const char* command, char* reply);
-  uint8_t buildAdvertData(uint8_t node_type, uint8_t* app_data);
+  uint8_t buildAdvertData(uint8_t node_type, uint8_t* app_data, uint16_t feat1 = 0);
 };


### PR DESCRIPTION
## Summary

Implements [#1906](https://github.com/meshcore-dev/MeshCore/issues/1906) — nodes that forward packets but aren't dedicated repeaters (room servers with repeat enabled, companions with `client_repeat`) can now advertise this via a bitmask in the existing FEAT1 advert field.

This helps companion apps distinguish relay-capable nodes in path displays and resolves hash collisions where a room server was being confused with a repeater (as reported in #1866 and #1707).

### What changed

- **Added `ADVERT_CAP_REPEAT` (0x0001)** — first bit in the FEAT1 bitmask, meaning "this node forwards packets".
- **`buildAdvertData()`** and **`createSelfAdvert()`** gain an optional `feat1` parameter (default 0, no extra bytes on wire).
- **Room server** sets `ADVERT_CAP_REPEAT` when repeat is enabled (`!disable_fwd`).
- **Companion radio** sets `ADVERT_CAP_REPEAT` when `client_repeat` is on (3 call sites: manual advert, self-export, periodic advert).
- **Dedicated repeater** sets `ADVERT_CAP_REPEAT` for consistency, even though `ADV_TYPE_REPEATER` already implies it.

The generic FEAT1 naming is kept intentionally — the 16-bit field carries different kinds of information (capabilities, flags, properties) depending on context, so a neutral name fits better than something specific.

### Backwards compatibility

Fully backwards compatible in both directions:
- **Old clients** that see the `ADV_FEAT1_MASK` bit simply skip the 2-byte field (already wired up in the parser).
- **Old firmware** sends `feat1 = 0`, so the field is omitted from the wire — no extra bytes.

### Future FEAT1 bits

The uint16_t bitmask has 15 bits remaining. Some candidates:

| Bit | Idea | Rationale | Related |
|-----|------|-----------|---------|
| TBD | `ADVERT_FLAG_OPEN_ROOM` | Room server has no password (or uses default) — apps could show a lock/unlock icon without needing a round-trip and skip the login screen | PR #901 |
| TBD | `ADVERT_FLAG_READONLY` | Room server has `allow_read_only` enabled — apps could indicate guest access is available | |

These don't have concrete firmware/app consumers yet, so they're not included — just noted for future reference.

## Test plan

- [x] Builds cleanly against `heltec_v4_companion_radio_usb`
- [x] Builds cleanly against `heltec_v4_room_server`
- [x] Builds cleanly against `heltec_v4_repeater`
- [x] Builds cleanly against `heltec_v4_sensor` (unchanged, still passes `feat1 = 0` via default)
- [ ] Verify on-air: companion with `client_repeat` on → advert includes FEAT1 field with 0x0001
- [ ] Verify on-air: room server with repeat → advert includes FEAT1 field with 0x0001
- [ ] Verify old companion app still parses adverts correctly (skips unknown 2 bytes)