### PR TITLE
fix(nrf52): add BLE security timeout and advertising watchdog

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -342,7 +342,18 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
   if (_isEnabled && _conn_handle != BLE_CONN_HANDLE_INVALID && !_isDeviceConnected) {
     if (_conn_pending_since > 0 && (now - _conn_pending_since) >= BLE_SECURITY_TIMEOUT_MS) {
       BLE_DEBUG_PRINTLN("SerialBLEInterface: security timeout, forcing disconnect");
+      // Reset _conn_pending_since so we don't call disconnect more than once in a half-connected state
+      _conn_pending_since = 0;
+
+      // Disconnect the current connection
       disconnect();
+
+      // Force an advertising health check
+      _last_health_check = now;
+      if (!isAdvertising()) {
+        BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising watchdog - advertising stopped, restarting");
+        Bluefruit.Advertising.start(0);
+      }
     }
   }
 

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -6,6 +6,7 @@
 
 // Magic numbers came from actual testing
 #define BLE_HEALTH_CHECK_INTERVAL  10000  // Advertising watchdog check every 10 seconds
+#define BLE_SECURITY_TIMEOUT_MS    15000  // Max time to wait for pairing/security to complete
 #define BLE_RETRY_THROTTLE_MS      250    // Throttle retries to 250ms when queue buildup detected
 
 // Connection parameters (units: interval=1.25ms, timeout=10ms)
@@ -29,6 +30,7 @@ void SerialBLEInterface::onConnect(uint16_t connection_handle) {
   if (instance) {
     instance->_conn_handle = connection_handle;
     instance->_isDeviceConnected = false;
+    instance->_conn_pending_since = millis();
     instance->clearBuffers();
   }
 }
@@ -39,6 +41,7 @@ void SerialBLEInterface::onDisconnect(uint16_t connection_handle, uint8_t reason
     if (instance->_conn_handle == connection_handle) {
       instance->_conn_handle = BLE_CONN_HANDLE_INVALID;
       instance->_isDeviceConnected = false;
+      instance->_conn_pending_since = 0;
       instance->clearBuffers();
     }
   }
@@ -49,6 +52,7 @@ void SerialBLEInterface::onSecured(uint16_t connection_handle) {
   if (instance) {
     if (instance->isValidConnection(connection_handle, true)) {
       instance->_isDeviceConnected = true;
+      instance->_conn_pending_since = 0;
       
       // Connection interval units: 1.25ms, supervision timeout units: 10ms
       // Apple: "The product will not read or use the parameters in the Peripheral Preferred Connection Parameters characteristic."
@@ -331,13 +335,23 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
     return len;
   }
   
+  unsigned long now = millis();
+
+  // Security timeout: if a connection has been pending pairing for too long, force-disconnect
+  // and let the watchdog below restart advertising. This handles the iOS pairing stall case.
+  if (_isEnabled && _conn_handle != BLE_CONN_HANDLE_INVALID && !_isDeviceConnected) {
+    if (_conn_pending_since > 0 && (now - _conn_pending_since) >= BLE_SECURITY_TIMEOUT_MS) {
+      BLE_DEBUG_PRINTLN("SerialBLEInterface: security timeout, forcing disconnect");
+      disconnect();
+    }
+  }
+
   // Advertising watchdog: periodically check if advertising is running, restart if not
   // Only run when truly disconnected (no connection handle), not during connection establishment
-  unsigned long now = millis();
   if (_isEnabled && !isConnected() && _conn_handle == BLE_CONN_HANDLE_INVALID) {
     if (now - _last_health_check >= BLE_HEALTH_CHECK_INTERVAL) {
       _last_health_check = now;
-      
+
       if (!isAdvertising()) {
         BLE_DEBUG_PRINTLN("SerialBLEInterface: advertising watchdog - advertising stopped, restarting");
         Bluefruit.Advertising.start(0);

--- a/src/helpers/nrf52/SerialBLEInterface.h
+++ b/src/helpers/nrf52/SerialBLEInterface.h
@@ -14,6 +14,7 @@ class SerialBLEInterface : public BaseSerialInterface {
   uint16_t _conn_handle;
   unsigned long _last_health_check;
   unsigned long _last_retry_attempt;
+  unsigned long _conn_pending_since;
 
   struct Frame {
     uint8_t len;
@@ -48,6 +49,7 @@ public:
     _conn_handle = BLE_CONN_HANDLE_INVALID;
     _last_health_check = 0;
     _last_retry_attempt = 0;
+    _conn_pending_since = 0;
     send_queue_len = 0;
     recv_queue_len = 0;
   }


### PR DESCRIPTION
Commit https://github.com/meshcore-dev/MeshCore/commit/25ea953cc3d744fde55b0cd78ffe222b4af5715f introduced a condition where a BLE connection that is established but not yet encrypted could result in a hung BLE stack under certain conditions.

If `onConnect` is called with a valid connection_handle, the `_isDeviceConnected` flag remains set to false. This prevents the watchdog loop on lines 336-346 from running until after the `onSecured` function is called and the `_isDeviceConnected` flag is set to true. 

For various reasons that are apparently more common in iPhones versus Android devices, the establishment of encryption is more likely to not complete, which would leave the nRF device BLE stack in a hung state.

To address this potential for a hung state I've implemented a timeout (BLE_SECURITY_TIMEOUT_MS) on the call to `onSecured` of 15 seconds, so that if a BLE connection is established via `onConnect` without the subsequent call to `onSecured` within that time, then `disconnect` is called, allowing the device to return to an advertising state and allow further connection attempts.

I have tested this patched firmware on a RAK 4631 board and it's been stable without any BLE issues for the past 24 hours.