### PR TITLE
Fix LED polarity on Thinknode M1, and align target configuration with datasheet

### DIFF
--- a/variants/thinknode_m1/ThinkNodeM1Board.cpp
+++ b/variants/thinknode_m1/ThinkNodeM1Board.cpp
@@ -12,7 +12,7 @@ void ThinkNodeM1Board::begin() {
 
 #ifdef P_LORA_TX_LED
   pinMode(P_LORA_TX_LED, OUTPUT);
-  digitalWrite(P_LORA_TX_LED, LOW);
+  digitalWrite(P_LORA_TX_LED, !LED_STATE_ON);
 #endif
 
   pinMode(SX126X_POWER_EN, OUTPUT);

--- a/variants/thinknode_m1/ThinkNodeM1Board.h
+++ b/variants/thinknode_m1/ThinkNodeM1Board.h
@@ -21,10 +21,10 @@ public:
 
   #if defined(P_LORA_TX_LED)
   void onBeforeTransmit() override {
-    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+    digitalWrite(P_LORA_TX_LED, LED_STATE_ON);   // turn TX LED on
   }
   void onAfterTransmit() override {
-    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+    digitalWrite(P_LORA_TX_LED, !LED_STATE_ON);   // turn TX LED off
   }
   #endif
 
@@ -36,7 +36,7 @@ public:
 
     // turn off all leds, sd_power_system_off will not do this for us
     #ifdef P_LORA_TX_LED
-    digitalWrite(P_LORA_TX_LED, LOW);
+    digitalWrite(P_LORA_TX_LED, !LED_STATE_ON);
     #endif
 
     // power off board

--- a/variants/thinknode_m1/variant.cpp
+++ b/variants/thinknode_m1/variant.cpp
@@ -20,10 +20,8 @@ void initVariant() {
   pinMode(PIN_BUTTON1, INPUT_PULLUP);
   pinMode(PIN_BUTTON2, INPUT_PULLUP);
 
-  pinMode(LED_RED, OUTPUT);
-  pinMode(LED_GREEN, OUTPUT);
+  pinMode(LED_RED,  OUTPUT);
   pinMode(LED_BLUE, OUTPUT);
-  digitalWrite(LED_BLUE, HIGH);
 
   pinMode(PIN_TXCO, OUTPUT);
   digitalWrite(PIN_TXCO, HIGH);

--- a/variants/thinknode_m1/variant.h
+++ b/variants/thinknode_m1/variant.h
@@ -69,10 +69,10 @@
 #define LED_BUILTIN             LED_GREEN
 #define PIN_LED                 LED_BUILTIN
 #define LED_PIN                 LED_BUILTIN
-#define LED_STATE_ON            LOW
 
 #define PIN_NEOPIXEL            (14)
 #define NEOPIXEL_NUM            (2)
+#define LED_STATE_ON            HIGH
 
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin buttons

--- a/variants/thinknode_m1/variant.h
+++ b/variants/thinknode_m1/variant.h
@@ -61,17 +61,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin LEDs
 
-#define LED_RED                 (38)
-#define LED_GREEN               (36)
-#define LED_BLUE                (14)
+#define LED_RED                 (36)
+#define LED_GREEN               (-1) // No green LED on this target
+#if defined(P_LORA_TX_LED) && P_LORA_TX_LED == 13
+  // When blue LED is used to indicate Lora TX,
+  // don't use it to indicate bluetooth connection state
+  #define LED_BLUE              (-1)
+#else
+  #define LED_BLUE              (13)
+#endif
 
-#define PIN_STATUS_LED          LED_GREEN
-#define LED_BUILTIN             LED_GREEN
+#define PIN_STATUS_LED          LED_RED
+#define LED_BUILTIN             LED_RED
 #define PIN_LED                 LED_BUILTIN
 #define LED_PIN                 LED_BUILTIN
-
-#define PIN_NEOPIXEL            (14)
-#define NEOPIXEL_NUM            (2)
 #define LED_STATE_ON            HIGH
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +84,7 @@
 #define BUTTON_PIN              PIN_BUTTON1
 #define PIN_USER_BTN            BUTTON_PIN
 
-#define PIN_BUTTON2             (11)
+#define PIN_BUTTON2             (39)
 #define BUTTON_PIN2             PIN_BUTTON2
 
 #define EXTERNAL_FLASH_DEVICES MX25R1635F
@@ -101,7 +104,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // SPI1
 
-#define PIN_SPI1_MISO           (38)
+#define PIN_SPI1_MISO           (-1) // Not connected on this target
 #define PIN_SPI1_MOSI           (29)
 #define PIN_SPI1_SCK            (31)
 
@@ -122,7 +125,7 @@ extern const int SCK;
 ////////////////////////////////////////////////////////////////////////////////
 // Display
 
-#define DISP_MISO               (38)
+#define DISP_MISO               (-1) // Not connected on this target
 #define DISP_MOSI               (29)
 #define DISP_SCLK               (31)
 #define DISP_CS                 (30)
@@ -136,8 +139,7 @@ extern const int SCK;
 
 #define PIN_GPS_RX              (40)
 #define PIN_GPS_TX              (41)
-#define GPS_EN                  (34)
+#define GPS_EN                  PIN_GPS_STANDBY // Datasheet lists only STANDBY
 #define PIN_GPS_RESET           (37)
-#define PIN_GPS_PPS             (36)
 #define PIN_GPS_STANDBY         (34)
 #define PIN_GPS_SWITCH          (33)


### PR DESCRIPTION
Fix polarity of LEDs on Thinknode M1
Saw that someone reported this as #1805 
I had the same issue on mine. After changing the polarity, the status LED is on for 20-200ms instead of ~4s on and 20-200ms off.