### PR TITLE
Add adaptive congestion control for backbone repeaters

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -415,10 +415,26 @@ bool MyMesh::isLooped(const mesh::Packet* packet, const uint8_t max_counters[]) 
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
-  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
-  if (packet->isRouteFlood() && recv_pkt_region == NULL) {
-    MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
-    return false;
+  if (packet->isRouteFlood()) {
+    if (recv_pkt_region == NULL) {
+      MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
+      return false;
+    }
+    // per-type adaptive hop limits (groups and adverts use busy-driven ramp,
+    // but never exceed the operator-configured flood_max)
+    uint8_t hops = packet->getPathHashCount();
+    uint8_t limit = _prefs.flood_max;
+    uint8_t type = packet->getPayloadType();
+    if (type == PAYLOAD_TYPE_GRP_TXT || type == PAYLOAD_TYPE_GRP_DATA) {
+      uint8_t adaptive = getEffectiveFloodMax(busy_tracker.busy,
+          GROUP_FLOOD_MAX, GROUP_FLOOD_MID, GROUP_FLOOD_FLOOR);
+      limit = (adaptive < limit) ? adaptive : limit;
+    } else if (type == PAYLOAD_TYPE_ADVERT) {
+      uint8_t adaptive = getEffectiveFloodMax(busy_tracker.busy,
+          ADVERT_FLOOD_MAX, ADVERT_FLOOD_MID, ADVERT_FLOOD_FLOOR);
+      limit = (adaptive < limit) ? adaptive : limit;
+    }
+    if (hops >= limit) return false;
   }
   if (packet->isRouteFlood() && _prefs.loop_detect != LOOP_DETECT_OFF) {
     const uint8_t* maximums;
@@ -525,7 +541,8 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
   uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 5*t + 1);
+  float scale = 1.0f + busy_tracker.busy * BUSY_TX_DELAY_SCALE;
+  return getRNG()->nextInt(0, (uint32_t)(5 * t * scale) + 1);
 }
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
   uint32_t t = (_radio->getEstAirtimeFor(packet->getPathByteLen() + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
@@ -830,7 +847,7 @@ void MyMesh::sendNodeDiscoverReq() {
 
 MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondClock &ms, mesh::RNG &rng,
                mesh::RTCClock &rtc, mesh::MeshTables &tables)
-    : mesh::Mesh(radio, ms, rng, rtc, *new StaticPoolPacketManager(32), tables),
+    : mesh::Mesh(radio, ms, rng, rtc, *new StaticPoolPacketManager(PACKET_POOL_SIZE), tables),
       _cli(board, rtc, sensors, acl, &_prefs, this), telemetry(MAX_PACKET_PAYLOAD - 4), region_map(key_store), temp_map(key_store),
       discover_limiter(4, 120),  // max 4 every 2 minutes
       anon_limiter(4, 180)   // max 4 every 3 minutes
@@ -907,6 +924,10 @@ void MyMesh::begin(FILESYSTEM *fs) {
     bridge.begin();
   }
 #endif
+
+  busy_tracker.reset(millis(), getTotalAirTime(), getReceiveAirTime(),
+                     getNumRecvFlood(),
+                     ((SimpleMeshTables *)getTables())->getNumFloodDups());
 
   radio_set_params(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
   radio_set_tx_power(_prefs.tx_power_dbm);
@@ -1057,8 +1078,25 @@ void MyMesh::formatRadioStatsReply(char *reply) {
 }
 
 void MyMesh::formatPacketStatsReply(char *reply) {
-  StatsFormatHelper::formatPacketStats(reply, radio_driver, getNumSentFlood(), getNumSentDirect(), 
+  StatsFormatHelper::formatPacketStats(reply, radio_driver, getNumSentFlood(), getNumSentDirect(),
                                        getNumRecvFlood(), getNumRecvDirect());
+}
+
+void MyMesh::formatBusyStatsReply(char *reply) {
+  const char* label = busy_tracker.busy < BUSY_ONSET ? "low"
+                    : busy_tracker.busy < 0.50f       ? "medium"
+                    :                                    "high";
+  uint8_t grp_hops = getEffectiveFloodMax(busy_tracker.busy,
+      GROUP_FLOOD_MAX, GROUP_FLOOD_MID, GROUP_FLOOD_FLOOR);
+  uint8_t adv_hops = getEffectiveFloodMax(busy_tracker.busy,
+      ADVERT_FLOOD_MAX, ADVERT_FLOOD_MID, ADVERT_FLOOD_FLOOR);
+  sprintf(reply,
+    "busy: %.2f (%s)\n"
+    "  air:%.2f q:%.2f dup:%.2f\n"
+    "  grp_hops:%d/%d adv_hops:%d/%d",
+    busy_tracker.busy, label,
+    busy_tracker.airtime_ratio, busy_tracker.queue_ratio, busy_tracker.dup_ratio,
+    grp_hops, GROUP_FLOOD_MAX, adv_hops, ADVERT_FLOOD_MAX);
 }
 
 void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
@@ -1078,6 +1116,9 @@ void MyMesh::clearStats() {
   radio_driver.resetStats();
   resetStats();
   ((SimpleMeshTables *)getTables())->resetStats();
+  busy_tracker.reset(millis(), getTotalAirTime(), getReceiveAirTime(),
+                     getNumRecvFlood(),
+                     ((SimpleMeshTables *)getTables())->getNumFloodDups());
 }
 
 void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply) {
@@ -1267,6 +1308,8 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
       sendNodeDiscoverReq();
       strcpy(reply, "OK - Discover sent");
     }
+  } else if (sender_timestamp == 0 && memcmp(command, "stats-busy", 10) == 0 && (command[10] == 0 || command[10] == ' ')) {
+    formatBusyStatsReply(reply);
   } else{
     _cli.handleCommand(sender_timestamp, command, reply);  // common CLI commands
   }
@@ -1314,6 +1357,12 @@ void MyMesh::loop() {
   uint32_t now = millis();
   uptime_millis += now - last_millis;
   last_millis = now;
+
+  // update busy score
+  auto t = (SimpleMeshTables *)getTables();
+  busy_tracker.update(now, getTotalAirTime(), getReceiveAirTime(),
+                      _mgr->getOutboundCount(now), PACKET_POOL_SIZE,
+                      getNumRecvFlood(), t->getNumFloodDups());
 }
 
 // To check if there is pending work

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -33,6 +33,7 @@
 #include <helpers/StatsFormatHelper.h>
 #include <helpers/TxtDataHelpers.h>
 #include <helpers/RegionMap.h>
+#include <helpers/BusyTracker.h>
 #include "RateLimiter.h"
 
 #ifdef WITH_BRIDGE
@@ -59,6 +60,10 @@ struct RepeaterStats {
 
 #ifndef MAX_CLIENTS
   #define MAX_CLIENTS           32
+#endif
+
+#ifndef PACKET_POOL_SIZE
+  #define PACKET_POOL_SIZE      32
 #endif
 
 struct NeighbourInfo {
@@ -97,6 +102,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   RegionMap region_map, temp_map;
   RegionEntry* load_stack[8];
   RegionEntry* recv_pkt_region;
+  BusyTracker busy_tracker;
   RateLimiter discover_limiter, anon_limiter;
   uint32_t pending_discover_tag;
   unsigned long pending_discover_until;
@@ -185,6 +191,9 @@ public:
   NodePrefs* getNodePrefs() {
     return &_prefs;
   }
+  BusyTracker* getBusyTracker() {
+    return &busy_tracker;
+  }
 
   void savePrefs() override {
     _cli.savePrefs(_fs);
@@ -209,6 +218,7 @@ public:
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
   void formatPacketStatsReply(char *reply) override;
+  void formatBusyStatsReply(char *reply);
 
   mesh::LocalIdentity& getSelfId() override { return self_id; }
 

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -22,10 +22,11 @@ static const uint8_t meshcore_logo [] PROGMEM = {
     0xe3, 0xe3, 0x8f, 0xff, 0x1f, 0xfc, 0x3c, 0x0e, 0x1f, 0xf8, 0xff, 0xf8, 0x70, 0x3c, 0x7f, 0xf8, 
 };
 
-void UITask::begin(NodePrefs* node_prefs, const char* build_date, const char* firmware_version) {
+void UITask::begin(NodePrefs* node_prefs, BusyTracker* busy, const char* build_date, const char* firmware_version) {
   _prevBtnState = HIGH;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   _node_prefs = node_prefs;
+  _busy_tracker = busy;
   _display->turnOn();
 
   // strip off dash and commit hash by changing dash to null terminator
@@ -77,6 +78,20 @@ void UITask::renderCurrScreen() {
     _display->setCursor(0, 30);
     sprintf(tmp, "BW: %03.2f CR: %d", _node_prefs->bw, _node_prefs->cr);
     _display->print(tmp);
+
+    // busy score + effective hop limits
+    if (_busy_tracker) {
+      uint8_t grp = getEffectiveFloodMax(_busy_tracker->busy,
+          GROUP_FLOOD_MAX, GROUP_FLOOD_MID, GROUP_FLOOD_FLOOR);
+      uint8_t adv = getEffectiveFloodMax(_busy_tracker->busy,
+          ADVERT_FLOOD_MAX, ADVERT_FLOOD_MID, ADVERT_FLOOD_FLOOR);
+      _display->setCursor(0, 42);
+      _display->setColor(DisplayDriver::LIGHT);
+      sprintf(tmp, "GRP:%d/%d ADV:%d/%d B:%.0f%%",
+              grp, GROUP_FLOOD_MAX, adv, ADVERT_FLOOD_MAX,
+              _busy_tracker->busy * 100.0f);
+      _display->print(tmp);
+    }
   }
 }
 

--- a/examples/simple_repeater/UITask.h
+++ b/examples/simple_repeater/UITask.h
@@ -2,18 +2,20 @@
 
 #include <helpers/ui/DisplayDriver.h>
 #include <helpers/CommonCLI.h>
+#include <helpers/BusyTracker.h>
 
 class UITask {
   DisplayDriver* _display;
   unsigned long _next_read, _next_refresh, _auto_off;
   int _prevBtnState;
   NodePrefs* _node_prefs;
+  BusyTracker* _busy_tracker;
   char _version_info[32];
 
   void renderCurrScreen();
 public:
-  UITask(DisplayDriver& display) : _display(&display) { _next_read = _next_refresh = 0; }
-  void begin(NodePrefs* node_prefs, const char* build_date, const char* firmware_version);
+  UITask(DisplayDriver& display) : _display(&display), _busy_tracker(nullptr) { _next_read = _next_refresh = 0; }
+  void begin(NodePrefs* node_prefs, BusyTracker* busy, const char* build_date, const char* firmware_version);
 
   void loop();
 };

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -91,7 +91,7 @@ void setup() {
   the_mesh.begin(fs);
 
 #ifdef DISPLAY_CLASS
-  ui_task.begin(the_mesh.getNodePrefs(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
+  ui_task.begin(the_mesh.getNodePrefs(), the_mesh.getBusyTracker(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
 #endif
 
   // send out initial zero hop Advertisement to the mesh

--- a/src/helpers/BusyTracker.h
+++ b/src/helpers/BusyTracker.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <stdint.h>
+
+// --- Congestion control compile-time defines ---
+// Override any of these via platformio.ini build_flags, e.g.:
+//   -D GROUP_FLOOD_MAX=16 -D BUSY_ONSET=0.20f
+
+#ifndef BUSY_ONSET
+  #define BUSY_ONSET  0.15f     // busy level below which no throttling occurs
+#endif
+#ifndef BUSY_WINDOW_MS
+  #define BUSY_WINDOW_MS  60000 // tumbling window for busy calculation (ms)
+#endif
+
+#ifndef GROUP_FLOOD_MAX
+  #define GROUP_FLOOD_MAX  8    // max group reach when quiet. 0 = no group forwarding.
+#endif
+#ifndef GROUP_FLOOD_MID
+  #define GROUP_FLOOD_MID  5    // knee point at moderate congestion
+#endif
+#ifndef GROUP_FLOOD_FLOOR
+  #define GROUP_FLOOD_FLOOR 2   // minimum group reach under extreme congestion
+#endif
+
+#ifndef ADVERT_FLOOD_MAX
+  #define ADVERT_FLOOD_MAX  8   // max advert reach when quiet. 0 = no advert forwarding.
+#endif
+#ifndef ADVERT_FLOOD_MID
+  #define ADVERT_FLOOD_MID  4   // knee point at moderate congestion
+#endif
+#ifndef ADVERT_FLOOD_FLOOR
+  #define ADVERT_FLOOD_FLOOR 1  // minimum advert reach under extreme congestion
+#endif
+
+// Busy score component weights (must sum to 1.0)
+#ifndef BUSY_WEIGHT_AIRTIME
+  #define BUSY_WEIGHT_AIRTIME  0.5f  // tx+rx airtime fraction of window
+#endif
+#ifndef BUSY_WEIGHT_QUEUE
+  #define BUSY_WEIGHT_QUEUE    0.3f  // tx queue fill level
+#endif
+#ifndef BUSY_WEIGHT_DUP
+  #define BUSY_WEIGHT_DUP      0.2f  // flood duplicate ratio
+#endif
+
+// TX delay scaling: delay multiplier = 1 + busy * BUSY_TX_DELAY_SCALE
+// At busy=0: 1× (unchanged), at busy=1: (1+scale)× wider jitter window
+#ifndef BUSY_TX_DELAY_SCALE
+  #define BUSY_TX_DELAY_SCALE  2.0f  // busy=1 gives 3× wider retransmit window
+#endif
+
+/**
+ * \brief  Piecewise-linear ramp: dead zone + two-segment curve through ceiling → mid → floor.
+ *         Returns effective hop limit for a given busy score.
+ */
+inline uint8_t getEffectiveFloodMax(float busy, uint8_t ceiling, uint8_t mid, uint8_t floor) {
+  if (ceiling == 0) return 0;          // type disabled
+  if (mid > ceiling) mid = ceiling;    // guard against misconfigured overrides
+  if (floor > mid)   floor = mid;
+  if (busy <= BUSY_ONSET) return ceiling;
+  if (busy >= 1.0f) return floor;
+
+  float t = (busy - BUSY_ONSET) / (1.0f - BUSY_ONSET);  // normalize active zone to [0,1]
+  if (t <= 0.5f) {
+    float s = t / 0.5f;  // [0,1] within first half
+    return mid + (uint8_t)((1.0f - s) * (ceiling - mid));
+  } else {
+    float s = (t - 0.5f) / 0.5f;  // [0,1] within second half
+    return floor + (uint8_t)((1.0f - s) * (mid - floor));
+  }
+}
+
+/**
+ * \brief  Lightweight busy score tracker. Computes busy ∈ [0,1] over a rolling window
+ *         from airtime ratio, queue depth, and flood duplicate ratio.
+ *         Call update() from loop(). Recomputes every BUSY_WINDOW_MS (tumbling window).
+ *         All counters come from existing Dispatcher/SimpleMeshTables.
+ */
+struct BusyTracker {
+  float busy;           // composite score [0,1]
+  float airtime_ratio;  // tx+rx airtime / window
+  float queue_ratio;    // queue depth / capacity
+  float dup_ratio;      // flood dups / flood recv
+
+  // snapshot of counters at start of window
+  unsigned long window_start;
+  unsigned long prev_tx_air;
+  unsigned long prev_rx_air;
+  uint32_t prev_flood_recv;
+  uint32_t prev_flood_dups;
+
+  void reset(unsigned long now_ms,
+             unsigned long tx_air, unsigned long rx_air,
+             uint32_t flood_recv, uint32_t flood_dups) {
+    busy = 0;
+    airtime_ratio = queue_ratio = dup_ratio = 0;
+    window_start = now_ms;
+    prev_tx_air = tx_air;
+    prev_rx_air = rx_air;
+    prev_flood_recv = flood_recv;
+    prev_flood_dups = flood_dups;
+  }
+
+  void update(unsigned long now_ms,
+              unsigned long tx_air, unsigned long rx_air,
+              int queue_count, int queue_capacity,
+              uint32_t flood_recv, uint32_t flood_dups) {
+    unsigned long elapsed = now_ms - window_start;
+    if (elapsed < BUSY_WINDOW_MS) return;  // not yet time
+
+    // airtime deltas — detect counter wrap (~49 days) and skip window
+    unsigned long delta_tx = tx_air - prev_tx_air;
+    unsigned long delta_rx = rx_air - prev_rx_air;
+    if (delta_tx > elapsed || delta_rx > elapsed) {
+      // counter wrapped — re-baseline and keep previous busy score
+      prev_tx_air = tx_air;
+      prev_rx_air = rx_air;
+      prev_flood_recv = flood_recv;
+      prev_flood_dups = flood_dups;
+      window_start = now_ms;
+      return;
+    }
+
+    // airtime component: fraction of window spent transmitting or receiving
+    airtime_ratio = (float)(delta_tx + delta_rx) / (float)elapsed;
+    if (airtime_ratio > 1.0f) airtime_ratio = 1.0f;
+
+    // queue component: instantaneous depth / capacity
+    queue_ratio = (queue_capacity > 0) ? (float)queue_count / (float)queue_capacity : 0;
+    if (queue_ratio > 1.0f) queue_ratio = 1.0f;
+
+    // duplicate component: flood dups / flood recv
+    uint32_t delta_recv = flood_recv - prev_flood_recv;
+    uint32_t delta_dups = flood_dups - prev_flood_dups;
+    dup_ratio = (delta_recv > 0) ? (float)delta_dups / (float)delta_recv : 0;
+    if (dup_ratio > 1.0f) dup_ratio = 1.0f;
+
+    // weighted composite
+    busy = airtime_ratio * BUSY_WEIGHT_AIRTIME + queue_ratio * BUSY_WEIGHT_QUEUE + dup_ratio * BUSY_WEIGHT_DUP;
+    if (busy > 1.0f) busy = 1.0f;
+
+    // slide window
+    prev_tx_air = tx_air;
+    prev_rx_air = rx_air;
+    prev_flood_recv = flood_recv;
+    prev_flood_dups = flood_dups;
+    window_start = now_ms;
+  }
+};

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -91,6 +91,15 @@ build_flags =
   -D MAX_NEIGHBOURS=50
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
+;  --- Congestion control tuning (compile-time) ---
+;  -D GROUP_FLOOD_MAX=8
+;  -D GROUP_FLOOD_MID=5
+;  -D GROUP_FLOOD_FLOOR=2
+;  -D ADVERT_FLOOD_MAX=8
+;  -D ADVERT_FLOOD_MID=4
+;  -D ADVERT_FLOOD_FLOOR=1
+;  -D BUSY_ONSET=0.15f
+;  -D BUSY_WINDOW_MS=60000
 build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>


### PR DESCRIPTION
## Adaptive Congestion Control for Backbone Repeaters

### Summary

This PR adds a lightweight, adaptive congestion control system to repeater nodes. When the network gets busy, repeaters automatically and gracefully reduce flood hop limits for group messages and advertisements, keeping the mesh healthy without manual intervention.

This addresses #1588 (repeater limit channel flooding) with a busy-adaptive approach rather than a static cap.

### How it works

**BusyTracker** (`src/helpers/BusyTracker.h`) computes a composite busy score (0.0–1.0) from three weighted signals over a 60-second tumbling window:

| Signal | Weight | Rationale |
|--------|--------|-----------|
| Airtime ratio | 50% | "Am I personally overloaded?" — measures actual radio utilization (TX + RX time as a fraction of the window). This is the most direct indicator of channel saturation. |
| Queue pressure | 30% | "Is my TX pipeline backed up?" — instantaneous queue fill level. High queue depth means packets are waiting longer to transmit, a leading indicator that airtime will spike next. |
| Duplicate ratio | 20% | "Is the mesh around me oversaturated?" — proportion of received floods that are duplicates. High dups mean many neighbors are reforwarding the same packets. This doesn't show up in airtime (dups are short RX, not TX) or queue (dups are dropped, never queued), but it tells us that reducing our own flood reach won't hurt delivery — other paths already cover those destinations. |

All three weights are compile-time configurable (`BUSY_WEIGHT_AIRTIME`, `BUSY_WEIGHT_QUEUE`, `BUSY_WEIGHT_DUP`).

The busy score drives a **piecewise-linear ramp** that smoothly reduces effective hop limits as congestion builds:

```
effective_hops
     ^
  8  |███
  7  |     \        ← upper segment: max → mid
  6  |        \
  5  |...........█      ← knee (mid)
  4  |              \
  3  |                 \    ← lower segment: mid → floor
  2  |                     ████████
     +--+--+--+--+--+--+--+--> busy
     0  .15       .58     1.0
        ^onset    ^knee
```

| Busy range | Label | Behavior |
|-----------|-------|----------|
| 0.00 – 0.15 | **Low** | Dead zone — full reach, no penalty |
| 0.15 – 0.58 | **Medium** | Progressive shedding: max → mid |
| 0.58 – 1.00 | **High** | Aggressive shedding: mid → floor |

**Example:** A repeater running at 40% busy will forward group messages up to ~6 hops (down from 8), while advertisements drop to ~5 hops. At 80% busy, groups are limited to ~3 hops and adverts to ~2. Direct/unicast traffic is never throttled.

### Traffic-aware retransmit delay

`getRetransmitDelay()` scales the random jitter window by `(1 + busy × 2)`:
- At `busy = 0` (idle): delay unchanged — same as current behavior
- At `busy = 0.5` (moderate): 2× wider jitter window, spreading retransmissions
- At `busy = 1.0` (saturated): 3× wider jitter window

This naturally reduces collision probability under load by spreading retransmissions over a wider time window. `getDirectRetransmitDelay()` is intentionally **not** scaled — DM and ACK traffic should not be penalized during congestion, as these are high-value, low-volume packets that need reliable delivery.

### Defaults

All thresholds are compile-time `#define`s, overridable via `build_flags` in `platformio.ini`:

| Parameter | Default | Purpose |
|-----------|---------|---------|
| `BUSY_ONSET` | 0.15 | Busy score below which no shedding occurs |
| `BUSY_WINDOW_MS` | 60000 | Tumbling window for score computation (ms) |
| `BUSY_WEIGHT_AIRTIME` | 0.5 | Weight for airtime ratio component |
| `BUSY_WEIGHT_QUEUE` | 0.3 | Weight for queue pressure component |
| `BUSY_WEIGHT_DUP` | 0.2 | Weight for duplicate ratio component |
| `GROUP_FLOOD_MAX` | 8 | Group message hop limit at idle |
| `GROUP_FLOOD_MID` | 5 | Group hops at the knee of the ramp |
| `GROUP_FLOOD_FLOOR` | 2 | Group hops at full congestion |
| `ADVERT_FLOOD_MAX` | 8 | Advertisement hop limit at idle |
| `ADVERT_FLOOD_MID` | 4 | Advert hops at the knee |
| `ADVERT_FLOOD_FLOOR` | 1 | Advert hops at full congestion |
| `PACKET_POOL_SIZE` | 32 | Packet pool capacity (shared with StaticPoolPacketManager) |
| `BUSY_TX_DELAY_SCALE` | 3 | TX delay scaling factor |

Operators can tune per-deployment, for example a high-traffic urban repeater:

```ini
build_flags =
  -DGROUP_FLOOD_FLOOR=1
  -DADVERT_FLOOD_FLOOR=0
  -DBUSY_ONSET=0.10
  -DBUSY_WEIGHT_AIRTIME=0.6f
  -DBUSY_WEIGHT_QUEUE=0.2f
  -DBUSY_WEIGHT_DUP=0.2f
```

### What's included

- **Adaptive hop limits** in `allowPacketForward()` — per-type flood limiting for group, advert, and fallback to `_prefs.flood_max`
- **Traffic-aware retransmit delay** — `getRetransmitDelay()` scales jitter by `(1 + busy × 2)`, spreading retransmissions when congested. Direct message delays are intentionally untouched to protect DM/ACK delivery
- **Counter wrap protection** — airtime counters wrap at ~49 days; BusyTracker detects implausible deltas (exceeding elapsed wall time), skips the window, re-baselines, and preserves the previous valid score
- **Misconfiguration guards** — `getEffectiveFloodMax()` clamps `mid` and `floor` if build flag overrides violate `ceiling >= mid >= floor`
- **`stats-busy` CLI command** — prints busy score, component breakdown, and effective hop limits over serial
- **OLED display line** — live status: `GRP:5/8 ADV:4/8 B:32%`
- **Build flag docs** in `variants/heltec_v4/platformio.ini`

### Design choices

- Zero heap allocation at runtime — everything is stack/static
- Header-only BusyTracker avoids touching core library build
- Piecewise-linear ramp gives smooth, predictable behavior without cliff edges
- Dead zone prevents flapping during normal low-traffic operation
- `PACKET_POOL_SIZE` constant shared between pool allocator and BusyTracker to prevent silent drift

### Is this overengineered?

Honest question — the core mechanism is simple (composite score → hop limit ramp), but there are a lot of configurable knobs and a linear ramp. The rationale is that different deployments face very different traffic patterns (urban dense mesh vs rural sparse backbone), and we won't know the right defaults until we have field data. The `#ifndef` guards make these zero-cost to ignore if you don't need them.

That said, if the consensus is that fewer knobs and hardcoded defaults would be better to start with, happy to strip the configurability down to just `GROUP_FLOOD_MAX`/`FLOOR` and `ADVERT_FLOOD_MAX`/`FLOOR` and bake the rest in. We can always add knobs back later if field testing shows they're needed. Would love to hear thoughts on this.

### Files changed

| File | Change |
|------|--------|
| `src/helpers/BusyTracker.h` | **New** — busy score computation, `getEffectiveFloodMax()`, all compile-time defines |
| `examples/simple_repeater/MyMesh.h` | BusyTracker member, getter, `PACKET_POOL_SIZE` define |
| `examples/simple_repeater/MyMesh.cpp` | Wired into loop/forward/delay/stats/CLI |
| `examples/simple_repeater/UITask.h` | Accept BusyTracker pointer |
| `examples/simple_repeater/UITask.cpp` | Render effective hop limits on display |
| `examples/simple_repeater/main.cpp` | Pass BusyTracker to UITask |
| `variants/heltec_v4/platformio.ini` | Documented congestion build flags |

### Related work

| Issue | Title | Relationship |
|-------|-------|-------------|
| #1502 | Token bucket rate limiting | **Complementary.** Per-sender fairness vs our global congestion response. Composes well. |
| #1588 | Repeater limit channel flooding | **Directly addressed.** Our `GROUP_FLOOD_MAX` is this feature, but busy-adaptive rather than static. |

Looking forward to feedback! Happy to tune defaults or simplify if it feels like too much for a first pass.
