### PR TITLE
Add SNR-driven dynamic coding rate selection for repeater retransmits

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -258,6 +258,10 @@ float MyMesh::getAirtimeBudgetFactor() const {
   return _prefs.airtime_factor;
 }
 
+uint32_t MyMesh::estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr) const {
+  return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+}
+
 int MyMesh::getInterferenceThreshold() const {
   return 0; // disabled for now, until currentRSSI() problem is resolved
 }
@@ -271,12 +275,12 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * 0.5f);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * 0.5f);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * 0.2f);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * 0.2f);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 uint8_t MyMesh::getExtraAckTransmitCount() const {
@@ -972,6 +976,7 @@ void MyMesh::begin(bool has_display) {
   _store->loadChannels(this);
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   MESH_DEBUG_PRINTLN("RX Boosted Gain Mode: %s",
@@ -1399,6 +1404,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       savePrefs();
 
       radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+      setDefaultCR(_prefs.cr);
       MESH_DEBUG_PRINTLN("OK: CMD_SET_RADIO_PARAMS: f=%d, bw=%d, sf=%d, cr=%d", freq, bw, (uint32_t)sf,
                          (uint32_t)cr);
 
@@ -1769,10 +1775,13 @@ void MyMesh::handleCmdFrame(size_t len) {
       memcpy(&auth, &cmd_frame[5], 4);
       auto pkt = createTrace(tag, auth, flags);
       if (pkt) {
+        if ((path_len >> path_sz) > 0) {
+          pkt->_tx_cr = selectCodingRateForPeer(&cmd_frame[10], 1 << path_sz);
+        }
         sendDirect(pkt, &cmd_frame[10], path_len);
 
-        uint32_t t = _radio->getEstAirtimeFor(pkt->payload_len + pkt->path_len + 2);
-        uint32_t est_timeout = calcDirectTimeoutMillisFor(t, path_len >> path_sz);
+        uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->payload_len + pkt->path_len + 2, pkt->_tx_cr);
+        uint32_t est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, path_len >> path_sz);
 
         out_frame[0] = RESP_CODE_SENT;
         out_frame[1] = 0;

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -264,6 +264,10 @@ float MyMesh::getAirtimeBudgetFactor() const {
   return _prefs.airtime_factor;
 }
 
+uint32_t MyMesh::estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr) const {
+  return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+}
+
 int MyMesh::getInterferenceThreshold() const {
   return _prefs.interference_threshold;
 }
@@ -277,12 +281,12 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 uint8_t MyMesh::getExtraAckTransmitCount() const {
@@ -1045,6 +1049,7 @@ void MyMesh::begin(bool has_display) {
   _store->loadChannels(this);
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
 
@@ -1489,6 +1494,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       savePrefs();
 
       radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+      setDefaultCR(_prefs.cr);
       MESH_DEBUG_PRINTLN("OK: CMD_SET_RADIO_PARAMS: f=%d, bw=%d, sf=%d, cr=%d", freq, bw, (uint32_t)sf,
                          (uint32_t)cr);
 
@@ -1863,10 +1869,13 @@ void MyMesh::handleCmdFrame(size_t len) {
       memcpy(&auth, &cmd_frame[5], 4);
       auto pkt = createTrace(tag, auth, flags);
       if (pkt) {
+        if ((path_len >> path_sz) > 0) {
+          pkt->_tx_cr = selectCodingRateForPeer(&cmd_frame[10], 1 << path_sz);
+        }
         sendDirect(pkt, &cmd_frame[10], path_len);
 
-        uint32_t t = _radio->getEstAirtimeFor(pkt->payload_len + pkt->path_len + 2);
-        uint32_t est_timeout = calcDirectTimeoutMillisFor(t, path_len >> path_sz);
+        uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->payload_len + pkt->path_len + 2, pkt->_tx_cr);
+        uint32_t est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, path_len >> path_sz);
 
         out_frame[0] = RESP_CODE_SENT;
         out_frame[1] = 0;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -104,6 +104,7 @@ public:
 
 protected:
   float getAirtimeBudgetFactor() const override;
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override;
   int getInterferenceThreshold() const override;
   bool getCADEnabled() const override;
   int calcRxDelay(float score, uint32_t air_time) const override;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -119,6 +119,7 @@ public:
 
 protected:
   float getAirtimeBudgetFactor() const override;
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override;
   int getInterferenceThreshold() const override;
   bool getCADEnabled() const override;
   int getAGCResetInterval() const override {

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -100,7 +100,7 @@ int8_t MyMesh::findNeighbourSNR(const uint8_t* hash, uint8_t hash_size) {
 }
 
 // Approximate SNR demod floor per SF (same as RadioLibWrappers.cpp)
-static float cr_snr_thresholds[] = {
+static const float cr_snr_thresholds[] = {
   -7.5f,  // SF7
   -10.0f, // SF8
   -12.5f, // SF9

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1,5 +1,6 @@
 #include "MyMesh.h"
 #include <algorithm>
+#include <climits>
 
 /* ------------------------------ Config -------------------------------- */
 
@@ -85,6 +86,42 @@ void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float sn
   neighbour->heard_timestamp = getRTCClock()->getCurrentTime();
   neighbour->snr = (int8_t)(snr * 4);
 #endif
+}
+
+int8_t MyMesh::findNeighbourSNR(const uint8_t* hash, uint8_t hash_size) {
+#if MAX_NEIGHBOURS
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    if (neighbours[i].heard_timestamp != 0 && neighbours[i].id.isHashMatch(hash, hash_size)) {
+      return neighbours[i].snr;
+    }
+  }
+#endif
+  return INT8_MAX;
+}
+
+// Approximate SNR demod floor per SF (same as RadioLibWrappers.cpp)
+static float cr_snr_thresholds[] = {
+  -7.5f,  // SF7
+  -10.0f, // SF8
+  -12.5f, // SF9
+  -15.0f, // SF10
+  -17.5f, // SF11
+  -20.0f  // SF12
+};
+
+uint8_t MyMesh::selectCodingRateForPeer(const uint8_t* hash, uint8_t hash_size) {
+  int8_t snr4 = findNeighbourSNR(hash, hash_size);
+  if (snr4 == INT8_MAX) return 0;  // unknown neighbor, use default
+
+  float snr = snr4 / 4.0f;
+  float threshold = (_prefs.sf >= 7 && _prefs.sf <= 12)
+    ? cr_snr_thresholds[_prefs.sf - 7] : -15.0f;
+  float margin = snr - threshold;
+
+  if (margin < 3.0f)  return 8;
+  if (margin < 6.0f)  return 7;
+  if (margin < 10.0f) return 6;
+  return 5;  // good margin, use lightest CR
 }
 
 uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood) {
@@ -957,6 +994,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
+  setDefaultCR(_prefs.cr);
 
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   MESH_DEBUG_PRINTLN("RX Boosted Gain Mode: %s",

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -575,12 +575,12 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 mesh::DispatcherAction MyMesh::onRecvPacket(mesh::Packet* pkt) {
@@ -1325,12 +1325,14 @@ void MyMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) { // apply pending (temporary) radio params
     set_radio_at = 0;                                     // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) { // revert radio params to orig
     revert_radio_at = 0;                                        // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -582,12 +582,12 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 mesh::DispatcherAction MyMesh::onRecvPacket(mesh::Packet* pkt) {
@@ -1347,12 +1347,14 @@ void MyMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) { // apply pending (temporary) radio params
     set_radio_at = 0;                                     // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) { // revert radio params to orig
     revert_radio_at = 0;                                        // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1,5 +1,6 @@
 #include "MyMesh.h"
 #include <algorithm>
+#include <climits>
 
 /* ------------------------------ Config -------------------------------- */
 
@@ -85,6 +86,42 @@ void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float sn
   neighbour->heard_timestamp = getRTCClock()->getCurrentTime();
   neighbour->snr = (int8_t)(snr * 4);
 #endif
+}
+
+int8_t MyMesh::findNeighbourSNR(const uint8_t* hash, uint8_t hash_size) {
+#if MAX_NEIGHBOURS
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    if (neighbours[i].heard_timestamp != 0 && neighbours[i].id.isHashMatch(hash, hash_size)) {
+      return neighbours[i].snr;
+    }
+  }
+#endif
+  return INT8_MAX;
+}
+
+// Approximate SNR demod floor per SF (same as RadioLibWrappers.cpp)
+static float cr_snr_thresholds[] = {
+  -7.5f,  // SF7
+  -10.0f, // SF8
+  -12.5f, // SF9
+  -15.0f, // SF10
+  -17.5f, // SF11
+  -20.0f  // SF12
+};
+
+uint8_t MyMesh::selectCodingRateForPeer(const uint8_t* hash, uint8_t hash_size) {
+  int8_t snr4 = findNeighbourSNR(hash, hash_size);
+  if (snr4 == INT8_MAX) return 0;  // unknown neighbor, use default
+
+  float snr = snr4 / 4.0f;
+  float threshold = (_prefs.sf >= 7 && _prefs.sf <= 12)
+    ? cr_snr_thresholds[_prefs.sf - 7] : -15.0f;
+  float margin = snr - threshold;
+
+  if (margin < 3.0f)  return 8;
+  if (margin < 6.0f)  return 7;
+  if (margin < 10.0f) return 6;
+  return 5;  // good margin, use lightest CR
 }
 
 uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood) {
@@ -978,6 +1015,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
+  setDefaultCR(_prefs.cr);
 
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   MESH_DEBUG_PRINTLN("RX Boosted Gain Mode: %s",

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -120,6 +120,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #endif
 
   void putNeighbour(const mesh::Identity& id, uint32_t timestamp, float snr);
+  int8_t findNeighbourSNR(const uint8_t* hash, uint8_t hash_size);
   uint8_t handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood);
   uint8_t handleAnonRegionsReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
   uint8_t handleAnonOwnerReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
@@ -159,6 +160,7 @@ protected:
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;
   }
+  uint8_t selectCodingRateForPeer(const uint8_t* hash, uint8_t hash_size) override;
 
 #if ENV_INCLUDE_GPS == 1
   void applyGpsPrefs() {

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -135,6 +135,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+  }
 
   bool allowPacketForward(const mesh::Packet* packet) override;
   const char* getLogDateTime() override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -117,6 +117,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #endif
 
   void putNeighbour(const mesh::Identity& id, uint32_t timestamp, float snr);
+  int8_t findNeighbourSNR(const uint8_t* hash, uint8_t hash_size);
   uint8_t handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood);
   uint8_t handleAnonRegionsReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
   uint8_t handleAnonOwnerReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
@@ -156,6 +157,7 @@ protected:
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;
   }
+  uint8_t selectCodingRateForPeer(const uint8_t* hash, uint8_t hash_size) override;
 
 #if ENV_INCLUDE_GPS == 1
   void applyGpsPrefs() {

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -132,6 +132,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+  }
 
   bool allowPacketForward(const mesh::Packet* packet) override;
   const char* getLogDateTime() override;

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -289,12 +289,12 @@ const char *MyMesh::getLogDateTime() {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
@@ -723,6 +723,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   }
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain);
@@ -1046,12 +1047,14 @@ void MyMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) { // apply pending (temporary) radio params
     set_radio_at = 0;                                     // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) { // revert radio params to orig
     revert_radio_at = 0;                                        // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -289,12 +289,12 @@ const char *MyMesh::getLogDateTime() {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 5 * tx_airtime_ms + 1);
 }
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
@@ -723,6 +723,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   }
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
 
@@ -1055,12 +1056,14 @@ void MyMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) { // apply pending (temporary) radio params
     set_radio_at = 0;                                     // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) { // revert radio params to orig
     revert_radio_at = 0;                                        // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -132,6 +132,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+  }
 
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
   void logRx(mesh::Packet* pkt, int len, float score) override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -131,6 +131,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+  }
 
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
   void logRx(mesh::Packet* pkt, int len, float score) override;

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -193,6 +193,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, LORA_SF, LORA_BW, tx_cr != 0 ? tx_cr : LORA_CR);
+  }
 
   int calcRxDelay(float score, uint32_t air_time) const override {
     return 0;  // disable rxdelay
@@ -582,6 +585,7 @@ void setup() {
 #endif
 
   radio_driver.setParams(the_mesh.getFreqPref(), LORA_BW, LORA_SF, LORA_CR);
+  the_mesh.setDefaultCR(LORA_CR);
   radio_driver.setTxPower(the_mesh.getTxPowerPref());
 
   the_mesh.showWelcome();

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -193,6 +193,9 @@ protected:
   float getAirtimeBudgetFactor() const override {
     return _prefs.airtime_factor;
   }
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, LORA_SF, LORA_BW, tx_cr != 0 ? tx_cr : LORA_CR);
+  }
 
   int calcRxDelay(float score, uint32_t air_time) const override {
     return 0;  // disable rxdelay
@@ -586,6 +589,7 @@ void setup() {
 #endif
 
   radio_driver.setParams(the_mesh.getFreqPref(), LORA_BW, LORA_SF, LORA_CR);
+  the_mesh.setDefaultCR(LORA_CR);
   radio_driver.setTxPower(the_mesh.getTxPowerPref());
 
   the_mesh.showWelcome();

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -313,12 +313,12 @@ int SensorMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t SensorMesh::getRetransmitDelay(const mesh::Packet* packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 6)*t;
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 6) * tx_airtime_ms;
 }
 uint32_t SensorMesh::getDirectRetransmitDelay(const mesh::Packet* packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 6)*t;
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 6) * tx_airtime_ms;
 }
 int SensorMesh::getInterferenceThreshold() const {
   return _prefs.interference_threshold;
@@ -769,6 +769,7 @@ void SensorMesh::begin(FILESYSTEM* fs) {
   }
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
   board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain);
 
@@ -914,12 +915,14 @@ void SensorMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) {   // apply pending (temporary) radio params
     set_radio_at = 0;  // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) {   // revert radio params to orig
     revert_radio_at = 0;  // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -313,12 +313,12 @@ int SensorMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t SensorMesh::getRetransmitDelay(const mesh::Packet* packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 6)*t;
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.tx_delay_factor);
+  return getRNG()->nextInt(0, 6) * tx_airtime_ms;
 }
 uint32_t SensorMesh::getDirectRetransmitDelay(const mesh::Packet* packet) {
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 6)*t;
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2, packet->_tx_cr) * _prefs.direct_tx_delay_factor);
+  return getRNG()->nextInt(0, 6) * tx_airtime_ms;
 }
 int SensorMesh::getInterferenceThreshold() const {
   return _prefs.interference_threshold;
@@ -770,6 +770,7 @@ void SensorMesh::begin(FILESYSTEM* fs) {
   }
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+  setDefaultCR(_prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
 
   board.attachDynamicPrefs(_prefs.getCustom());
@@ -916,12 +917,14 @@ void SensorMesh::loop() {
   if (set_radio_at && millisHasNowPassed(set_radio_at)) {   // apply pending (temporary) radio params
     set_radio_at = 0;  // clear timer
     radio_driver.setParams(pending_freq, pending_bw, pending_sf, pending_cr);
+    setDefaultCR(pending_cr);
     MESH_DEBUG_PRINTLN("Temp radio params");
   }
 
   if (revert_radio_at && millisHasNowPassed(revert_radio_at)) {   // revert radio params to orig
     revert_radio_at = 0;  // clear timer
     radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
+    setDefaultCR(_prefs.cr);
     MESH_DEBUG_PRINTLN("Radio params restored");
   }
 

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -115,6 +115,9 @@ protected:
 
   // Mesh overrides
   float getAirtimeBudgetFactor() const override;
+  uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const override {
+    return estimateLoRaAirtimeFor(len_bytes, _prefs.sf, _prefs.bw, tx_cr != 0 ? tx_cr : _prefs.cr);
+  }
   bool allowPacketForward(const mesh::Packet* packet) override;
   int calcRxDelay(float score, uint32_t air_time) const override;
   uint32_t getRetransmitDelay(const mesh::Packet* packet) override;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -210,6 +210,7 @@ void Dispatcher::checkRecv() {
       } else {
         if (tryParsePacket(pkt, raw, len)) {
           pkt->_snr = _radio->getLastSNR() * 4.0f;
+          pkt->_tx_cr = 0;   // pool slots are reused without zeroing; clear stale CR override so flood/non-direct retransmits use the default CR
           score = _radio->packetScore(_radio->getLastSNR(), len);
           air_time = _radio->getEstAirtimeFor(len);
           rx_air_time += air_time;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -74,7 +74,10 @@ uint32_t Dispatcher::estimateLoRaAirtimeFor(int len_bytes, uint8_t sf, float bw_
   float low_data_rate_optimize = ldro_enabled ? 1.0f : 0.0f;
   float implicit_header = 0.0f;
   float crc_enabled = 1.0f;
-  float preamble_symbols = 16.0f;
+  // Preamble length is SF-dependent (RadioLibWrapper::preambleLengthForSF): 32 symbols for
+  // SF<=8, else 16. Hardcoding 16 under-counts airtime by 16 symbols on SF7/SF8 (the default
+  // is SF8), which would skew retransmit delays and the TX-expiry watchdog.
+  float preamble_symbols = (sf <= 8) ? 32.0f : 16.0f;
   float payload_symbols = 8.0f + fmaxf(ceilf((8.0f * (float)len_bytes - 4.0f * (float)sf + 28.0f + 16.0f * crc_enabled - 20.0f * implicit_header) /
                                              (4.0f * (float)sf - 8.0f * low_data_rate_optimize)) * (float)cr, 0.0f);
   float total_symbols = preamble_symbols + payload_symbols + 4.25f;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -106,6 +106,9 @@ void Dispatcher::loop() {
       }
 
       _radio->onSendFinished();
+      if (outbound->_tx_cr != 0 && outbound->_tx_cr != _default_cr) {
+        _radio->setCodingRate(_default_cr);
+      }
       logTx(outbound, 2 + outbound->getPathByteLen() + outbound->payload_len);
       if (outbound->isRouteFlood()) {
         n_sent_flood++;
@@ -118,6 +121,9 @@ void Dispatcher::loop() {
       MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): WARNING: outbound packed send timed out!", getLogDateTime());
 
       _radio->onSendFinished();
+      if (outbound->_tx_cr != 0 && outbound->_tx_cr != _default_cr) {
+        _radio->setCodingRate(_default_cr);
+      }
       logTxFail(outbound, 2 + outbound->getPathByteLen() + outbound->payload_len);
 
       releasePacket(outbound);  // return to pool
@@ -324,14 +330,21 @@ void Dispatcher::checkSend() {
     } else {
       memcpy(&raw[len], outbound->payload, outbound->payload_len); len += outbound->payload_len;
 
+      if (outbound->_tx_cr != 0 && outbound->_tx_cr != _default_cr) {
+        _radio->setCodingRate(outbound->_tx_cr);
+      }
+
       uint32_t max_airtime = _radio->getEstAirtimeFor(len)*3/2;
       outbound_start = _ms->getMillis();
       bool success = _radio->startSendRaw(raw, len);
       if (!success) {
         MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): ERROR: send start failed!", getLogDateTime());
+        if (outbound->_tx_cr != 0 && outbound->_tx_cr != _default_cr) {
+          _radio->setCodingRate(_default_cr);
+        }
 
         logTxFail(outbound, outbound->getRawLength());
-  
+
         releasePacket(outbound);  // return to pool
         outbound = NULL;
         return;
@@ -360,6 +373,7 @@ Packet* Dispatcher::obtainNewPacket() {
   } else {
     pkt->payload_len = pkt->path_len = 0;
     pkt->_snr = 0;
+    pkt->_tx_cr = 0;
   }
   return pkt;
 }

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -63,6 +63,25 @@ uint32_t Dispatcher::getCADFailMaxDuration() const {
   return 4000;   // 4 seconds
 }
 
+uint32_t Dispatcher::estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr) const {
+  (void)tx_cr;
+  return _radio->getEstAirtimeFor(len_bytes);
+}
+
+// Matches the standard LoRa time-on-air equation for the configured modem settings.
+uint32_t Dispatcher::estimateLoRaAirtimeFor(int len_bytes, uint8_t sf, float bw_khz, uint8_t cr) const {
+  bool ldro_enabled = (((float)(1UL << sf)) / bw_khz) > 16.0f;
+  float low_data_rate_optimize = ldro_enabled ? 1.0f : 0.0f;
+  float implicit_header = 0.0f;
+  float crc_enabled = 1.0f;
+  float preamble_symbols = 16.0f;
+  float payload_symbols = 8.0f + fmaxf(ceilf((8.0f * (float)len_bytes - 4.0f * (float)sf + 28.0f + 16.0f * crc_enabled - 20.0f * implicit_header) /
+                                             (4.0f * (float)sf - 8.0f * low_data_rate_optimize)) * (float)cr, 0.0f);
+  float total_symbols = preamble_symbols + payload_symbols + 4.25f;
+  float symbol_length_ms = ((float)(uint32_t(1) << sf) / bw_khz);
+  return (uint32_t)ceilf(symbol_length_ms * total_symbols);
+}
+
 void Dispatcher::loop() {
   if (millisHasNowPassed(next_floor_calib_time)) {
     _radio->triggerNoiseFloorCalibrate(getInterferenceThreshold());
@@ -334,8 +353,7 @@ void Dispatcher::checkSend() {
       if (outbound->_tx_cr != 0 && outbound->_tx_cr != _default_cr) {
         _radio->setCodingRate(outbound->_tx_cr);
       }
-
-      uint32_t max_airtime = _radio->getEstAirtimeFor(len)*3/2;
+      uint32_t max_airtime = estimateTxAirtimeFor(len, outbound->_tx_cr) * 3 / 2;
       outbound_start = _ms->getMillis();
       bool success = _radio->startSendRaw(raw, len);
       if (!success) {

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -176,6 +176,10 @@ protected:
   virtual bool getCADEnabled() const { return false; }    // hardware CAD disabled by default
   virtual int getAGCResetInterval() const { return 0; }    // disabled by default
   virtual unsigned long getDutyCycleWindowMs() const { return 3600000; }
+  // Estimates TX airtime using an explicit per-packet CR override when present.
+  virtual uint32_t estimateTxAirtimeFor(int len_bytes, uint8_t tx_cr=0) const;
+  // LoRa airtime helper for meshes that know the active SF/BW/CR settings directly.
+  uint32_t estimateLoRaAirtimeFor(int len_bytes, uint8_t sf, float bw_khz, uint8_t cr) const;
 
 public:
   void begin();

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -76,6 +76,8 @@ public:
   */
   virtual bool isReceiving() { return false; }
 
+  virtual void setCodingRate(uint8_t cr) { }
+
   virtual float getLastRSSI() const { return 0; }
   virtual float getLastSNR() const { return 0; }
 };
@@ -138,6 +140,8 @@ protected:
   MillisecondClock* _ms;
   uint16_t _err_flags;
 
+  uint8_t _default_cr;
+
   Dispatcher(Radio& radio, MillisecondClock& ms, PacketManager& mgr)
     : _radio(&radio), _ms(&ms), _mgr(&mgr)
   {
@@ -152,6 +156,7 @@ protected:
     tx_budget_ms = 0;
     last_budget_update = 0;
     duty_cycle_window_ms = 3600000;
+    _default_cr = 5;
   }
 
   virtual DispatcherAction onRecvPacket(Packet* pkt) = 0;
@@ -187,6 +192,8 @@ public:
   uint32_t getNumSentDirect() const { return n_sent_direct; }
   uint32_t getNumRecvFlood() const { return n_recv_flood; }
   uint32_t getNumRecvDirect() const { return n_recv_direct; }
+  void setDefaultCR(uint8_t cr) { _default_cr = cr; }
+
   void resetStats() {
     n_sent_flood = n_sent_direct = n_recv_flood = n_recv_direct = 0;
     _err_flags = 0;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -101,9 +101,10 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       if (!_tables->wasSeen(pkt)) {
         _tables->markSeen(pkt);
         removeSelfFromPath(pkt);
+        pkt->_tx_cr = selectCodingRateForPeer(pkt->path, pkt->getPathHashSize());
 
         uint32_t d = getDirectRetransmitDelay(pkt);
-        return ACTION_RETRANSMIT_DELAYED(0, d);  // Routed traffic is HIGHEST priority 
+        return ACTION_RETRANSMIT_DELAYED(0, d);  // Routed traffic is HIGHEST priority
       }
     }
     return ACTION_RELEASE;   // this node is NOT the next hop (OR this packet has already been forwarded), so discard.

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -15,9 +15,9 @@ bool Mesh::allowPacketForward(const mesh::Packet* packet) {
   return false;  // by default, Transport NOT enabled
 }
 uint32_t Mesh::getRetransmitDelay(const mesh::Packet* packet) { 
-  uint32_t t = (_radio->getEstAirtimeFor(packet->getRawLength()) * 52 / 50) / 2;
+  uint32_t tx_airtime_ms = (estimateTxAirtimeFor(packet->getRawLength(), packet->_tx_cr) * 52 / 50) / 2;
 
-  return _rng->nextInt(0, 5)*t;
+  return _rng->nextInt(0, 5) * tx_airtime_ms;
 }
 uint32_t Mesh::getDirectRetransmitDelay(const Packet* packet) {
   return 0;  // by default, no delay
@@ -705,6 +705,9 @@ void Mesh::sendDirect(Packet* packet, const uint8_t* path, uint8_t path_len, uin
     pri = 5;   // maybe make this configurable
   } else {
     packet->path_len = Packet::copyPath(packet->path, path, path_len);
+    if (packet->_tx_cr == 0 && packet->getPathHashCount() > 0) {
+      packet->_tx_cr = selectCodingRateForPeer(packet->path, packet->getPathHashSize());
+    }
     if (packet->getPayloadType() == PAYLOAD_TYPE_PATH) {
       pri = 1;   // slightly less priority
     } else {

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -72,6 +72,14 @@ protected:
   virtual uint8_t getExtraAckTransmitCount() const;
 
   /**
+   * \brief  Select a coding rate for the next-hop peer based on link quality.
+   * \param  hash       the hash of the next-hop peer (from path[0..hash_size-1])
+   * \param  hash_size  bytes per hash entry
+   * \returns  0 = use node default CR, 5-8 = override CR for this packet
+   */
+  virtual uint8_t selectCodingRateForPeer(const uint8_t* hash, uint8_t hash_size) { return 0; }
+
+  /**
    * \brief  Perform search of local DB of peers/contacts.
    * \returns  Number of peers with matching hash
    */

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -8,6 +8,8 @@ Packet::Packet() {
   header = 0;
   path_len = 0;
   payload_len = 0;
+  _snr = 0;
+  _tx_cr = 0;
 }
 
 bool Packet::isValidPathLen(uint8_t path_len) {

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -49,6 +49,7 @@ public:
   uint8_t path[MAX_PATH_SIZE];
   uint8_t payload[MAX_PACKET_PAYLOAD];
   int8_t _snr;
+  uint8_t _tx_cr;   // 0 = use node default, 5-8 = override CR for this TX (not serialized to wire)
 
   /**
    * \brief calculate the hash of payload + type

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -443,16 +443,18 @@ int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp,
   mesh::Packet* pkt = composeMsgPacket(recipient, timestamp, attempt, text, expected_ack);
   if (pkt == NULL) return MSG_SEND_FAILED;
 
-  uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
-
   int rc;
   if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendFloodScoped(recipient, pkt);
-    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(t));
+    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms));
     rc = MSG_SEND_SENT_FLOOD;
   } else {
+    pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+    // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len));
+    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len));
     rc = MSG_SEND_SENT_DIRECT;
   }
   return rc;
@@ -470,15 +472,18 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len);
   if (pkt == NULL) return MSG_SEND_FAILED;
 
-  uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
   int rc;
   if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendFloodScoped(recipient, pkt);
-    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(t));
+    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms));
     rc = MSG_SEND_SENT_FLOOD;
   } else {
+    pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+    // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len));
+    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len));
     rc = MSG_SEND_SENT_DIRECT;
   }
   return rc;
@@ -590,14 +595,17 @@ int BaseChatMesh::sendLogin(const ContactInfo& recipient, const char* password, 
     pkt = createAnonDatagram(PAYLOAD_TYPE_ANON_REQ, self_id, recipient.id, recipient.getSharedSecret(self_id), temp, tlen);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -615,14 +623,17 @@ int BaseChatMesh::sendAnonReq(const ContactInfo& recipient, const uint8_t* data,
     pkt = createAnonDatagram(PAYLOAD_TYPE_ANON_REQ, self_id, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + len);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -642,14 +653,17 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -669,14 +683,17 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp));
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -474,16 +474,18 @@ int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp,
   mesh::Packet* pkt = composeMsgPacket(recipient, timestamp, attempt, text, expected_ack);
   if (pkt == NULL) return MSG_SEND_FAILED;
 
-  uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
-
   int rc;
   if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendFloodScoped(recipient, pkt);
-    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(t));
+    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms));
     rc = MSG_SEND_SENT_FLOOD;
   } else {
+    pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+    // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len));
+    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len));
     rc = MSG_SEND_SENT_DIRECT;
   }
   return rc;
@@ -501,15 +503,18 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   auto pkt = createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, 5 + text_len);
   if (pkt == NULL) return MSG_SEND_FAILED;
 
-  uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
   int rc;
   if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendFloodScoped(recipient, pkt);
-    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(t));
+    txt_send_timeout = futureMillis(est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms));
     rc = MSG_SEND_SENT_FLOOD;
   } else {
+    pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+    // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+    uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
     sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len));
+    txt_send_timeout = futureMillis(est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len));
     rc = MSG_SEND_SENT_DIRECT;
   }
   return rc;
@@ -621,14 +626,17 @@ int BaseChatMesh::sendLogin(const ContactInfo& recipient, const char* password, 
     pkt = createAnonDatagram(PAYLOAD_TYPE_ANON_REQ, self_id, recipient.id, recipient.getSharedSecret(self_id), temp, tlen);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -646,14 +654,17 @@ int BaseChatMesh::sendAnonReq(const ContactInfo& recipient, const uint8_t* data,
     pkt = createAnonDatagram(PAYLOAD_TYPE_ANON_REQ, self_id, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + len);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -673,14 +684,17 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, const uint8_t* req_
     pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, 4 + data_len);
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }
@@ -700,14 +714,17 @@ int  BaseChatMesh::sendRequest(const ContactInfo& recipient, uint8_t req_type, u
     pkt = createDatagram(PAYLOAD_TYPE_REQ, recipient.id, recipient.getSharedSecret(self_id), temp, sizeof(temp));
   }
   if (pkt) {
-    uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len == OUT_PATH_UNKNOWN) {
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendFloodScoped(recipient, pkt);
-      est_timeout = calcFloodTimeoutMillisFor(t);
+      est_timeout = calcFloodTimeoutMillisFor(tx_airtime_ms);
       return MSG_SEND_SENT_FLOOD;
     } else {
+      pkt->_tx_cr = selectCodingRateForPeer(recipient.out_path, (recipient.out_path_len >> 6) + 1);
+      // Downstream repeater CR choices are not knowable here, so only the local hop is modeled exactly.
+      uint32_t tx_airtime_ms = estimateTxAirtimeFor(pkt->getRawLength(), pkt->_tx_cr);
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = calcDirectTimeoutMillisFor(tx_airtime_ms, recipient.out_path_len);
       return MSG_SEND_SENT_DIRECT;
     }
   }

--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -29,6 +29,8 @@ public:
   float getLastRSSI() const override { return ((CustomLLCC68 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLLCC68 *)_radio)->getSNR(); }
 
+  void setCodingRate(uint8_t cr) override { ((CustomLLCC68 *)_radio)->setCodingRate(cr); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomLLCC68 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -38,6 +38,8 @@ public:
     _radio->setPreambleLength(preambleLengthForSF(getSpreadingFactor())); // overcomes weird issues with small and big pkts
   }
 
+  void setCodingRate(uint8_t cr) override { ((CustomLR1110 *)_radio)->setCodingRate(cr); }
+
   float getLastRSSI() const override { return ((CustomLR1110 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLR1110 *)_radio)->getSNR(); }
 

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -29,6 +29,8 @@ public:
   float getLastRSSI() const override { return ((CustomSTM32WLx *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSTM32WLx *)_radio)->getSNR(); }
 
+  void setCodingRate(uint8_t cr) override { ((CustomSTM32WLx *)_radio)->setCodingRate(cr); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomSTM32WLx *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -32,6 +32,8 @@ public:
   float getLastRSSI() const override { return ((CustomSX1262 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1262 *)_radio)->getSNR(); }
 
+  void setCodingRate(uint8_t cr) override { ((CustomSX1262 *)_radio)->setCodingRate(cr); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomSX1262 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -32,6 +32,8 @@ public:
   float getLastRSSI() const override { return ((CustomSX1268 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1268 *)_radio)->getSNR(); }
 
+  void setCodingRate(uint8_t cr) override { ((CustomSX1268 *)_radio)->setCodingRate(cr); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomSX1268 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -28,6 +28,8 @@ public:
   float getLastRSSI() const override { return ((CustomSX1276 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1276 *)_radio)->getSNR(); }
 
+  void setCodingRate(uint8_t cr) override { ((CustomSX1276 *)_radio)->setCodingRate(cr); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomSX1276 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);


### PR DESCRIPTION
When a repeater forwards a direct-routed pkt, it looks up the next-hop neighbor's SNR, computes the link margin against the SF-specific demodulation floor, then determines coding rate (CR) based on SNR. Weaker links get higher CR. We apply CR on a per-packet basis and restore to default configuration after TX.

```
Margin thresholds:
<3 dB   - CR 4/8
3-6 dB  - CR 4/7
6-10 dB - CR 4/6
>=10 dB - CR 4/5
```

Flood repeats adhere to configured CR, as do forwards to unknown neighbors.

If you want to try this you can [BUILD HERE](https://mcimages.weebl.me/?commitId=snr-drives-cr).

I saw this was on the roadmap so I had a go at it. For now we leave flood repeats as-is. In future we might do something smart with average SNR of all our neighbors, but let's take small steps.