### PR TITLE
Stop clamping tx power in CommonCLI

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -200,13 +200,17 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `set tx <dbm>`
 
 **Parameters:**
-- `dbm`: Power level in dBm (1-22)
+- `dbm`: Requested transmit power in dBm
 
 **Set by build flag:** `LORA_TX_POWER`
 
 **Default:** Varies by board
 
-**Notes:** This setting only controls the power level of the LoRa chip. Some nodes have an additional power amplifier stage which increases the total output. Refer to the node's manual for the correct setting to use. **Setting a value too high may violate the laws in your country.**
+**Notes:**
+- MeshCore stores the configured value and passes it to the board/radio layer.
+- Supported values depend on the underlying radio implementation and may differ between LoRa radio families and ESP-NOW builds.
+- On LoRa boards, this controls the LoRa radio transmit power request. Some nodes also have an additional power amplifier stage which increases total output.
+- Refer to the node's manual and the underlying radio documentation for the correct setting to use. **Setting a value too high may violate the laws in your country.**
 
 ---
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -98,7 +98,6 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->bw = constrain(_prefs->bw, 7.8f, 500.0f);
     _prefs->sf = constrain(_prefs->sf, 5, 12);
     _prefs->cr = constrain(_prefs->cr, 5, 8);
-    _prefs->tx_power_dbm = constrain(_prefs->tx_power_dbm, -9, 30);
     _prefs->multi_acks = constrain(_prefs->multi_acks, 0, 1);
     _prefs->adc_multiplier = constrain(_prefs->adc_multiplier, 0.0f, 10.0f);
     _prefs->path_hash_mode = constrain(_prefs->path_hash_mode, 0, 2);   // NOTE: mode 3 reserved for future

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -24,7 +24,7 @@ struct NodePrefs { // persisted to file
   double node_lat, node_lon;
   char password[16];
   float freq;
-  int8_t tx_power_dbm;
+  int8_t tx_power_dbm; // requested radio TX power in dBm (board/radio dependent)
   uint8_t disable_fwd;
   uint8_t advert_interval;       // minutes / 2
   uint8_t flood_advert_interval; // hours


### PR DESCRIPTION
## Summary
- remove the generic `tx_power_dbm` clamp from `CommonCLI` preference loading
- clarify that `tx` is a backend-dependent transmit power request
- update the CLI docs and persisted preference comment to match the actual implementation

## Rationale
MeshCore does not implement a single universal transmit-power backend.

The current `set tx` flow stores the requested dBm value and passes it to the board/radio layer via `_callbacks->setTxPower(...)`. From there, different targets forward that value into different lower-level APIs:
- most LoRa targets call `radio.setOutputPower(dbm)`
- ESP-NOW targets call the ESP32 Wi-Fi TX power API

That means the old generic load-time clamp in `CommonCLI`:

```cpp
_prefs->tx_power_dbm = constrain(_prefs->tx_power_dbm, -9, 30);
```

was an MC-layer policy that did not match the actual supported ranges of the underlying backends.

Examples from the lower-level docs:
- RadioLib SX126x: `setOutputPower()` supports `-9` to `22 dBm`
  - https://jgromes.github.io/RadioLib/class_s_x1268.html
- RadioLib SX128x: `setOutputPower()` supports `-18` to `13 dBm`
  - https://jgromes.github.io/RadioLib/class_s_x128x.html
- RadioLib LR11x0 family: supported ranges depend on PA path and include values below `-9 dBm`
  - https://jgromes.github.io/RadioLib/class_l_r1121.html
- ESP32 Wi-Fi TX power is controlled by `esp_wifi_set_max_tx_power(...)`, which is a different backend entirely
  - https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/wifi.html

So the correct split here is:
- MeshCore stores the requested value
- the board/radio backend owns the actual supported range
- docs/comments should describe that backend-dependent behavior instead of a fake universal range

## Why only this implementation change
This PR does not add new CLI-side validation because the current callback path is already backend-specific and does not expose a portable cross-platform success/failure result. The narrow fix here is to stop silently rewriting stored values to a generic range that is not valid across all supported radios.

## Validation
- `git diff --check`
- `pio run -e Heltec_v3_terminal_chat`
- `pio run -e waveshare_rp2040_lora_repeater`
- `pio run -e wio-e5-repeater_bridge_rs232`
- `pio run -e RAK_4631_repeater`

## Testing Firmware
This change has been built into the testing firmware at [meshcore.eklhq.com](https://meshcore.eklhq.com/). Help with testing would be appreciated.
