### PR TITLE
round af/rx-/txdelay to 3 decimal places

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -741,7 +741,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     int dc_frac = (int)((dc - dc_int) * 10.0f + 0.5f);
     sprintf(reply, "> %d.%d%%", dc_int, dc_frac);
   } else if (memcmp(config, "af", 2) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->airtime_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->airtime_factor));
   } else if (memcmp(config, "int.thresh", 10) == 0) {
     sprintf(reply, "> %d", (uint32_t) _prefs->interference_threshold);
   } else if (memcmp(config, "agc.reset.interval", 18) == 0) {
@@ -779,13 +779,13 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(bw, StrHelper::ftoa3(_prefs->bw));
     sprintf(reply, "> %s,%s,%d,%d", freq, bw, (uint32_t)_prefs->sf, (uint32_t)_prefs->cr);
   } else if (memcmp(config, "rxdelay", 7) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->rx_delay_base));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->rx_delay_base));
   } else if (memcmp(config, "txdelay", 7) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->tx_delay_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->tx_delay_factor));
   } else if (memcmp(config, "flood.max", 9) == 0) {
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
   } else if (memcmp(config, "direct.txdelay", 14) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->direct_tx_delay_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->direct_tx_delay_factor));
   } else if (memcmp(config, "owner.info", 10) == 0) {
     auto start = reply;
     *reply++ = '>';

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -789,7 +789,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     int dc_frac = (int)((dc - dc_int) * 10.0f + 0.5f);
     sprintf(reply, "> %d.%d%%", dc_int, dc_frac);
   } else if (memcmp(config, "af", 2) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->airtime_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->airtime_factor));
   } else if (memcmp(config, "int.thresh", 10) == 0) {
     sprintf(reply, "> %d", (uint32_t) _prefs->interference_threshold);
   } else if (memcmp(config, "cad", 3) == 0) {
@@ -833,9 +833,9 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(bw, StrHelper::ftoa3(_prefs->bw));
     sprintf(reply, "> %s,%s,%d,%d", freq, bw, (uint32_t)_prefs->sf, (uint32_t)_prefs->cr);
   } else if (memcmp(config, "rxdelay", 7) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->rx_delay_base));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->rx_delay_base));
   } else if (memcmp(config, "txdelay", 7) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->tx_delay_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->tx_delay_factor));
   } else if (memcmp(config, "flood.max.advert", 16) == 0) {
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max_advert);
   } else if (memcmp(config, "flood.max.unscoped", 18) == 0) {
@@ -843,7 +843,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (memcmp(config, "flood.max", 9) == 0) {
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
   } else if (memcmp(config, "direct.txdelay", 14) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->direct_tx_delay_factor));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->direct_tx_delay_factor));
   } else if (memcmp(config, "owner.info", 10) == 0) {
     auto start = reply;
     *reply++ = '>';

--- a/src/helpers/CommonRadioPrefs.cpp
+++ b/src/helpers/CommonRadioPrefs.cpp
@@ -63,7 +63,7 @@ bool CommonRadioPrefs::handleCommand(const char* command, uint32_t sender_timest
   }
 
   if (strcmp(command, "get af") == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(getAirtimeFactor()));
+    sprintf(reply, "> %s", StrHelper::ftoa3(getAirtimeFactor()));
     return true;
   }
   if (memcmp(command, "set af ", 7) == 0) {
@@ -140,7 +140,7 @@ bool CommonRadioPrefs::handleCommand(const char* command, uint32_t sender_timest
   }
 
   if (strcmp(command, "get rxdelay") == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(getRxDelay()));
+    sprintf(reply, "> %s", StrHelper::ftoa3(getRxDelay()));
     return true;
   }
   if (memcmp(command, "set rxdelay ", 12) == 0) {
@@ -191,7 +191,7 @@ bool CommonRadioPrefs::handleCommand(const char* command, uint32_t sender_timest
   }
 
   if (strcmp(command, "get txdelay") == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(getFloodTxDelay()));
+    sprintf(reply, "> %s", StrHelper::ftoa3(getFloodTxDelay()));
     return true;
   }
   if (memcmp(command, "set txdelay ", 12) == 0) {
@@ -206,7 +206,7 @@ bool CommonRadioPrefs::handleCommand(const char* command, uint32_t sender_timest
   }
 
   if (strcmp(command, "get direct.txdelay") == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(getDirectTxDelay()));
+    sprintf(reply, "> %s", StrHelper::ftoa3(getDirectTxDelay()));
     return true;
   }
   if (memcmp(command, "set direct.txdelay ", 19) == 0) {


### PR DESCRIPTION
Minor nit to fix this:

<img width="171" height="101" alt="image" src="https://github.com/user-attachments/assets/009484d4-ee3d-41b3-b6e8-1cc5df906411" />

7 decimals precision is required for frequency get/set but not so relevant for the delays/af etc.