### PR TITLE
Update devcontainer features to use Node instead of Bun

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "MeshCore",
 	"image": "mcr.microsoft.com/devcontainers/python:3-bookworm",
 	"features": {
-		"ghcr.io/devcontainers-extra/features/bun:1": {},
+		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": [
 				"sudo"


### PR DESCRIPTION
Replace Bun with Node in the devcontainer due to compability issues