### PR TITLE
Fix T1000-E sensor power pin mapping

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -69,10 +69,6 @@ public:
     #ifdef PIN_3V3_ACC_EN
         digitalWrite(PIN_3V3_ACC_EN, LOW);
     #endif
-    #ifdef SENSOR_EN
-        digitalWrite(SENSOR_EN, LOW);
-    #endif
-
     // set led on and wait for button release before poweroff
     #ifdef LED_PIN
     digitalWrite(LED_PIN, HIGH);

--- a/variants/t1000-e/t1000e_sensors.cpp
+++ b/variants/t1000-e/t1000e_sensors.cpp
@@ -72,7 +72,6 @@ float t1000e_get_temperature(void) {
   unsigned int ntc_v, vcc_v;
 
   digitalWrite(PIN_3V3_EN, HIGH);
-  digitalWrite(SENSOR_EN, HIGH);
   analogReference(AR_INTERNAL_3_0);
   analogReadResolution(12);
   delay(10);
@@ -80,7 +79,6 @@ float t1000e_get_temperature(void) {
   vcc_v = (rail_v > NTC_REF_VCC) ? NTC_REF_VCC : rail_v;
   ntc_v = (1000.0 * AREF_VOLTAGE * analogRead(TEMP_SENSOR)) / 4096;
   digitalWrite(PIN_3V3_EN, LOW);
-  digitalWrite(SENSOR_EN, LOW);
 
   return get_heater_temperature(vcc_v, ntc_v);
 }
@@ -90,13 +88,11 @@ uint32_t t1000e_get_light(void) {
   unsigned int lux_v = 0;
 
   digitalWrite(PIN_3V3_EN, HIGH);
-  digitalWrite(SENSOR_EN, HIGH);
   analogReference(AR_INTERNAL_3_0);
   analogReadResolution(12);
   delay(10);
   lux_v = 1000 * analogRead(LUX_SENSOR) * AREF_VOLTAGE / 4096;
   lux = get_light_lv(lux_v);
-  digitalWrite(SENSOR_EN, LOW);
   digitalWrite(PIN_3V3_EN, LOW);
 
   return lux;

--- a/variants/t1000-e/variant.cpp
+++ b/variants/t1000-e/variant.cpp
@@ -14,7 +14,7 @@ const uint32_t g_ADigitalPinMap[PINS_COUNT + 1] =
   1,  // P0.01
   2,  // P0.02, AIN0 BATTERY_PIN
   3,  // P0.03
-  4,  // P0.04, SENSOR_EN
+  4,  // P0.04
   5,  // P0.05, EXT_PWR_DETEC
   6,  // P0.06, PIN_BUTTON1
   7,  // P0.07, LORA_BUSY
@@ -77,7 +77,6 @@ void initVariant()
   pinMode(PIN_3V3_EN, OUTPUT);
   pinMode(PIN_3V3_ACC_EN, OUTPUT);
   pinMode(BUZZER_EN, OUTPUT);
-  pinMode(SENSOR_EN, OUTPUT);
   pinMode(GPS_EN, OUTPUT);
   pinMode(GPS_RESET, OUTPUT);
   pinMode(GPS_VRTC_EN, OUTPUT);
@@ -88,7 +87,6 @@ void initVariant()
   digitalWrite(PIN_3V3_EN, LOW);
   digitalWrite(PIN_3V3_ACC_EN, LOW);
   digitalWrite(BUZZER_EN, LOW);
-  digitalWrite(SENSOR_EN, LOW);
   digitalWrite(GPS_EN, LOW);
   digitalWrite(GPS_RESET, LOW);
   digitalWrite(GPS_VRTC_EN, LOW);

--- a/variants/t1000-e/variant.h
+++ b/variants/t1000-e/variant.h
@@ -120,7 +120,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Temp+Lux Sensor
 
-#define SENSOR_EN               (4)             // P0.4
 #define TEMP_SENSOR             (31)            // P0.31/AIN7
 #define LUX_SENSOR              (29)            // P0.29/AIN5
 


### PR DESCRIPTION
## Summary
- stop treating T1000-E `P0.04` as a sensor power-enable output
- remove the extra `SENSOR_EN` rail toggle from the T1000-E sensor path
- keep sensor power control on the documented `PIN_3V3_EN` / `P1.06` rail

## Issue
The current T1000-E variant defines two different sensor-power control signals:
- `PIN_3V3_EN = 38` (`P1.06`)
- `SENSOR_EN = 4` (`P0.04`)

The firmware actively drives both of them:
- `initVariant()` configures both as outputs and drives them low
- `t1000e_get_temperature()` and `t1000e_get_light()` drive both high before sampling
- `powerOff()` drives both low again

That is hard to reconcile with Seeed's newer official T1000-E pin table, which documents:
- `P1.06` as `Sensor VCC Enable`
- `P0.04` as `VCC voltage detect`

If that mapping is correct, the current variant is driving a voltage-detect input as if it were a rail-enable output.

## Authoritative source
Seeed Studio's newer official board page:
- https://wiki.seeedstudio.com/get_started_with_lorawan_tracker/

Relevant entries from the pin table:
- `P0.04` = `VCC voltage detect`
- `P1.06` = `Sensor VCC Enable`
- `P0.05` = `Charger insert detect`
- `P1.03` = `Charger State`

The older page at https://wiki.seeedstudio.com/t1000_e_intro/ is less complete and conflicts with this newer table.

## Fix
This change removes the stale `SENSOR_EN` definition and stops driving `P0.04` anywhere in the T1000-E implementation.

After this change:
- the board no longer configures `P0.04` as an output
- temp/light reads only toggle `PIN_3V3_EN`
- power-off no longer tries to drive an extra sensor-enable pin

## Why this fixes it
This keeps sensor rail control on the pin Seeed currently documents for that purpose (`P1.06`) and removes the most likely incorrect electrical behavior in the current tree: treating `P0.04` as an output control line.

It also avoids changing unrelated GPS, charging, or battery logic. The fix is intentionally narrow: remove the extra power-enable path that conflicts with the newer hardware documentation.

## Validation
- `pio run -e t1000e_companion_radio_ble`
