### PR TITLE
Bugfix: BaseChatMesh has inconsistent use of multi-byte paths

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -477,23 +477,23 @@ bool MyMesh::allowPacketForward(const mesh::Packet* packet) {
 void MyMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   // TODO: dynamic send_scope, depending on recipient and current 'home' Region
   if (send_scope.isNull()) {
-    sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
+    sendFlood(pkt, delay_millis, getPathHashSize());
   } else {
     uint16_t codes[2];
     codes[0] = send_scope.calcTransportCode(pkt);
     codes[1] = 0;  // REVISIT: set to 'home' Region, for sender/return region?
-    sendFlood(pkt, codes, delay_millis, _prefs.path_hash_mode + 1);
+    sendFlood(pkt, codes, delay_millis, getPathHashSize());
   }
 }
 void MyMesh::sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis) {
   // TODO: have per-channel send_scope
   if (send_scope.isNull()) {
-    sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
+    sendFlood(pkt, delay_millis, getPathHashSize());
   } else {
     uint16_t codes[2];
     codes[0] = send_scope.calcTransportCode(pkt);
     codes[1] = 0;  // REVISIT: set to 'home' Region, for sender/return region?
-    sendFlood(pkt, codes, delay_millis, _prefs.path_hash_mode + 1);
+    sendFlood(pkt, codes, delay_millis, getPathHashSize());
   }
 }
 
@@ -1120,7 +1120,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     if (pkt) {
       if (len >= 2 && cmd_frame[1] == 1) { // optional param (1 = flood, 0 = zero hop)
         unsigned long delay_millis = 0;
-        sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
+        sendFlood(pkt, delay_millis, getPathHashSize());
       } else {
         sendZeroHop(pkt);
       }

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -112,6 +112,7 @@ protected:
   bool filterRecvFloodPacket(mesh::Packet* packet) override;
   bool allowPacketForward(const mesh::Packet* packet) override;
 
+  uint8_t getPathHashSize() const override { return _prefs.path_hash_mode + 1; }
   void sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis=0) override;
   void sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis=0) override;
 

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -67,12 +67,15 @@ struct NodePrefs {  // persisted to file
   double node_lat, node_lon;
   float freq;
   int8_t tx_power_dbm;
-  uint8_t unused[3];
+  uint8_t path_hash_mode;
+  uint8_t unused[2];
 };
 
 class MyMesh : public BaseChatMesh, ContactVisitor {
   FILESYSTEM* _fs;
   NodePrefs _prefs;
+
+  uint8_t getPathHashSize() const override { return _prefs.path_hash_mode + 1; }
   uint32_t expected_ack_crc;
   ChannelDetails* _public;
   unsigned long last_msg_sent;
@@ -368,7 +371,7 @@ public:
   void sendSelfAdvert(int delay_millis) {
     auto pkt = createSelfAdvert(_prefs.node_name, _prefs.node_lat, _prefs.node_lon);
     if (pkt) {
-      sendFlood(pkt, delay_millis);
+      sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
     }
   }
 
@@ -411,7 +414,7 @@ public:
       int len = strlen((char *) &temp[5]);
       auto pkt = createGroupDatagram(PAYLOAD_TYPE_GRP_TXT, _public->channel, temp, 5 + len);
       if (pkt) {
-        sendFlood(pkt);
+        sendFlood(pkt, 0, _prefs.path_hash_mode + 1);
         Serial.println("   Sent.");
       } else {
         Serial.println("   ERROR: unable to send");

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -414,7 +414,7 @@ public:
       int len = strlen((char *) &temp[5]);
       auto pkt = createGroupDatagram(PAYLOAD_TYPE_GRP_TXT, _public->channel, temp, 5 + len);
       if (pkt) {
-        sendFlood(pkt, 0, getPathHashSize());
+        sendFlood(pkt, 0u, getPathHashSize());
         Serial.println("   Sent.");
       } else {
         Serial.println("   ERROR: unable to send");

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -371,7 +371,7 @@ public:
   void sendSelfAdvert(int delay_millis) {
     auto pkt = createSelfAdvert(_prefs.node_name, _prefs.node_lat, _prefs.node_lon);
     if (pkt) {
-      sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
+      sendFlood(pkt, delay_millis, getPathHashSize());
     }
   }
 
@@ -414,7 +414,7 @@ public:
       int len = strlen((char *) &temp[5]);
       auto pkt = createGroupDatagram(PAYLOAD_TYPE_GRP_TXT, _public->channel, temp, 5 + len);
       if (pkt) {
-        sendFlood(pkt, 0, _prefs.path_hash_mode + 1);
+        sendFlood(pkt, 0, getPathHashSize());
         Serial.println("   Sent.");
       } else {
         Serial.println("   ERROR: unable to send");

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -10,10 +10,10 @@
 #endif
 
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
-  sendFlood(pkt, delay_millis);
+  sendFlood(pkt, delay_millis, getPathHashSize());
 }
 void BaseChatMesh::sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis) {
-  sendFlood(pkt, delay_millis);
+  sendFlood(pkt, delay_millis, getPathHashSize());
 }
 
 mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name) {

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -115,6 +115,7 @@ protected:
   virtual void onContactResponse(const ContactInfo& contact, const uint8_t* data, uint8_t len) = 0;
   virtual void handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len);
 
+  virtual uint8_t getPathHashSize() const = 0;
   virtual void sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis=0);
   virtual void sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis=0);
 


### PR DESCRIPTION
I submitted another PR (#2035) to fix a bug with auto-adverts not being published with multi-byte paths on repeaters and room servers. My original PR setup was bad, so @ripplebiz applied the patch directly to dev branch instead. 

There was some code left behind in the PR that wasn't merged related to classes inheriting `BaseChatMesh` (Companion, Simple Secure Chat etc). The base function `sendFloodScoped` was defaulting to a single byte path. If this function was not overridden by subclasses, then the behaviour would persist unknowingly into those classes. In this case, only Simple Secure Chat was affected, Companion had overridden the behaviour but had the `path_hash_mode + 1` convention mentioned in 5 places.

This PR introduces a new virtual helper function `getPathHashSize()` in the `BaseChatMesh` class so that all subclasses have to properly implement the multi-byte support. I have updated the subclasses to be in-line with this approach too. Hopefully it prevents any future bugs by obscurity and standardises the implementation for future subclasses too.

I'm open to commentary from community/reviewers on whether this `getPathHashSize()` function makes sense to be in all the firmwares, because there are 7 occurences of the `path_hash_mode + 1` function being used elsewhere. At least building out the helper function reduces the risk of not being consistent across the codebase when future changes happen. Thoughts?