### PR TITLE
Move ESP-NOW bridge RX processing out of callbacks

### DIFF
--- a/src/helpers/bridges/ESPNowBridge.cpp
+++ b/src/helpers/bridges/ESPNowBridge.cpp
@@ -22,12 +22,17 @@ void ESPNowBridge::send_cb(const uint8_t *mac, esp_now_send_status_t status) {
 }
 
 ESPNowBridge::ESPNowBridge(NodePrefs *prefs, mesh::PacketManager *mgr, mesh::RTCClock *rtc)
-    : BridgeBase(prefs, mgr, rtc), _rx_buffer_pos(0) {
+    : BridgeBase(prefs, mgr, rtc), _rx_read_idx(0), _rx_write_idx(0), _rx_count(0), _rx_drop_count(0), _rx_lock(portMUX_INITIALIZER_UNLOCKED) {
   _instance = this;
 }
 
 void ESPNowBridge::begin() {
   BRIDGE_DEBUG_PRINTLN("Initializing...\n");
+
+  _rx_read_idx = 0;
+  _rx_write_idx = 0;
+  _rx_count = 0;
+  _rx_drop_count = 0;
 
   // Initialize WiFi in station mode
   WiFi.mode(WIFI_STA);
@@ -87,10 +92,19 @@ void ESPNowBridge::end() {
 
   // Update bridge state
   _initialized = false;
+
+  portENTER_CRITICAL(&_rx_lock);
+  _rx_read_idx = 0;
+  _rx_write_idx = 0;
+  _rx_count = 0;
+  portEXIT_CRITICAL(&_rx_lock);
 }
 
 void ESPNowBridge::loop() {
-  // Nothing to do here - ESP-NOW is callback based
+  PendingFrame frame;
+  while (popPendingFrame(frame)) {
+    processReceivedFrame(frame.buf, frame.len);
+  }
 }
 
 void ESPNowBridge::xorCrypt(uint8_t *data, size_t len) {
@@ -101,6 +115,12 @@ void ESPNowBridge::xorCrypt(uint8_t *data, size_t len) {
 }
 
 void ESPNowBridge::onDataRecv(const uint8_t *mac, const uint8_t *data, int32_t len) {
+  (void)mac;
+
+  if (_initialized == false) {
+    return;
+  }
+
   // Ignore packets that are too small to contain header + checksum
   if (len < (BRIDGE_MAGIC_SIZE + BRIDGE_CHECKSUM_SIZE)) {
     BRIDGE_DEBUG_PRINTLN("RX packet too small, len=%d\n", len);
@@ -110,6 +130,42 @@ void ESPNowBridge::onDataRecv(const uint8_t *mac, const uint8_t *data, int32_t l
   // Validate total packet size
   if (len > MAX_ESPNOW_PACKET_SIZE) {
     BRIDGE_DEBUG_PRINTLN("RX packet too large, len=%d\n", len);
+    return;
+  }
+
+  portENTER_CRITICAL(&_rx_lock);
+  if (_rx_count >= RX_QUEUE_SIZE) {
+    _rx_drop_count++;
+    portEXIT_CRITICAL(&_rx_lock);
+    BRIDGE_DEBUG_PRINTLN("RX queue full, dropping frame len=%d (drops=%lu)\n", len, (unsigned long)_rx_drop_count);
+    return;
+  }
+
+  PendingFrame &slot = _rx_queue[_rx_write_idx];
+  slot.len = len;
+  memcpy(slot.buf, data, len);
+  _rx_write_idx = (_rx_write_idx + 1) % RX_QUEUE_SIZE;
+  _rx_count++;
+  portEXIT_CRITICAL(&_rx_lock);
+}
+
+bool ESPNowBridge::popPendingFrame(PendingFrame &frame) {
+  bool have_frame = false;
+  portENTER_CRITICAL(&_rx_lock);
+  if (_rx_count > 0) {
+    frame = _rx_queue[_rx_read_idx];
+    _rx_read_idx = (_rx_read_idx + 1) % RX_QUEUE_SIZE;
+    _rx_count--;
+    have_frame = true;
+  }
+  portEXIT_CRITICAL(&_rx_lock);
+  return have_frame;
+}
+
+void ESPNowBridge::processReceivedFrame(const uint8_t *data, size_t len) {
+  // Ignore packets that are too small to contain header + checksum
+  if (len < (BRIDGE_MAGIC_SIZE + BRIDGE_CHECKSUM_SIZE)) {
+    BRIDGE_DEBUG_PRINTLN("RX packet too small, len=%d\n", (int)len);
     return;
   }
 

--- a/src/helpers/bridges/ESPNowBridge.h
+++ b/src/helpers/bridges/ESPNowBridge.h
@@ -3,6 +3,8 @@
 #include "MeshCore.h"
 #include "esp_now.h"
 #include "helpers/bridges/BridgeBase.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
 
 #ifdef WITH_ESPNOW_BRIDGE
 
@@ -63,11 +65,18 @@ private:
    */
   static const size_t MAX_PAYLOAD_SIZE = MAX_ESPNOW_PACKET_SIZE - (BRIDGE_MAGIC_SIZE + BRIDGE_CHECKSUM_SIZE);
 
-  /** Buffer for receiving ESP-NOW packets */
-  uint8_t _rx_buffer[MAX_ESPNOW_PACKET_SIZE];
+  struct PendingFrame {
+    uint16_t len;
+    uint8_t buf[MAX_ESPNOW_PACKET_SIZE];
+  };
 
-  /** Current position in receive buffer */
-  size_t _rx_buffer_pos;
+  static const uint8_t RX_QUEUE_SIZE = 4;
+  PendingFrame _rx_queue[RX_QUEUE_SIZE];
+  uint8_t _rx_read_idx;
+  uint8_t _rx_write_idx;
+  uint8_t _rx_count;
+  uint32_t _rx_drop_count;
+  portMUX_TYPE _rx_lock;
 
   /**
    * Performs XOR encryption/decryption of data
@@ -91,6 +100,10 @@ private:
    * @param len Length of received data
    */
   void onDataRecv(const uint8_t *mac, const uint8_t *data, int32_t len);
+
+  void processReceivedFrame(const uint8_t *data, size_t len);
+
+  bool popPendingFrame(PendingFrame &frame);
 
   /**
    * ESP-NOW send callback


### PR DESCRIPTION
## Summary

This fixes the ESP-NOW bridge receive path so callback context no longer allocates mesh packets, mutates duplicate-tracking state, or touches the packet manager queues.

## Problem

`ESPNowBridge::recv_cb()` currently calls into `onDataRecv()`, which fully parses incoming frames and then:

- allocates `mesh::Packet` objects
- calls `_seen_packets.hasSeen()`
- queues inbound packets via `_mgr->queueInbound()`
- frees packets on failure

That work runs from the ESP-NOW callback path, while the main dispatcher loop is simultaneously using the same `PacketManager` and duplicate tables. `StaticPoolPacketManager` is not synchronized; it mutates raw arrays and counters directly. So the bridge was crossing the packet ownership boundary from callback context and could race the main loop.

This is the exact class of issue previously identified in thread-safety review: heavy callback-side processing over shared queue state.

## Fix

This PR changes the bridge RX flow to a bounded mailbox model:

- the ESP-NOW callback now only validates basic size, copies the raw frame into a small fixed queue, and returns
- a short critical section protects queue head/tail/count publication
- `ESPNowBridge::loop()` now drains queued raw frames in normal main-loop context
- decryption, checksum validation, `Packet` allocation, duplicate checking, and `_mgr->queueInbound()` all happen from the main loop instead of callback context
- overflow is handled explicitly with drop accounting and debug logging

## Why this fixes it

After this change, callback context never touches:

- `StaticPoolPacketManager`
- `SimpleMeshTables`
- mesh packet allocation/free paths

Those shared ownership structures are back to being single-context for this bridge implementation, which removes the queue corruption / duplicate-table race that existed before.

## Validation

Built successfully:

- `Heltec_v2_repeater_bridge_espnow`
