### PR TITLE
Make bridge baud a UART pass-through setting

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -916,9 +916,13 @@ region save
 - `set bridge.baud <rate>`
 
 **Parameters:**
-- `rate`: Baud rate (`9600`, `19200`, `38400`, `57600`, or `115200`)
+- `rate`: Positive integer baud rate value passed to the underlying serial library
 
 **Default:** `115200`
+
+**Notes:**
+- MeshCore stores the configured baud rate and passes it to the platform UART library when the RS-232 bridge starts or restarts.
+- Supported values depend on the board/core UART implementation. Some platforms may reject unsupported values or round to the nearest achievable baud rate.
 
 ---
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -4,10 +4,6 @@
 #include "AdvertDataHelpers.h"
 #include <RTClib.h>
 
-#ifndef BRIDGE_MAX_BAUD
-#define BRIDGE_MAX_BAUD 115200
-#endif
-
 // Believe it or not, this std C function is busted on some platforms!
 static uint32_t _atoi(const char* sp) {
   uint32_t n = 0;
@@ -107,7 +103,9 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->bridge_enabled = constrain(_prefs->bridge_enabled, 0, 1);
     _prefs->bridge_delay = constrain(_prefs->bridge_delay, 0, 10000);
     _prefs->bridge_pkt_src = constrain(_prefs->bridge_pkt_src, 0, 1);
-    _prefs->bridge_baud = constrain(_prefs->bridge_baud, 9600, BRIDGE_MAX_BAUD);
+    if (_prefs->bridge_baud == 0) {
+      _prefs->bridge_baud = 115200;
+    }
     _prefs->bridge_channel = constrain(_prefs->bridge_channel, 0, 14);
 
     _prefs->powersaving_enabled = constrain(_prefs->powersaving_enabled, 0, 1);
@@ -658,14 +656,14 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
 #endif
 #ifdef WITH_RS232_BRIDGE
       } else if (memcmp(config, "bridge.baud ", 12) == 0) {
-        uint32_t baud = atoi(&config[12]);
-        if (baud >= 9600 && baud <= BRIDGE_MAX_BAUD) {
+        int32_t baud = atoi(&config[12]);
+        if (baud > 0) {
           _prefs->bridge_baud = (uint32_t)baud;
           _callbacks->restartBridge();
           savePrefs();
           strcpy(reply, "OK");
         } else {
-          sprintf(reply, "Error: baud rate must be between 9600-%d",BRIDGE_MAX_BAUD);
+          strcpy(reply, "Error: baud rate must be a positive integer");
         }
 #endif
 #ifdef WITH_ESPNOW_BRIDGE

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -45,7 +45,7 @@ struct NodePrefs { // persisted to file
   uint8_t bridge_enabled; // boolean
   uint16_t bridge_delay;  // milliseconds (default 500 ms)
   uint8_t bridge_pkt_src; // 0 = logTx, 1 = logRx (default logTx)
-  uint32_t bridge_baud;   // 9600, 19200, 38400, 57600, 115200 (default 115200)
+  uint32_t bridge_baud;   // pass-through UART baud rate (default 115200)
   uint8_t bridge_channel; // 1-14 (ESP-NOW only)
   char bridge_secret[16]; // for XOR encryption of bridge packets (ESP-NOW only)
   // Power setting

--- a/src/helpers/bridges/RS232Bridge.h
+++ b/src/helpers/bridges/RS232Bridge.h
@@ -19,7 +19,7 @@
  * - Magic header for packet synchronization and frame alignment
  * - Duplicate packet detection using SimpleMeshTables tracking
  * - Configurable RX/TX pins via build defines
- * - Fixed baud rate at 115200 for consistent timing
+ * - Configurable baud rate supplied from node preferences
  *
  * Packet Structure:
  * [2 bytes] Magic Header (0xC03E) - Used to identify start of RS232Bridge packets
@@ -61,7 +61,7 @@ public:
    *
    * - Validates that RX/TX pins are defined
    * - Configures UART pins based on target platform
-   * - Sets baud rate to 115200 for consistent communication
+   * - Starts the UART using the configured bridge baud rate
    * - Platform-specific pin configuration methods are used
    */
   void begin() override;


### PR DESCRIPTION
## Summary
- stop enforcing a MeshCore-specific baud list for `bridge.baud`
- store any positive parsed baud value and pass it through to the underlying UART library
- keep the default at `115200` when the stored preference is unset
- align CLI docs and comments with the actual pass-through behavior

## Why
MeshCore does not implement board-specific baud validation for the RS-232 bridge. The configured value is forwarded directly into the platform UART driver in `RS232Bridge::begin()` via `begin(_prefs->bridge_baud)`, so the lower-level UART implementation is the authority on what is supported or how a requested baud is approximated.

Relevant lower-level references:
- ESP32 Arduino serial API: https://docs.espressif.com/projects/arduino-esp32/en/latest/api/serial.html
- Arduino-Pico serial docs: https://arduino-pico.readthedocs.io/en/stable/serial.html
- Raspberry Pi Pico SDK UART docs: https://www.raspberrypi.com/documentation/pico-sdk/hardware.html
- Nordic nRF52840 PDK / UART documentation reference: https://infocenter.nordicsemi.com/pdf/nRF52840_PDK_User_Guide_v1.2.pdf
- STM32duino API reference: https://github.com/stm32duino/Arduino_Core_STM32/wiki/API

## Behavior
- `set bridge.baud <rate>` now accepts any positive integer parsed by the existing CLI style
- invalid or non-positive values still return an error
- MeshCore no longer clamps persisted baud values back into an artificial `9600..115200` window on load
- unsupported values remain the responsibility of the underlying platform UART stack

## Validation
- `git diff --check`
- `pio run -e Heltec_v3_terminal_chat`
- `pio run -e waveshare_rp2040_lora_repeater`
- `pio run -e wio-e5-repeater_bridge_rs232`
- `pio run -e RAK_4631_repeater_bridge_rs232_serial1`

## Testing Firmware
This change has been built into the testing firmware at [meshcore.eklhq.com](https://meshcore.eklhq.com/). Help with testing would be appreciated.
