### PR TITLE
feat: add support of Meshpocket 5000 mah. variant with LiHV 4.35V battery

### DIFF
--- a/variants/mesh_pocket/platformio.ini
+++ b/variants/mesh_pocket/platformio.ini
@@ -89,6 +89,32 @@ lib_deps =
   ${Mesh_pocket.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:Mesh_pocket_5000_companion_ble]
+extends = Mesh_pocket
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${Mesh_pocket.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  -D AUTO_OFF_MILLIS=0
+; 4.35 Volts is usually upper indicated limit for LiHV
+  -D BATT_MAX_MILLIVOLTS=4350
+;  -D BLE_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+
+build_src_filter = ${Mesh_pocket.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Mesh_pocket.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:Mesh_pocket_companion_radio_usb]
 extends = Mesh_pocket
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld


### PR DESCRIPTION
Heltec Meshpocket comes in two variants: 5000 mAh and 10000 mAh. 
Data sheet isn't very clear, but it says: "Battery charging limit voltage 4.4V" without indicating specific version. 
Internet (and Meshtastic community) mentioned, that 5000 mAh version has LiHV battery (fully charged it indicates 4.35V), 10000 mAh version has standard LiPO battery (4.2V fully charged).
This PR introduces 5000 mAh BT companion build variant with max voltages set as 4350 mV. It should fix device UI indication of charge level. 
