### PR TITLE
Fix T1000-E button helper polarity

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -4,6 +4,10 @@
 #include <Arduino.h>
 #include <helpers/NRF52Board.h>
 
+#ifndef USER_BTN_PRESSED
+  #define USER_BTN_PRESSED LOW
+#endif
+
 class T1000eBoard : public NRF52BoardDCDC {
 protected:
   uint8_t btn_prev_state;
@@ -43,7 +47,7 @@ public:
     uint8_t v = digitalRead(BUTTON_PIN);
     if (v != btn_prev_state) {
       btn_prev_state = v;
-      return (v == LOW) ? 1 : -1;
+      return (v == USER_BTN_PRESSED) ? 1 : -1;
     }
   #endif
     return 0;


### PR DESCRIPTION
## Summary
- make `T1000eBoard::buttonStateChanged()` respect `USER_BTN_PRESSED`
- align the board helper with the T1000-E build flags and UI code
- keep the change limited to the stale helper implementation

## Issue
The T1000-E board definition already declares the user button as active-high in:
- `variants/t1000-e/platformio.ini`
  - `-D USER_BTN_PRESSED=HIGH`

But `T1000eBoard::buttonStateChanged()` still hardcodes `LOW` as the pressed state.

That leaves the board helper out of sync with the actual board configuration. Even if most T1000-E UI paths currently use the generic button abstraction instead of this helper, keeping the helper inverted is still a maintenance trap for any code that uses the board class directly.

## Fix
This change:
- adds the same `USER_BTN_PRESSED` fallback used elsewhere in the UI code
- replaces the hardcoded `LOW` comparison in `buttonStateChanged()` with `USER_BTN_PRESSED`

## Why this fixes it
It makes the board helper follow the same polarity source as the rest of the T1000-E build. That keeps the T1000-E board abstraction internally consistent and avoids future regressions where direct board-button callers would interpret presses backwards.

## Validation
- `pio run -e t1000e_companion_radio_ble`

## Testing Firmware
This change has been built into the testing firmware at [meshcore.eklhq.com](https://meshcore.eklhq.com/). Help with testing would be appreciated.
