### PR TITLE
Align T1000-E charge detect pins with docs

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -11,6 +11,13 @@ protected:
 public:
   T1000eBoard() : NRF52Board("T1000E_OTA") {}
   void begin();
+  bool isExternalPowered() override {
+  #ifdef CHARGER_INSERT_DETECT
+    return digitalRead(CHARGER_INSERT_DETECT) == CHARGER_INSERT_ACTIVE || NRF52Board::isExternalPowered();
+  #else
+    return NRF52Board::isExternalPowered();
+  #endif
+  }
 
   uint16_t getBattMilliVolts() override {
   #ifdef BATTERY_PIN

--- a/variants/t1000-e/variant.cpp
+++ b/variants/t1000-e/variant.cpp
@@ -15,7 +15,7 @@ const uint32_t g_ADigitalPinMap[PINS_COUNT + 1] =
   2,  // P0.02, AIN0 BATTERY_PIN
   3,  // P0.03
   4,  // P0.04, SENSOR_EN
-  5,  // P0.05, EXT_PWR_DETEC
+  5,  // P0.05, CHARGER_INSERT_DETECT
   6,  // P0.06, PIN_BUTTON1
   7,  // P0.07, LORA_BUSY
   8,  // P0.08, GPS_VRTC_EN
@@ -45,7 +45,7 @@ const uint32_t g_ADigitalPinMap[PINS_COUNT + 1] =
   32, // P1.00
   33, // P1.01, LORA_DIO_1
   34, // P1.02
-  35, // P1.03, EXT_CHRG_DETECT
+  35, // P1.03, CHARGER_STATE_DETECT
   36, // P1.04
   37, // P1.05, LR1110_EN
   38, // P1.06, 3V3_EN PWR TO SENSORS
@@ -69,8 +69,8 @@ void initVariant()
   pinMode(BATTERY_PIN, INPUT);
   pinMode(TEMP_SENSOR, INPUT);
   pinMode(LUX_SENSOR, INPUT);
-  pinMode(EXT_CHRG_DETECT, INPUT);
-  pinMode(EXT_PWR_DETECT, INPUT);
+  pinMode(CHARGER_STATE_DETECT, INPUT);
+  pinMode(CHARGER_INSERT_DETECT, INPUT);
   pinMode(GPS_RESETB, INPUT);
   pinMode(PIN_BUTTON1, INPUT);
 

--- a/variants/t1000-e/variant.h
+++ b/variants/t1000-e/variant.h
@@ -25,8 +25,9 @@
 #define BATTERY_IMMUTABLE
 #define ADC_MULTIPLIER          (2.0F)
 
-#define EXT_CHRG_DETECT         (35)            // P1.3
-#define EXT_PWR_DETECT          (5)             // P0.5
+#define CHARGER_STATE_DETECT    (35)            // P1.3 Charger State
+#define CHARGER_INSERT_DETECT   (5)             // P0.5 Charger insert detect
+#define CHARGER_INSERT_ACTIVE   HIGH
 
 #define ADC_RESOLUTION          (14)
 #define BATTERY_SENSE_RES       (12)


### PR DESCRIPTION
## Summary
- rename the T1000-E charge-related pins to match Seeed's current pin table
- route the documented charger-insert signal into the existing `MainBoard::isExternalPowered()` API
- keep the change narrow to T1000-E board metadata and board power detection only

## Issue
The current T1000-E variant uses generic names:
- `EXT_PWR_DETECT`
- `EXT_CHRG_DETECT`

But Seeed's current official T1000-E hardware page is more specific:
- `P0.05` = charger insert detect
- `P1.03` = charger state

The current names blur those meanings, and the board-specific signals are not used by the existing board power API. As a result, T1000-E carries documented charge/power pins in the variant, but MeshCore still falls back to the generic nRF52 USB power check instead of the board-level detect line.

## Authoritative source
Seeed Studio's current official T1000-E page:
- https://wiki.seeedstudio.com/get_started_with_lorawan_tracker/

Relevant pin table entries:
- `P0.05` = `Charger insert detect`
- `P1.03` = `Charger State`
- `P1.04` = `Charger Done`

## Fix
This change:
- renames `EXT_PWR_DETECT` to `CHARGER_INSERT_DETECT`
- renames `EXT_CHRG_DETECT` to `CHARGER_STATE_DETECT`
- adds `CHARGER_INSERT_ACTIVE` as an explicit board macro
- overrides `T1000eBoard::isExternalPowered()` to use the charger-insert signal, while still falling back to the generic nRF52 USB register check

## Why this fixes it
This aligns the T1000-E variant naming with the current board documentation and lets MeshCore's existing board API use the board's own documented power-detect signal.

The fallback to `NRF52Board::isExternalPowered()` keeps the behavior compatible with the existing nRF52 path, while the T1000-E-specific override gives the board a more accurate hardware-specific answer when its charger-insert signal is available.

## Assumptions
The Seeed page names the `P0.05` signal as `Charger insert detect`, but it does not explicitly state polarity. This PR therefore makes the polarity explicit with:
- `CHARGER_INSERT_ACTIVE`

and defaults it to `HIGH`, which is the most likely interpretation for a detect line named this way. If board testing shows the polarity is inverted, that can be corrected in one place without changing the board API again.

## Validation
- `pio run -e t1000e_companion_radio_ble`
