### PR TITLE
Increase MAX_FRAME_SIZE by 4 bytes

### DIFF
--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -2,7 +2,7 @@
 
 #include <Arduino.h>
 
-#define MAX_FRAME_SIZE  172
+#define MAX_FRAME_SIZE  176   // +4 for transport codes (region scoping)
 
 class BaseSerialInterface {
 protected:


### PR DESCRIPTION
When a region is set, transport codes add 4 bytes to the wire format. For longer flood messages (~133+ chars for 14 char username), this pushes 1-hop repeat packets past the logRxRaw() limit of MAX_FRAME_SIZE - 3 (169 bytes). The raw packet gets silently dropped, so the companion app never sees repeats and can't show "heard repeats" for those messages.

Shorter messages and messages without a region set are unaffected because they stay under the limit.

Fix: bump MAX_FRAME_SIZE from 172 to 176 (the size of the transport code field). All frame buffers and size checks reference this constant so nothing else needs to change.

Memory cost is ~1 KB worst case across all queue buffers — negligible on all platforms.

This is the easiest fix for now without dropping region scoped messages by 10-16 bytes at worst.

Confirmed this fixes it for companions. First message is 1 byte over the limit with 173 bytes, second message is at the limit with 172 bytes, third message is after flashing with this fix and stays under 176 byte limit.

<img width="1080" height="1179" alt="image" src="https://github.com/user-attachments/assets/196f63e7-77f3-4f36-85a6-61505acec47d" />
