### PR TITLE
Perf/UI allocation reduction

### DIFF
--- a/src/helpers/ui/OLEDDisplay.cpp
+++ b/src/helpers/ui/OLEDDisplay.cpp
@@ -619,11 +619,8 @@ uint16_t OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const cha
 
 uint16_t OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String &strUser) {
   uint16_t lineHeight = pgm_read_byte(fontData + HEIGHT_POS);
-
-  // char* text must be freed!
-  char* text = strdup(strUser.c_str());
-  if (!text) {
-    DEBUG_OLEDDISPLAY("[OLEDDISPLAY][drawString] Can't allocate char array.\n");
+  const char* text = strUser.c_str();
+  if (text == nullptr) {
     return 0;
   }
 
@@ -642,13 +639,27 @@ uint16_t OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String &str
 
   uint16_t charDrawn = 0;
   uint16_t line = 0;
-  char* textPart = strtok(text,"\n");
-  while (textPart != NULL) {
-    uint16_t length = strlen(textPart);
-    charDrawn += drawStringInternal(xMove, yMove - yOffset + (line++) * lineHeight, textPart, length, getStringWidth(textPart, length, true), true);
-    textPart = strtok(NULL, "\n");
+  const char* lineStart = text;
+  while (true) {
+    const char* lineEnd = lineStart;
+    while (*lineEnd != 0 && *lineEnd != '\n') {
+      lineEnd++;
+    }
+
+    if (lineEnd == lineStart && *lineEnd == '\n') {
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    uint16_t length = lineEnd - lineStart;
+    charDrawn += drawStringInternal(xMove, yMove - yOffset + (line++) * lineHeight, lineStart, length,
+                                    getStringWidth(lineStart, length, true), true);
+
+    if (*lineEnd == 0) {
+      break;
+    }
+    lineStart = lineEnd + 1;
   }
-  free(text);
   return charDrawn;
 }
 

--- a/src/helpers/ui/ST7789Spi.h
+++ b/src/helpers/ui/ST7789Spi.h
@@ -103,9 +103,11 @@ class ST7789Spi : public OLEDDisplay {
       int             _mosi;
       int             _clk;
       SPIClass * _spi;
-      SPISettings 		    _spiSettings;
+      SPISettings          _spiSettings;
       uint16_t            _RGB=0xFFFF;
       uint8_t             _buffheight;
+      uint16_t*           _pixbuf = nullptr;
+      uint32_t            _pixbuf_capacity = 0;
   public:
     /* pass _cs as -1 to indicate "do not use CS pin", for cases where it is hard wired low */
     ST7789Spi(SPIClass *spiClass,uint8_t _rst, uint8_t _dc, uint8_t _cs, OLEDDISPLAY_GEOMETRY g = GEOMETRY_RAWMODE,uint16_t width=240,uint16_t height=135,int mosi=-1,int miso=-1,int clk=-1) {
@@ -121,9 +123,29 @@ class ST7789Spi : public OLEDDisplay {
       setGeometry(g,width,height);
     }
 
+    ~ST7789Spi() {
+      if (_pixbuf != nullptr) {
+        rtos_free(_pixbuf);
+        _pixbuf = nullptr;
+        _pixbuf_capacity = 0;
+      }
+    }
+
     bool connect(){
       this->_buffheight=displayHeight / 8;
       this->_buffheight+=displayHeight % 8 ? 1:0;
+      if (_pixbuf == nullptr || _pixbuf_capacity < displayWidth) {
+        uint16_t* new_pixbuf = (uint16_t *)rtos_malloc(sizeof(uint16_t) * displayWidth);
+        if (new_pixbuf == nullptr) {
+          _pixbuf_capacity = 0;
+          return false;
+        }
+        if (_pixbuf != nullptr) {
+          rtos_free(_pixbuf);
+        }
+        _pixbuf = new_pixbuf;
+        _pixbuf_capacity = displayWidth;
+      }
       pinMode(_cs, OUTPUT);
       pinMode(_dc, OUTPUT);
       //pinMode(_ledA, OUTPUT);
@@ -186,27 +208,25 @@ class ST7789Spi : public OLEDDisplay {
 		  set_CS(LOW);
 		  _spi->beginTransaction(_spiSettings);
 
-          for (y = minBoundY; y <= maxBoundY; y++)
-          {
-            for(int temp = 0; temp<8;temp++)
-            {
-              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
-              setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
-              //setAddrWindow(y*8+temp,minBoundX,1,maxBoundX-minBoundX+1);
-              uint32_t const pixbufcount = maxBoundX-minBoundX+1;
-              uint16_t *pixbuf = (uint16_t *)rtos_malloc(2 * pixbufcount);
-              for (x = minBoundX; x <= maxBoundX; x++)
-              {
-                pixbuf[x-minBoundX] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
-              }
+	          for (y = minBoundY; y <= maxBoundY; y++)
+	          {
+	            for(int temp = 0; temp<8;temp++)
+	            {
+	              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+	              setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+	              //setAddrWindow(y*8+temp,minBoundX,1,maxBoundX-minBoundX+1);
+	              uint32_t const pixbufcount = maxBoundX-minBoundX+1;
+	              for (x = minBoundX; x <= maxBoundX; x++)
+	              {
+	                _pixbuf[x-minBoundX] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
+	              }
 #ifdef ESP_PLATFORM
-              _spi->transferBytes((uint8_t *)pixbuf, NULL, 2 * pixbufcount);
+	              _spi->transferBytes((uint8_t *)_pixbuf, NULL, 2 * pixbufcount);
 #else
-              _spi->transfer(pixbuf, NULL, 2 * pixbufcount);
+	              _spi->transfer(_pixbuf, NULL, 2 * pixbufcount);
 #endif
-              rtos_free(pixbuf);
-            }
-          }
+	            }
+	          }
 	  _spi->endTransaction();
 	  set_CS(HIGH);
 
@@ -214,27 +234,25 @@ class ST7789Spi : public OLEDDisplay {
 		  set_CS(LOW);
 		  _spi->beginTransaction(_spiSettings);
 		uint8_t x, y;
-          for (y = 0; y < _buffheight; y++)
-          {
-            for(int temp = 0; temp<8;temp++)
-            {
-              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
-              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
-              setAddrWindow(y*8+temp,0,1,displayWidth);
-              uint32_t const pixbufcount = displayWidth;
-              uint16_t *pixbuf = (uint16_t *)rtos_malloc(2 * pixbufcount);
-              for (x = 0; x < displayWidth; x++)
-              {
-                pixbuf[x] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
-              }
+	          for (y = 0; y < _buffheight; y++)
+	          {
+	            for(int temp = 0; temp<8;temp++)
+	            {
+	              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+	              //setAddrWindow(minBoundX,y*8+temp,maxBoundX-minBoundX+1,1);
+	              setAddrWindow(y*8+temp,0,1,displayWidth);
+	              uint32_t const pixbufcount = displayWidth;
+	              for (x = 0; x < displayWidth; x++)
+	              {
+	                _pixbuf[x] = ((buffer[x + y * displayWidth]>>temp)&0x01)==1?_RGB:0;
+	              }
 #ifdef ESP_PLATFORM
-              _spi->transferBytes((uint8_t *)pixbuf, NULL, 2 * pixbufcount);
+	              _spi->transferBytes((uint8_t *)_pixbuf, NULL, 2 * pixbufcount);
 #else
-              _spi->transfer(pixbuf, NULL, 2 * pixbufcount);
+	              _spi->transfer(_pixbuf, NULL, 2 * pixbufcount);
 #endif
-              rtos_free(pixbuf);
-            }
-          }
+	            }
+	          }
 	  _spi->endTransaction();
 	  set_CS(HIGH);
 


### PR DESCRIPTION
## Summary

This branch reduces avoidable UI-time heap allocation in two hot paths:

- Reuses a persistent scanline buffer in the ST7789 flush path instead of allocating/freeing a temporary pixel buffer on each row update.
- Rewrites `OLEDDisplay::drawString()` to scan the source string directly instead of copying it with `strdup()` and splitting it with `strtok()`.

## Changes

### ST7789 scanline buffer reuse

What changed:
- Added a persistent `_pixbuf` scratch buffer and `_pixbuf_capacity` to `ST7789Spi`.
- Allocates the scratch buffer in `connect()` when needed and reuses it across `display()` calls.
- Removes per-iteration `rtos_malloc()` / `rtos_free()` calls from both ST7789 `display()` code paths.
- Frees the scratch buffer in the destructor.
- Preserves the existing buffer if a resize/allocation attempt fails.

Why:
- `display()` was doing repeated heap allocation in a render hot path.
- Reusing a single buffer reduces allocator churn and fragmentation risk on embedded targets.

### OLED drawString heap removal

What changed:
- Replaced `strdup()` + `strtok()` in `OLEDDisplay::drawString()` with direct pointer-based scanning over `strUser.c_str()`.
- Keeps vertical centering logic intact.
- Preserves the previous behavior of skipping empty newline-only segments.

Why:
- `drawString()` previously allocated and copied the full input string on every call.
- Rendering now avoids heap allocation entirely for this path.

## Behavior

Expected behavior is unchanged aside from allocation strategy:
- ST7789 rendering still produces the same converted scanline data.
- `OLEDDisplay::drawString()` still renders the same logical lines and alignment behavior as before.

## Benefit

These changes remove unnecessary heap allocation from two UI rendering paths.

- Lower runtime allocation churn during display updates.
- Reduced risk of heap fragmentation on long-running embedded devices.
- More predictable rendering performance, especially on frequent redraw paths.
- Same behavior with less transient memory traffic.