### PR TITLE
Add repeater-only observability metrics

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -119,6 +119,8 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 **Serial Only:** Yes
 
+**Repeater Note:** Repeater firmware also includes `active_nbrs` and `stable_nbrs` in this response.
+
 ---
 
 ### Radio Stats - Noise floor, Last RSSI/SNR, Airtime, Receive errors
@@ -132,6 +134,28 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Usage:** `stats-packets`
 
 **Serial Only:** Yes
+
+---
+
+### Repeater stats - ACK, admin traffic, and forward/drop counters
+**Usage:** `stats-repeater`
+
+**Serial Only:** Yes
+
+**Repeater Only:** Yes
+
+**Fields:**
+- `ack_d`: Direct ACKs sent
+- `ack_f`: Flood ACKs sent
+- `req`: Admin requests handled
+- `cli`: CLI commands handled
+- `rep_d`: Admin replies sent direct
+- `rep_f`: Admin replies sent by flood
+- `fwd`: Flood packets forwarded
+- `drop_dis`: Flood packets dropped because forwarding is disabled
+- `drop_max`: Flood packets dropped because they exceeded `flood_max`
+- `drop_reg`: Flood packets dropped because no allowed region match was available
+- `drop_loop`: Flood packets dropped by loop detection
 
 ---
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -59,9 +59,12 @@
 #define CLI_REPLY_DELAY_MILLIS      600
 
 #define LAZY_CONTACTS_WRITE_DELAY    5000
+#define ACTIVE_NEIGHBOUR_SECS      3600
+#define STABLE_NEIGHBOUR_HEARS        3
 
 void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float snr) {
 #if MAX_NEIGHBOURS // check if neighbours enabled
+  bool found = false;
   // find existing neighbour, else use least recently updated
   uint32_t oldest_timestamp = 0xFFFFFFFF;
   NeighbourInfo *neighbour = &neighbours[0];
@@ -69,6 +72,7 @@ void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float sn
     // if neighbour already known, we should update it
     if (id.matches(neighbours[i].id)) {
       neighbour = &neighbours[i];
+      found = true;
       break;
     }
 
@@ -84,6 +88,38 @@ void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float sn
   neighbour->advert_timestamp = timestamp;
   neighbour->heard_timestamp = getRTCClock()->getCurrentTime();
   neighbour->snr = (int8_t)(snr * 4);
+  neighbour->hear_count = found ? (uint16_t)(neighbour->hear_count + 1) : 1;
+#endif
+}
+
+uint16_t MyMesh::getActiveNeighbourCount() const {
+#if MAX_NEIGHBOURS
+  uint16_t count = 0;
+  uint32_t now = rtc_clock.getCurrentTime();
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    if (neighbours[i].heard_timestamp > 0 && now - neighbours[i].heard_timestamp <= ACTIVE_NEIGHBOUR_SECS) {
+      count++;
+    }
+  }
+  return count;
+#else
+  return 0;
+#endif
+}
+
+uint16_t MyMesh::getStableNeighbourCount() const {
+#if MAX_NEIGHBOURS
+  uint16_t count = 0;
+  uint32_t now = rtc_clock.getCurrentTime();
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    if (neighbours[i].heard_timestamp > 0 && now - neighbours[i].heard_timestamp <= ACTIVE_NEIGHBOUR_SECS
+        && neighbours[i].hear_count >= STABLE_NEIGHBOUR_HEARS) {
+      count++;
+    }
+  }
+  return count;
+#else
+  return 0;
 #endif
 }
 
@@ -414,9 +450,16 @@ bool MyMesh::isLooped(const mesh::Packet* packet, const uint8_t max_counters[]) 
 }
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
-  if (_prefs.disable_fwd) return false;
-  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
+  if (_prefs.disable_fwd) {
+    if (packet->isRouteFlood()) metrics.drop_disabled++;
+    return false;
+  }
+  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) {
+    metrics.drop_max++;
+    return false;
+  }
   if (packet->isRouteFlood() && recv_pkt_region == NULL) {
+    metrics.drop_region++;
     MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
     return false;
   }
@@ -430,10 +473,12 @@ bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
       maximums = max_loop_strict;
     }
     if (isLooped(packet, maximums)) {
+      metrics.drop_loop++;
       MESH_DEBUG_PRINTLN("allowPacketForward: FLOOD packet loop detected!");
       return false;
     }
   }
+  if (packet->isRouteFlood()) metrics.flood_forwarded++;
   return true;
 }
 
@@ -647,6 +692,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       int reply_len = handleRequest(client, timestamp, &data[4], len - 4);
       if (reply_len == 0) return; // invalid command
 
+      metrics.admin_req_recv++;
       client->last_timestamp = timestamp;
       client->last_activity = getRTCClock()->getCurrentTime();
 
@@ -655,14 +701,17 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         mesh::Packet *path = createPathReturn(client->id, secret, packet->path, packet->path_len,
                                               PAYLOAD_TYPE_RESPONSE, reply_data, reply_len);
         if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
+        metrics.admin_reply_flood++;
       } else {
         mesh::Packet *reply =
             createDatagram(PAYLOAD_TYPE_RESPONSE, client->id, secret, reply_data, reply_len);
         if (reply) {
           if (client->out_path_len != OUT_PATH_UNKNOWN) { // we have an out_path, so send DIRECT
             sendDirect(reply, client->out_path, client->out_path_len, SERVER_RESPONSE_DELAY);
+            metrics.admin_reply_direct++;
           } else {
             sendFlood(reply, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
+            metrics.admin_reply_flood++;
           }
         }
       }
@@ -690,12 +739,17 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         mesh::Utils::sha256((uint8_t *)&ack_hash, 4, data, 5 + strlen((char *)&data[5]), client->id.pub_key,
                             PUB_KEY_SIZE);
 
-        mesh::Packet *ack = createAck(ack_hash);
-        if (ack) {
-          if (client->out_path_len == OUT_PATH_UNKNOWN) {
+        if (client->out_path_len == OUT_PATH_UNKNOWN) {
+          mesh::Packet *ack = createAck(ack_hash);
+          if (ack) {
             sendFlood(ack, TXT_ACK_DELAY, packet->getPathHashSize());
-          } else {
+            metrics.ack_flood_sent++;
+          }
+        } else {
+          mesh::Packet *ack = createAck(ack_hash);
+          if (ack) {
             sendDirect(ack, client->out_path, client->out_path_len, TXT_ACK_DELAY);
+            metrics.ack_direct_sent++;
           }
         }
       }
@@ -706,6 +760,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       if (is_retry) {
         *reply = 0;
       } else {
+        metrics.cli_cmd_recv++;
         handleCommand(sender_timestamp, command, reply);
       }
       int text_len = strlen(reply);
@@ -722,8 +777,10 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
         if (reply) {
           if (client->out_path_len == OUT_PATH_UNKNOWN) {
             sendFlood(reply, CLI_REPLY_DELAY_MILLIS, packet->getPathHashSize());
+            metrics.admin_reply_flood++;
           } else {
             sendDirect(reply, client->out_path, client->out_path_len, CLI_REPLY_DELAY_MILLIS);
+            metrics.admin_reply_direct++;
           }
         }
       }
@@ -1067,7 +1124,14 @@ void MyMesh::removeNeighbor(const uint8_t *pubkey, int key_len) {
 }
 
 void MyMesh::formatStatsReply(char *reply) {
-  StatsFormatHelper::formatCoreStats(reply, board, *_ms, _err_flags, _mgr);
+  sprintf(reply,
+          "{\"battery_mv\":%u,\"uptime_secs\":%u,\"errors\":%u,\"queue_len\":%u,\"active_nbrs\":%u,\"stable_nbrs\":%u}",
+          board.getBattMilliVolts(),
+          _ms->getMillis() / 1000,
+          _err_flags,
+          _mgr->getOutboundTotal(),
+          getActiveNeighbourCount(),
+          getStableNeighbourCount());
 }
 
 void MyMesh::formatRadioStatsReply(char *reply) {
@@ -1077,6 +1141,22 @@ void MyMesh::formatRadioStatsReply(char *reply) {
 void MyMesh::formatPacketStatsReply(char *reply) {
   StatsFormatHelper::formatPacketStats(reply, radio_driver, getNumSentFlood(), getNumSentDirect(), 
                                        getNumRecvFlood(), getNumRecvDirect());
+}
+
+void MyMesh::formatRepeaterStatsReply(char *reply) {
+  sprintf(reply,
+          "{\"ack_d\":%u,\"ack_f\":%u,\"req\":%u,\"cli\":%u,\"rep_d\":%u,\"rep_f\":%u,\"fwd\":%u,\"drop_dis\":%u,\"drop_max\":%u,\"drop_reg\":%u,\"drop_loop\":%u}",
+          metrics.ack_direct_sent,
+          metrics.ack_flood_sent,
+          metrics.admin_req_recv,
+          metrics.cli_cmd_recv,
+          metrics.admin_reply_direct,
+          metrics.admin_reply_flood,
+          metrics.flood_forwarded,
+          metrics.drop_disabled,
+          metrics.drop_max,
+          metrics.drop_region,
+          metrics.drop_loop);
 }
 
 void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
@@ -1096,6 +1176,12 @@ void MyMesh::clearStats() {
   radio_driver.resetStats();
   resetStats();
   ((SimpleMeshTables *)getTables())->resetStats();
+  memset(&metrics, 0, sizeof(metrics));
+#if MAX_NEIGHBOURS
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    neighbours[i].hear_count = 0;
+  }
+#endif
 }
 
 void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply) {
@@ -1285,6 +1371,8 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
       sendNodeDiscoverReq();
       strcpy(reply, "OK - Discover sent");
     }
+  } else if (sender_timestamp == 0 && strcmp(command, "stats-repeater") == 0) {
+    formatRepeaterStatsReply(reply);
   } else{
     _cli.handleCommand(sender_timestamp, command, reply);  // common CLI commands
   }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -66,6 +66,21 @@ struct NeighbourInfo {
   uint32_t advert_timestamp;
   uint32_t heard_timestamp;
   int8_t snr; // multiplied by 4, user should divide to get float value
+  uint16_t hear_count;
+};
+
+struct RepeaterMetrics {
+  uint32_t ack_direct_sent;
+  uint32_t ack_flood_sent;
+  uint32_t admin_req_recv;
+  uint32_t cli_cmd_recv;
+  uint32_t admin_reply_direct;
+  uint32_t admin_reply_flood;
+  uint32_t flood_forwarded;
+  uint32_t drop_disabled;
+  uint32_t drop_max;
+  uint32_t drop_region;
+  uint32_t drop_loop;
 };
 
 #ifndef FIRMWARE_BUILD_DATE
@@ -105,6 +120,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif
+  RepeaterMetrics metrics;
   CayenneLPP telemetry;
   unsigned long set_radio_at, revert_radio_at;
   float pending_freq;
@@ -119,6 +135,8 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #endif
 
   void putNeighbour(const mesh::Identity& id, uint32_t timestamp, float snr);
+  uint16_t getActiveNeighbourCount() const;
+  uint16_t getStableNeighbourCount() const;
   void sendNodeDiscoverReq();
   uint8_t handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood);
   uint8_t handleAnonRegionsReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
@@ -209,6 +227,7 @@ public:
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
   void formatPacketStatsReply(char *reply) override;
+  void formatRepeaterStatsReply(char *reply);
 
   mesh::LocalIdentity& getSelfId() override { return self_id; }
 


### PR DESCRIPTION
## Summary
- add a first batch of repeater-only observability metrics
- expose the new counters through a new serial-only `stats-repeater` command
- add `active_nbrs` and `stable_nbrs` to repeater `stats-core`
- leave the remote repeater status payload unchanged for compatibility

## What changed
This adds a small repeater-local metrics block in `examples/simple_repeater/MyMesh` and increments it at the actual decision points for:
- direct ACK sends
- flood ACK sends
- admin request handling
- CLI command handling
- admin replies sent direct vs flood
- flood packets forwarded
- flood drops due to:
  - forwarding disabled
  - `flood_max`
  - missing allowed region
  - loop detection

It also tracks repeater neighbor activity using the existing neighbor table and exposes two derived counts:
- `active_nbrs`
- `stable_nbrs`

The new serial-only command is:
- `stats-repeater`

## Why serial-only first
These metrics are operationally useful for repeater tuning, but they do not need a protocol change yet.

Keeping them serial-only in the first step avoids changing the packed remote repeater status response and avoids breaking existing clients or parsers that already consume the current `REQ_TYPE_GET_STATUS` payload.

That keeps this change low risk while still making the new observability immediately available on deployed repeaters through the local admin/debug surface.

## Benefits
- gives repeater operators visibility into ACK behavior and admin traffic
- makes flood forwarding decisions and drop reasons observable
- adds a simple signal for local repeater neighborhood health
- keeps the implementation cheap and local to the repeater firmware
- avoids any wire-format or compatibility changes

## Tradeoffs
- the new counters are currently available only through serial CLI
- counters are cumulative from boot and reset with `clear stats`
- neighbor stability is intentionally simple in this first pass

## Validation
- `git diff --check`
- `pio run -e Heltec_v3_repeater`
- `pio run -e RAK_4631_repeater`
- `pio run -e waveshare_rp2040_lora_repeater`
