### PR TITLE
Synchronize ESP32 BLE serial frame queues

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -10,6 +10,77 @@
 
 #define ADVERT_RESTART_DELAY  1000   // millis
 
+void SerialBLEInterface::clearBuffers() {
+  portENTER_CRITICAL(&_queue_lock);
+  recv_queue_read_idx = recv_queue_write_idx = recv_queue_len = 0;
+  send_queue_read_idx = send_queue_write_idx = send_queue_len = 0;
+  portEXIT_CRITICAL(&_queue_lock);
+}
+
+bool SerialBLEInterface::enqueueRecvFrame(const uint8_t src[], size_t len) {
+  bool queued = false;
+
+  portENTER_CRITICAL(&_queue_lock);
+  if (recv_queue_len < FRAME_QUEUE_SIZE) {
+    Frame *frame = &recv_queue[recv_queue_write_idx];
+    frame->len = len;
+    memcpy(frame->buf, src, len);
+    recv_queue_write_idx = (recv_queue_write_idx + 1) % FRAME_QUEUE_SIZE;
+    recv_queue_len++;
+    queued = true;
+  }
+  portEXIT_CRITICAL(&_queue_lock);
+
+  return queued;
+}
+
+bool SerialBLEInterface::dequeueRecvFrame(Frame *frame) {
+  bool found = false;
+
+  portENTER_CRITICAL(&_queue_lock);
+  if (recv_queue_len > 0) {
+    *frame = recv_queue[recv_queue_read_idx];
+    recv_queue_read_idx = (recv_queue_read_idx + 1) % FRAME_QUEUE_SIZE;
+    recv_queue_len--;
+    found = true;
+  }
+  portEXIT_CRITICAL(&_queue_lock);
+
+  return found;
+}
+
+bool SerialBLEInterface::enqueueSendFrame(const uint8_t src[], size_t len) {
+  bool queued = false;
+
+  portENTER_CRITICAL(&_queue_lock);
+  if (send_queue_len < FRAME_QUEUE_SIZE) {
+    Frame *frame = &send_queue[send_queue_write_idx];
+    frame->len = len;
+    memcpy(frame->buf, src, len);
+    send_queue_write_idx = (send_queue_write_idx + 1) % FRAME_QUEUE_SIZE;
+    send_queue_len++;
+    queued = true;
+  }
+  portEXIT_CRITICAL(&_queue_lock);
+
+  return queued;
+}
+
+bool SerialBLEInterface::dequeueSendFrame(Frame *frame) {
+  bool found = false;
+
+  portENTER_CRITICAL(&_queue_lock);
+  if (send_queue_len > 0) {
+    *frame = send_queue[send_queue_read_idx];
+    send_queue_read_idx = (send_queue_read_idx + 1) % FRAME_QUEUE_SIZE;
+    send_queue_len--;
+    found = true;
+  }
+  portEXIT_CRITICAL(&_queue_lock);
+
+  return found;
+}
+
 void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code) {
   _pin_code = pin_code;
 
@@ -118,12 +189,8 @@ void SerialBLEInterface::onWrite(BLECharacteristic* pCharacteristic, esp_ble_gat
 
   if (len > MAX_FRAME_SIZE) {
     BLE_DEBUG_PRINTLN("ERROR: onWrite(), frame too big, len=%d", len);
-  } else if (recv_queue_len >= FRAME_QUEUE_SIZE) {
+  } else if (!enqueueRecvFrame(rxValue, len)) {
     BLE_DEBUG_PRINTLN("ERROR: onWrite(), recv_queue is full!");
-  } else {
-    recv_queue[recv_queue_len].len = len;
-    memcpy(recv_queue[recv_queue_len].buf, rxValue, len);
-    recv_queue_len++;
   }
 }
 
@@ -166,14 +233,10 @@ size_t SerialBLEInterface::writeFrame(const uint8_t src[], size_t len) {
   }
 
   if (deviceConnected && len > 0) {
-    if (send_queue_len >= FRAME_QUEUE_SIZE) {
+    if (!enqueueSendFrame(src, len)) {
       BLE_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
       return 0;
     }
-
-    send_queue[send_queue_len].len = len;  // add to send queue
-    memcpy(send_queue[send_queue_len].buf, src, len);
-    send_queue_len++;
 
     return len;
   }
@@ -187,31 +250,22 @@ bool SerialBLEInterface::isWriteBusy() const {
 }
 
 size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
-  if (send_queue_len > 0   // first, check send queue
-    && millis() >= _last_write + BLE_WRITE_MIN_INTERVAL    // space the writes apart
-  ) {
+  Frame frame;
+
+  if (millis() >= _last_write + BLE_WRITE_MIN_INTERVAL && dequeueSendFrame(&frame)) {
     _last_write = millis();
-    pTxCharacteristic->setValue(send_queue[0].buf, send_queue[0].len);
+    pTxCharacteristic->setValue(frame.buf, frame.len);
     pTxCharacteristic->notify();
 
-    BLE_DEBUG_PRINTLN("writeBytes: sz=%d, hdr=%d", (uint32_t)send_queue[0].len, (uint32_t) send_queue[0].buf[0]);
-
-    send_queue_len--;
-    for (int i = 0; i < send_queue_len; i++) {   // delete top item from queue
-      send_queue[i] = send_queue[i + 1];
-    }
+    BLE_DEBUG_PRINTLN("writeBytes: sz=%d, hdr=%d", (uint32_t)frame.len, (uint32_t) frame.buf[0]);
   }
 
-  if (recv_queue_len > 0) {   // check recv queue
-    size_t len = recv_queue[0].len;   // take from top of queue
-    memcpy(dest, recv_queue[0].buf, len);
+  if (dequeueRecvFrame(&frame)) {
+    size_t len = frame.len;
+    memcpy(dest, frame.buf, len);
 
     BLE_DEBUG_PRINTLN("readBytes: sz=%d, hdr=%d", len, (uint32_t) dest[0]);
 
-    recv_queue_len--;
-    for (int i = 0; i < recv_queue_len; i++) {   // delete top item from queue
-      recv_queue[i] = recv_queue[i + 1];
-    }
     return len;
   }
 

--- a/src/helpers/esp32/SerialBLEInterface.h
+++ b/src/helpers/esp32/SerialBLEInterface.h
@@ -5,6 +5,8 @@
 #include <BLEServer.h>
 #include <BLEUtils.h>
 #include <BLE2902.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
 
 class SerialBLEInterface : public BaseSerialInterface, BLESecurityCallbacks, BLEServerCallbacks, BLECharacteristicCallbacks {
   BLEServer *pServer;
@@ -24,12 +26,21 @@ class SerialBLEInterface : public BaseSerialInterface, BLESecurityCallbacks, BLE
   };
 
   #define FRAME_QUEUE_SIZE  4
-  int recv_queue_len;
   Frame recv_queue[FRAME_QUEUE_SIZE];
-  int send_queue_len;
   Frame send_queue[FRAME_QUEUE_SIZE];
+  uint8_t recv_queue_read_idx;
+  uint8_t recv_queue_write_idx;
+  uint8_t recv_queue_len;
+  uint8_t send_queue_read_idx;
+  uint8_t send_queue_write_idx;
+  uint8_t send_queue_len;
+  portMUX_TYPE _queue_lock;
 
-  void clearBuffers() { recv_queue_len = 0; send_queue_len = 0; }
+  void clearBuffers();
+  bool enqueueRecvFrame(const uint8_t src[], size_t len);
+  bool dequeueRecvFrame(Frame *frame);
+  bool enqueueSendFrame(const uint8_t src[], size_t len);
+  bool dequeueSendFrame(Frame *frame);
 
 protected:
   // BLESecurityCallbacks methods
@@ -58,7 +69,9 @@ public:
     _isEnabled = false;
     _last_write = 0;
     last_conn_id = 0;
-    send_queue_len = recv_queue_len = 0;
+    recv_queue_read_idx = recv_queue_write_idx = recv_queue_len = 0;
+    send_queue_read_idx = send_queue_write_idx = send_queue_len = 0;
+    _queue_lock = portMUX_INITIALIZER_UNLOCKED;
   }
 
   /**


### PR DESCRIPTION
## Summary
- replace the ESP32 BLE serial send/receive queues with bounded ring buffers
- protect queue head/tail publication with a small ESP32 critical section
- stop shifting queue arrays in `checkRecvFrame()` while callbacks can append to them

## Issue
`SerialBLEInterface` currently shares `recv_queue`, `send_queue`, and their length counters between BLE callback context and the main loop.

The problematic pattern is:
- `onWrite()` appends a received BLE frame directly into `recv_queue` and increments `recv_queue_len`
- `writeFrame()` appends outbound frames directly into `send_queue` and increments `send_queue_len`
- `checkRecvFrame()` consumes the first element of each queue and compacts the remaining array entries in place

That means the BLE callback can be writing queue entries and lengths at the same time that the main loop is reading and shifting those same arrays. On ESP32, those BLE callbacks are not guaranteed to run in the same execution context as the app loop, so the current code has a real producer/consumer race:
- a callback can append while the loop is compacting the array
- queue length can change while the loop is consuming the front element
- partially moved or overwritten frames can be observed under load

## Fix
This change keeps the existing queue sizes and behavior, but changes the queue implementation so callback and loop code stop mutating the same array layout concurrently.

Specifically:
- both send and receive paths now use bounded ring buffers instead of "array plus compaction"
- queue reads and writes publish head/tail/count updates inside a short `portENTER_CRITICAL` / `portEXIT_CRITICAL` section
- `onWrite()` only enqueues a complete received frame
- `writeFrame()` only enqueues a complete outbound frame
- `checkRecvFrame()` dequeues stable frames and no longer shifts queue contents in place

## Why this fixes it
The old race existed because the producer and consumer both rewrote the queue storage layout. Once `checkRecvFrame()` removed the first element, it had to copy every remaining entry down by one slot, which directly overlapped with callback-time appends.

With the ring-buffer handoff:
- producers only write the next free slot and publish it atomically
- consumers only read the next committed slot and advance the read index atomically
- no in-place array compaction happens anymore

That removes the window where callback and loop code can corrupt each other's queue state or frame contents.

## Validation
- `pio run -e Heltec_v3_companion_radio_ble`
