### PR TITLE
fix: standardize bridge.source on rx and tx

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -903,10 +903,12 @@ region save
 
 **Parameters:**
 - `source`: 
-  - `logRx`: bridges received packets
-  - `logTx`: bridges transmitted packets
+  - `rx`: bridges received packets
+  - `tx`: bridges transmitted packets
 
-**Default:** `logTx`
+`set bridge.source` requires a value and returns an error when `source` is missing or not one of `rx` or `tx`.
+
+**Default:** `tx`
 
 ---
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -384,7 +384,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       } else if (memcmp(config, "bridge.delay", 12) == 0) {
         sprintf(reply, "> %d", (uint32_t)_prefs->bridge_delay);
       } else if (memcmp(config, "bridge.source", 13) == 0) {
-        sprintf(reply, "> %s", _prefs->bridge_pkt_src ? "logRx" : "logTx");
+        sprintf(reply, "> %s", _prefs->bridge_pkt_src ? "rx" : "tx");
 #endif
 #ifdef WITH_RS232_BRIDGE
       } else if (memcmp(config, "bridge.baud", 11) == 0) {
@@ -651,10 +651,21 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         } else {
           strcpy(reply, "Error: delay must be between 0-10000 ms");
         }
+      } else if (strcmp(config, "bridge.source") == 0) {
+        strcpy(reply, "Error: source must be rx or tx");
       } else if (memcmp(config, "bridge.source ", 14) == 0) {
-        _prefs->bridge_pkt_src = memcmp(&config[14], "rx", 2) == 0;
-        savePrefs();
-        strcpy(reply, "OK");
+        const char* source = &config[14];
+        if (strcmp(source, "rx") == 0) {
+          _prefs->bridge_pkt_src = true;
+          savePrefs();
+          strcpy(reply, "OK");
+        } else if (strcmp(source, "tx") == 0) {
+          _prefs->bridge_pkt_src = false;
+          savePrefs();
+          strcpy(reply, "OK");
+        } else {
+          strcpy(reply, "Error: source must be rx or tx");
+        }
 #endif
 #ifdef WITH_RS232_BRIDGE
       } else if (memcmp(config, "bridge.baud ", 12) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -44,7 +44,7 @@ struct NodePrefs { // persisted to file
   // Bridge settings
   uint8_t bridge_enabled; // boolean
   uint16_t bridge_delay;  // milliseconds (default 500 ms)
-  uint8_t bridge_pkt_src; // 0 = logTx, 1 = logRx (default logTx)
+  uint8_t bridge_pkt_src; // 0 = tx, 1 = rx (default tx)
   uint32_t bridge_baud;   // 9600, 19200, 38400, 57600, 115200 (default 115200)
   uint8_t bridge_channel; // 1-14 (ESP-NOW only)
   char bridge_secret[16]; // for XOR encryption of bridge packets (ESP-NOW only)


### PR DESCRIPTION
## Summary
- standardize `bridge.source` on `rx` and `tx`
- keep explicit validation for missing or invalid values
- align the CLI documentation with the accepted values

## Testing
- `git diff --check`

## Testing Firmware
This change has been built into the testing firmware at [meshcore.eklhq.com](https://meshcore.eklhq.com/). Help with testing would be appreciated.
