### PR TITLE
docs: clarify BridgeBase receive path comment

### DIFF
--- a/src/helpers/bridges/BridgeBase.cpp
+++ b/src/helpers/bridges/BridgeBase.cpp
@@ -40,7 +40,9 @@ void BridgeBase::handleReceivedPacket(mesh::Packet *packet) {
   }
 
   if (!_seen_packets.hasSeen(packet)) {
-    // bridge_delay provides a buffer to prevent immediate processing conflicts in the mesh network.
+    // Only hand the packet off to the mesh once per bridge-side receive. New packets are queued with
+    // bridge_delay applied so they are processed asynchronously instead of immediately inside the
+    // bridge RX path, which reduces feedback/reprocessing conflicts with other mesh activity.
     _mgr->queueInbound(packet, millis() + _prefs->bridge_delay);
   } else {
     _mgr->free(packet);


### PR DESCRIPTION
## Summary
- expand the BridgeBase receive-path comment to describe duplicate suppression
- explain why packets are queued with `bridge_delay` instead of being processed inline

## Testing
- `git diff --check`