### PR TITLE
Coalesce direct ACKs behind multi_acks

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -690,13 +690,13 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         mesh::Utils::sha256((uint8_t *)&ack_hash, 4, data, 5 + strlen((char *)&data[5]), client->id.pub_key,
                             PUB_KEY_SIZE);
 
-        mesh::Packet *ack = createAck(ack_hash);
-        if (ack) {
-          if (client->out_path_len == OUT_PATH_UNKNOWN) {
-            sendFlood(ack, TXT_ACK_DELAY, packet->getPathHashSize());
-          } else {
-            sendDirect(ack, client->out_path, client->out_path_len, TXT_ACK_DELAY);
-          }
+        if (client->out_path_len == OUT_PATH_UNKNOWN) {
+          mesh::Packet *ack = createAck(ack_hash);
+          if (ack) sendFlood(ack, TXT_ACK_DELAY, packet->getPathHashSize());
+        } else if (!(getExtraAckTransmitCount() > 0
+                     && enqueueDirectAck(ack_hash, client->out_path, client->out_path_len, TXT_ACK_DELAY))) {
+          mesh::Packet *ack = createAck(ack_hash);
+          if (ack) sendDirect(ack, client->out_path, client->out_path_len, TXT_ACK_DELAY);
         }
       }
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,14 +1,103 @@
 #include "Mesh.h"
 //#include <Arduino.h>
+#include <string.h>
 
 namespace mesh {
 
 void Mesh::begin() {
+  memset(_pending_direct_acks, 0, sizeof(_pending_direct_acks));
   Dispatcher::begin();
 }
 
 void Mesh::loop() {
+  flushQueuedDirectAcks();
   Dispatcher::loop();
+}
+
+bool Mesh::queueDirectAck(uint32_t ack_crc, const uint8_t* path, uint8_t path_len, uint32_t delay_millis) {
+  unsigned long scheduled_for = futureMillis(delay_millis);
+  PendingDirectAck* slot = NULL;
+  PendingDirectAck* empty = NULL;
+  uint8_t path_byte_len = ((path_len & 63) * ((path_len >> 6) + 1));
+
+  for (uint8_t i = 0; i < MAX_PENDING_DIRECT_ACKS; i++) {
+    auto* curr = &_pending_direct_acks[i];
+    if (!curr->used) {
+      if (empty == NULL) empty = curr;
+      continue;
+    }
+    if (curr->path_len == path_len && memcmp(curr->path, path, path_byte_len) == 0) {
+      slot = curr;
+      break;
+    }
+  }
+
+  if (slot == NULL) {
+    slot = empty;
+    if (slot == NULL) return false;
+
+    slot->used = 1;
+    slot->count = 0;
+    slot->path_len = Packet::copyPath(slot->path, path, path_len);
+    slot->scheduled_for = scheduled_for;
+  } else if (scheduled_for < slot->scheduled_for) {
+    slot->scheduled_for = scheduled_for;
+  }
+
+  for (uint8_t i = 0; i < slot->count; i++) {
+    if (slot->ack_crcs[i] == ack_crc) return true;
+  }
+
+  if (slot->count >= sizeof(slot->ack_crcs) / sizeof(slot->ack_crcs[0])) return false;
+
+  slot->ack_crcs[slot->count++] = ack_crc;
+  return true;
+}
+
+void Mesh::flushQueuedDirectAcks() {
+  for (uint8_t i = 0; i < MAX_PENDING_DIRECT_ACKS; i++) {
+    auto* slot = &_pending_direct_acks[i];
+    if (!slot->used || slot->count == 0 || !millisHasNowPassed(slot->scheduled_for)) continue;
+
+    uint32_t delay_millis = 0;
+
+    if (slot->count == 1) {
+      uint8_t extra = getExtraAckTransmitCount();
+      if (extra > 0) {
+        auto* a1 = createMultiAck(slot->ack_crcs[0], 1);
+        if (a1) {
+          a1->path_len = Packet::copyPath(a1->path, slot->path, slot->path_len);
+          a1->header &= ~PH_ROUTE_MASK;
+          a1->header |= ROUTE_TYPE_DIRECT;
+          sendPacket(a1, 0, delay_millis);
+        }
+        delay_millis += 300;
+      }
+
+      auto* a2 = createAck(slot->ack_crcs[0]);
+      if (a2) {
+        a2->path_len = Packet::copyPath(a2->path, slot->path, slot->path_len);
+        a2->header &= ~PH_ROUTE_MASK;
+        a2->header |= ROUTE_TYPE_DIRECT;
+        sendPacket(a2, 0, delay_millis);
+      }
+    } else {
+      for (uint8_t n = 0; n < slot->count; n++) {
+        uint8_t remaining = slot->count - n - 1;
+        Packet* ack = remaining > 0 ? createMultiAck(slot->ack_crcs[n], remaining)
+                                    : createAck(slot->ack_crcs[n]);
+        if (ack) {
+          ack->path_len = Packet::copyPath(ack->path, slot->path, slot->path_len);
+          ack->header &= ~PH_ROUTE_MASK;
+          ack->header |= ROUTE_TYPE_DIRECT;
+          sendPacket(ack, 0, delay_millis);
+        }
+        delay_millis += 300;
+      }
+    }
+
+    memset(slot, 0, sizeof(*slot));
+  }
 }
 
 bool Mesh::allowPacketForward(const mesh::Packet* packet) { 

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -24,14 +24,28 @@ public:
  *     and provides virtual methods for sub-classes on handling incoming, and also preparing outbound Packets.
 */
 class Mesh : public Dispatcher {
+  struct PendingDirectAck {
+    uint8_t used;
+    uint8_t count;
+    uint8_t path_len;
+    uint32_t scheduled_for;
+    uint8_t path[MAX_PATH_SIZE];
+    uint32_t ack_crcs[4];
+  };
+
+  static constexpr uint8_t MAX_PENDING_DIRECT_ACKS = 4;
+
   RTCClock* _rtc;
   RNG* _rng;
   MeshTables* _tables;
+  PendingDirectAck _pending_direct_acks[MAX_PENDING_DIRECT_ACKS];
 
   void removeSelfFromPath(Packet* packet);
   void routeDirectRecvAcks(Packet* packet, uint32_t delay_millis);
   //void routeRecvAcks(Packet* packet, uint32_t delay_millis);
   DispatcherAction forwardMultipartDirect(Packet* pkt);
+  bool queueDirectAck(uint32_t ack_crc, const uint8_t* path, uint8_t path_len, uint32_t delay_millis);
+  void flushQueuedDirectAcks();
 
 protected:
   DispatcherAction onRecvPacket(Packet* pkt) override;
@@ -208,6 +222,9 @@ public:
    * \brief  send a locally-generated Packet with Direct routing
   */
   void sendDirect(Packet* packet, const uint8_t* path, uint8_t path_len, uint32_t delay_millis=0);
+  bool enqueueDirectAck(uint32_t ack_crc, const uint8_t* path, uint8_t path_len, uint32_t delay_millis=0) {
+    return queueDirectAck(ack_crc, path, path_len, delay_millis);
+  }
 
   /**
    * \brief  send a locally-generated Packet to just neigbor nodes (zero hops)

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -43,6 +43,11 @@ void BaseChatMesh::sendAckTo(const ContactInfo& dest, uint32_t ack_hash) {
     mesh::Packet* ack = createAck(ack_hash);
     if (ack) sendFloodScoped(dest, ack, TXT_ACK_DELAY);
   } else {
+    if (getExtraAckTransmitCount() > 0
+        && enqueueDirectAck(ack_hash, dest.out_path, dest.out_path_len, TXT_ACK_DELAY)) {
+      return;
+    }
+
     uint32_t d = TXT_ACK_DELAY;
     if (getExtraAckTransmitCount() > 0) {
       mesh::Packet* a1 = createMultiAck(ack_hash, 1);


### PR DESCRIPTION
## Summary
- coalesce direct ACKs behind the existing `multi_acks` setting
- reuse the current multipart ACK wire format instead of introducing a new ACK packet type
- leave flood ACK behavior unchanged
- preserve the existing fallback path when ACK coalescing cannot be used

## What changed
This adds a small pending direct-ACK accumulator in `Mesh` and switches direct ACK send paths to enqueue direct ACKs when `getExtraAckTransmitCount() > 0`.

The branch now covers:
- `BaseChatMesh::sendAckTo()` for chat/companion-style firmware
- the direct ACK send path in `examples/simple_repeater/MyMesh.cpp` for repeater firmware

When multiple direct ACKs for the same direct path are pending inside the same short delay window, they are emitted as the existing multipart ACK sequence:
- if only one ACK is pending, behavior stays equivalent to the existing multi-ACK redundancy path
- if multiple ACKs are pending for the same path, they are sent as a multipart ACK chain followed by a final normal ACK

The receive side is unchanged. Multipart ACKs are still unpacked into one `ack_crc` at a time, so `onAckRecv()` and `processAck()` semantics do not change.

## Benefits
- reduces direct ACK airtime when multiple ACKs are generated close together for the same path
- extends that benefit to repeater firmware as well as `BaseChatMesh`-based firmware
- reuses protocol machinery that MeshCore already implements today
- avoids introducing a new payload type or a new ACK-set format
- keeps the change narrowly scoped to direct ACK sending
- preserves existing behavior when `multi_acks` is disabled

This is most useful when a node is directly exchanging several ACKed packets with the same peer in a short burst, such as chat/companion traffic or repeater-admin CLI interactions.

## Why this design
MeshCore already had partial multipart ACK support, but it was being used only for repeated ACK redundancy, not coalescing multiple distinct ACK hashes.

This PR uses the smallest viable extension of that support:
- send-side coalescing only
- no receive-side semantic changes
- no protocol compatibility expansion beyond existing multipart ACK handling

## Tradeoffs
- adds a small amount of transient state in `Mesh` for queued direct ACKs
- batching is keyed by exact direct path, not by contact identity
- flood ACKs are intentionally not coalesced in this first step
- this only changes behavior when `multi_acks` is already enabled

## Alternatives considered
1. Introduce a brand new ACK-set packet format
   - rejected because it would expand protocol surface and require new receive semantics

2. Apply batching to all ACKs, including flood ACKs
   - rejected for the first step because flood timing/propagation is noisier and higher risk

3. Batch even when `multi_acks` is off
   - rejected to keep the rollout behind the existing opt-in setting

4. Keep ACK coalescing only in `BaseChatMesh`
   - rejected because multipart ACK encode/decode already lives in `Mesh`, and repeater firmware benefits from the same direct ACK coalescing behavior

## Validation
- `git diff --check`
- `pio run -e Heltec_v3_terminal_chat`
- `pio run -e Heltec_v3_repeater`
- `pio run -e RAK_4631_repeater`
- `pio run -e waveshare_rp2040_lora_repeater`

## Review notes
I did not find any existing MeshCore PR or issue discussion covering multipart ACK batching. This implementation is based on the current code and protocol behavior already present in `Mesh`, `BaseChatMesh`, and repeater firmware.
