### PR TITLE
Gate path updates to unknown, better-hop, or stale routes

### DIFF
--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -63,6 +63,14 @@
 
 #define ALERT_ACK_EXPIRY_MILLIS         8000   // wait 8 secs for ACKs to alert messages
 
+#ifndef PATH_STALE_SECS
+  #define PATH_STALE_SECS 60
+#endif
+
+static inline uint8_t pathHopCount(uint8_t path_len) {
+  return path_len & 0x3F;  // lower 6 bits encode hash count
+}
+
 static File openAppend(FILESYSTEM* _fs, const char* fname) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
     return _fs->open(fname, FILE_O_WRITE);
@@ -665,15 +673,23 @@ bool SensorMesh::onPeerPathRecv(mesh::Packet* packet, int sender_idx, const uint
   ClientInfo* from = acl.getClientByIdx(i);
 
   MESH_DEBUG_PRINTLN("PATH to contact, path_len=%d", (uint32_t) path_len);
-  // NOTE: for this impl, we just replace the current 'out_path' regardless, whenever sender sends us a new out_path.
-  // FUTURE: could store multiple out_paths per contact, and try to find which is the 'best'(?)
-  from->out_path_len = mesh::Packet::copyPath(from->out_path, path, path_len);  // store a copy of path, for sendDirect()
-  from->last_activity = getRTCClock()->getCurrentTime();
+  uint32_t now = getRTCClock()->getCurrentTime();
+  bool has_no_path = (from->out_path_len == OUT_PATH_UNKNOWN);
+  bool better_hops = !has_no_path && (pathHopCount(path_len) < pathHopCount(from->out_path_len));
+  bool stale = !has_no_path && (now > from->last_activity + PATH_STALE_SECS);
+  bool accept = has_no_path || better_hops || stale;
 
-  // REVISIT: maybe make ALL out_paths non-persisted to minimise flash writes??
-  if (from->isAdmin()) {
-    // only do saveContacts() (of this out_path change) if this is an admin
-    dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
+  if (accept) {
+    from->out_path_len = mesh::Packet::copyPath(from->out_path, path, path_len);  // store a copy of path, for sendDirect()
+    from->last_activity = now;
+
+    // REVISIT: maybe make ALL out_paths non-persisted to minimise flash writes??
+    if (from->isAdmin()) {
+      // only do saveContacts() (of this out_path change) if this is an admin
+      dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
+    }
+  } else {
+    MESH_DEBUG_PRINTLN("onPeerPathRecv: ignoring non-improving path update");
   }
 
   // NOTE: no reciprocal path send!!

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -9,6 +9,14 @@
   #define TXT_ACK_DELAY     200
 #endif
 
+#ifndef PATH_STALE_SECS
+  #define PATH_STALE_SECS 60
+#endif
+
+static inline uint8_t pathHopCount(uint8_t path_len) {
+  return path_len & 0x3F;  // lower 6 bits encode hash count
+}
+
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   sendFlood(pkt, delay_millis);
 }
@@ -302,12 +310,22 @@ bool BaseChatMesh::onPeerPathRecv(mesh::Packet* packet, int sender_idx, const ui
 }
 
 bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_t in_path_len, uint8_t* out_path, uint8_t out_path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) {
-  // NOTE: default impl, we just replace the current 'out_path' regardless, whenever sender sends us a new out_path.
-  // FUTURE: could store multiple out_paths per contact, and try to find which is the 'best'(?)
-  from.out_path_len = mesh::Packet::copyPath(from.out_path, out_path, out_path_len);  // store a copy of path, for sendDirect()
-  from.lastmod = getRTCClock()->getCurrentTime();
+  uint32_t now = getRTCClock()->getCurrentTime();
+  bool has_no_path = (from.out_path_len == OUT_PATH_UNKNOWN);
+  bool better_hops = !has_no_path && (pathHopCount(out_path_len) < pathHopCount(from.out_path_len));
+  bool stale = !has_no_path && (now > from.lastmod + PATH_STALE_SECS);
+  bool accept = has_no_path || better_hops || stale;
 
-  onContactPathUpdated(from);
+  if (accept) {
+    // Accept unknown, better-hop, or stale replacement paths.
+    from.out_path_len = mesh::Packet::copyPath(from.out_path, out_path, out_path_len);
+    from.lastmod = now;
+    onContactPathUpdated(from);
+  } else {
+    MESH_DEBUG_PRINTLN("onContactPathRecv: keeping existing path (curr_hops=%u new_hops=%u)",
+                        (uint32_t)pathHopCount(from.out_path_len),
+                        (uint32_t)pathHopCount(out_path_len));
+  }
 
   if (extra_type == PAYLOAD_TYPE_ACK && extra_len >= 4) {
     // also got an encoded ACK!


### PR DESCRIPTION
## Summary
This change replaces unconditional contact path overwrites with a simple acceptance gate so routing state is more stable under noisy/frequent path updates.

## Problem
Current path handling effectively behaves like "last received path wins" for contact/client `out_path`.
That can cause route churn when equal-or-worse paths arrive after a good path.

## What Changed
- Added `PATH_STALE_SECS` (default `60`) in:
  - `src/helpers/BaseChatMesh.cpp`
  - `examples/simple_sensor/SensorMesh.cpp`
- Added a small helper:
  - `pathHopCount(path_len)` using lower 6 bits of `path_len`.
- Updated path update logic to accept a new path only when:
  - existing path is unknown, or
  - new path has fewer hops, or
  - existing path is stale.
- Added debug logs for rejected non-improving path updates.
- Left existing ACK/response extra payload behavior unchanged.

## Behavior Impact
- Reduces path flapping.
- Preserves fast adoption of clearly better paths.
- Allows recovery from stale routes without introducing multi-path complexity.