### PR TITLE
Add support for Sensirion SHT3X

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -124,6 +124,7 @@ build_flags =
   -D ENV_INCLUDE_BME280=1
   -D ENV_INCLUDE_BMP280=1
   -D ENV_INCLUDE_SHTC3=1
+  -D ENV_INCLUDE_SHT3X=1
   -D ENV_INCLUDE_SHT4X=1
   -D ENV_INCLUDE_LPS22HB=1
   -D ENV_INCLUDE_INA3221=1
@@ -143,6 +144,7 @@ lib_deps =
   adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit BMP280 Library @ ^2.6.8
   adafruit/Adafruit SHTC3 Library @ ^1.0.1
+  sensirion/Sensirion I2C SHT3x @ ^1.0.1
   sensirion/Sensirion I2C SHT4x @ ^1.1.2
   arduino-libraries/Arduino_LPS22HB @ ^1.0.2
   adafruit/Adafruit MLX90614 Library @ ^2.1.5

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -50,6 +50,12 @@ static Adafruit_BMP280 BMP280(TELEM_WIRE);
 static Adafruit_SHTC3 SHTC3;
 #endif
 
+#if ENV_INCLUDE_SHT3X
+#define TELEM_SHT3X_ADDRESS 0x44  //Addresses with 0x44 (default) and 0x45 are possible
+#include <SensirionI2cSht3x.h>
+static SensirionI2cSht3x SHT3X;
+#endif
+
 #if ENV_INCLUDE_SHT4X
 #define TELEM_SHT4X_ADDRESS 0x44  //0x44 - 0x46
 #include <SensirionI2cSht4x.h>
@@ -228,6 +234,19 @@ bool EnvironmentSensorManager::begin() {
   }
   #endif
 
+  #if ENV_INCLUDE_SHT3X
+  SHT3X.begin(*TELEM_WIRE, TELEM_SHT3X_ADDRESS);
+  uint16_t aStatusRegister = 0u;
+  int16_t sht3x_error;
+  sht3x_error = SHT3X.readStatusRegister(aStatusRegister);
+  if (sht3x_error == 0) {
+    MESH_DEBUG_PRINTLN("Found SHT3X at address: %02X", TELEM_SHT3X_ADDRESS);
+    SHT3X_initialized = true;
+  } else {
+    SHT3X_initialized = false;
+    MESH_DEBUG_PRINTLN("SHT3X was not found at I2C address %02X", TELEM_SHT3X_ADDRESS);
+  }
+  #endif
 
   #if ENV_INCLUDE_SHT4X
   SHT4X.begin(*TELEM_WIRE, TELEM_SHT4X_ADDRESS);
@@ -391,6 +410,18 @@ bool EnvironmentSensorManager::querySensors(uint8_t requester_permissions, Cayen
 
       telemetry.addTemperature(TELEM_CHANNEL_SELF, temp.temperature);
       telemetry.addRelativeHumidity(TELEM_CHANNEL_SELF, humidity.relative_humidity);
+    }
+    #endif
+
+    #if ENV_INCLUDE_SHT3X
+    if (SHT3X_initialized) {
+      float sht3x_humidity, sht3x_temperature;
+      int16_t sht3x_error;
+      sht3x_error = SHT3X.measureSingleShot(REPEATABILITY_MEDIUM, false, sht3x_temperature, sht3x_humidity);
+      if (sht3x_error == 0) {
+        telemetry.addTemperature(TELEM_CHANNEL_SELF, sht3x_temperature);
+        telemetry.addRelativeHumidity(TELEM_CHANNEL_SELF, sht3x_humidity);
+      }
     }
     #endif
 

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -236,9 +236,9 @@ bool EnvironmentSensorManager::begin() {
 
   #if ENV_INCLUDE_SHT3X
   SHT3X.begin(*TELEM_WIRE, TELEM_SHT3X_ADDRESS);
-  uint16_t aStatusRegister = 0u;
+  uint16_t SHT3XStatusRegister = 0u;
   int16_t sht3x_error;
-  sht3x_error = SHT3X.readStatusRegister(aStatusRegister);
+  sht3x_error = SHT3X.readStatusRegister(SHT3XStatusRegister);
   if (sht3x_error == 0) {
     MESH_DEBUG_PRINTLN("Found SHT3X at address: %02X", TELEM_SHT3X_ADDRESS);
     SHT3X_initialized = true;

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -19,6 +19,7 @@ protected:
   bool LPS22HB_initialized = false;
   bool MLX90614_initialized = false;
   bool VL53L0X_initialized = false;
+  bool SHT3X_initialized = false;
   bool SHT4X_initialized = false;
   bool BME680_initialized = false;
   bool BMP085_initialized = false;


### PR DESCRIPTION
Adds support for Sensirion SHT-3X sensors. Tested with SHT-31 and a Heltec-V3 sensor:
<img width="1080" height="2124" alt="Screenshot_20260313_230001_MeshCore" src="https://github.com/user-attachments/assets/88c795f9-8bf6-4b04-9e7b-612af3f94665" />

This PR should address #565 and #1849