### PR TITLE
Add error-aware SX126x receive hook

### DIFF
--- a/src/helpers/radiolib/CustomLLCC68.h
+++ b/src/helpers/radiolib/CustomLLCC68.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RadioLib.h>
+#include "SX126xReadHelper.h"
 
 #define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
 #define SX126X_IRQ_PREAMBLE_DETECTED           0x04
@@ -8,6 +9,10 @@
 class CustomLLCC68 : public LLCC68 {
   public:
     CustomLLCC68(Module *mod) : LLCC68(mod) { }
+
+    int tryReadData(uint8_t* data, size_t max_len, size_t* out_len = nullptr) {
+      return sx126xTryReadData(*this, data, max_len, out_len);
+    }
 
   #ifdef RP2040_PLATFORM
     bool std_init(SPIClassRP2040* spi = NULL)

--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -6,6 +6,16 @@
 class CustomLLCC68Wrapper : public RadioLibWrapper {
 public:
   CustomLLCC68Wrapper(CustomLLCC68& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+protected:
+  int tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len) override {
+    size_t len = 0;
+    int err = ((CustomLLCC68*)_radio)->tryReadData(bytes, (size_t)sz, &len);
+    if (out_len) {
+      *out_len = (err == RADIOLIB_ERR_NONE) ? (int)len : 0;
+    }
+    return err;
+  }
+public:
   bool isReceivingPacket() override { 
     return ((CustomLLCC68 *)_radio)->isReceiving();
   }

--- a/src/helpers/radiolib/CustomSTM32WLx.h
+++ b/src/helpers/radiolib/CustomSTM32WLx.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RadioLib.h>
+#include "SX126xReadHelper.h"
 
 #define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
 #define SX126X_IRQ_PREAMBLE_DETECTED           0x04
@@ -9,9 +10,17 @@ class CustomSTM32WLx : public STM32WLx {
   public:
     CustomSTM32WLx(STM32WLx_Module *mod) : STM32WLx(mod) { }
 
+    int tryReadData(uint8_t* data, size_t max_len, size_t* out_len = nullptr) {
+      return sx126xTryReadData(*this, data, max_len, out_len);
+    }
+
     bool isReceiving() {
       uint16_t irq = getIrqFlags();
       bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
 };
+
+inline int sx126xClearAllIrqs(CustomSTM32WLx& radio) {
+  return radio.clearIrqStatus(RADIOLIB_SX126X_IRQ_ALL);
+}

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -7,6 +7,16 @@
 class CustomSTM32WLxWrapper : public RadioLibWrapper {
 public:
   CustomSTM32WLxWrapper(CustomSTM32WLx& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+protected:
+  int tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len) override {
+    size_t len = 0;
+    int err = ((CustomSTM32WLx*)_radio)->tryReadData(bytes, (size_t)sz, &len);
+    if (out_len) {
+      *out_len = (err == RADIOLIB_ERR_NONE) ? (int)len : 0;
+    }
+    return err;
+  }
+public:
   bool isReceivingPacket() override { 
     return ((CustomSTM32WLx *)_radio)->isReceiving();
   }

--- a/src/helpers/radiolib/CustomSX1262.h
+++ b/src/helpers/radiolib/CustomSX1262.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RadioLib.h>
+#include "SX126xReadHelper.h"
 
 #define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
 #define SX126X_IRQ_PREAMBLE_DETECTED           0x04
@@ -8,6 +9,10 @@
 class CustomSX1262 : public SX1262 {
   public:
     CustomSX1262(Module *mod) : SX1262(mod) { }
+
+    int tryReadData(uint8_t* data, size_t max_len, size_t* out_len = nullptr) {
+      return sx126xTryReadData(*this, data, max_len, out_len);
+    }
 
   #ifdef RP2040_PLATFORM
     bool std_init(SPIClassRP2040* spi = NULL)

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -6,6 +6,16 @@
 class CustomSX1262Wrapper : public RadioLibWrapper {
 public:
   CustomSX1262Wrapper(CustomSX1262& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+protected:
+  int tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len) override {
+    size_t len = 0;
+    int err = ((CustomSX1262*)_radio)->tryReadData(bytes, (size_t)sz, &len);
+    if (out_len) {
+      *out_len = (err == RADIOLIB_ERR_NONE) ? (int)len : 0;
+    }
+    return err;
+  }
+public:
   bool isReceivingPacket() override { 
     return ((CustomSX1262 *)_radio)->isReceiving();
   }

--- a/src/helpers/radiolib/CustomSX1268.h
+++ b/src/helpers/radiolib/CustomSX1268.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RadioLib.h>
+#include "SX126xReadHelper.h"
 
 #define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
 #define SX126X_IRQ_PREAMBLE_DETECTED           0x04
@@ -8,6 +9,10 @@
 class CustomSX1268 : public SX1268 {
   public:
     CustomSX1268(Module *mod) : SX1268(mod) { }
+
+    int tryReadData(uint8_t* data, size_t max_len, size_t* out_len = nullptr) {
+      return sx126xTryReadData(*this, data, max_len, out_len);
+    }
 
   #ifdef RP2040_PLATFORM
     bool std_init(SPIClassRP2040* spi = NULL)

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -6,6 +6,16 @@
 class CustomSX1268Wrapper : public RadioLibWrapper {
 public:
   CustomSX1268Wrapper(CustomSX1268& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+protected:
+  int tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len) override {
+    size_t len = 0;
+    int err = ((CustomSX1268*)_radio)->tryReadData(bytes, (size_t)sz, &len);
+    if (out_len) {
+      *out_len = (err == RADIOLIB_ERR_NONE) ? (int)len : 0;
+    }
+    return err;
+  }
+public:
   bool isReceivingPacket() override { 
     return ((CustomSX1268 *)_radio)->isReceiving();
   }

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -95,21 +95,38 @@ bool RadioLibWrapper::isInRecvMode() const {
   return (state & ~STATE_INT_READY) == STATE_RX;
 }
 
+int RadioLibWrapper::tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len) {
+  int len = _radio->getPacketLength();
+  if (len <= 0) {
+    if (out_len) { *out_len = 0; }
+    return RADIOLIB_ERR_NONE;
+  }
+
+  if (len > sz) {
+    len = sz;
+  }
+
+  int err = _radio->readData(bytes, len);
+  if (err != RADIOLIB_ERR_NONE) {
+    if (out_len) { *out_len = 0; }
+    return err;
+  }
+
+  if (out_len) { *out_len = len; }
+  return RADIOLIB_ERR_NONE;
+}
+
 int RadioLibWrapper::recvRaw(uint8_t* bytes, int sz) {
   int len = 0;
   if (state & STATE_INT_READY) {
-    len = _radio->getPacketLength();
-    if (len > 0) {
-      if (len > sz) { len = sz; }
-      int err = _radio->readData(bytes, len);
-      if (err != RADIOLIB_ERR_NONE) {
-        MESH_DEBUG_PRINTLN("RadioLibWrapper: error: readData(%d)", err);
-        len = 0;
-        n_recv_errors++;
-      } else {
-      //  Serial.print("  readData() -> "); Serial.println(len);
-        n_recv++;
-      }
+    int err = tryReadRawWithMeta(bytes, sz, &len);
+    if (err != RADIOLIB_ERR_NONE) {
+      MESH_DEBUG_PRINTLN("RadioLibWrapper: error: readData(%d)", err);
+      len = 0;
+      n_recv_errors++;
+    } else if (len > 0) {
+    //  Serial.print("  readData() -> "); Serial.println(len);
+      n_recv++;
     }
     state = STATE_IDLE;   // need another startReceive()
   }

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -15,10 +15,12 @@ protected:
   void idle();
   void startRecv();
   float packetScoreInt(float snr, int sf, int packet_len);
+  virtual int tryReadRawWithMeta(uint8_t* bytes, int sz, int* out_len);
   virtual bool isReceivingPacket() =0;
 
 public:
-  RadioLibWrapper(PhysicalLayer& radio, mesh::MainBoard& board) : _radio(&radio), _board(&board) { n_recv = n_sent = 0; }
+  RadioLibWrapper(PhysicalLayer& radio, mesh::MainBoard& board)
+      : _radio(&radio), _board(&board), n_recv(0), n_sent(0), n_recv_errors(0) {}
 
   void begin() override;
   virtual void powerOff() { _radio->sleep(); }

--- a/src/helpers/radiolib/SX126xReadHelper.h
+++ b/src/helpers/radiolib/SX126xReadHelper.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <RadioLib.h>
+
+#define SX126X_HELPER_IRQ_HEADER_VALID 0b0000010000
+
+template <typename RadioT>
+inline int sx126xClearAllIrqs(RadioT& radio) {
+  return radio.clearIrqStatus();
+}
+
+template <typename RadioT>
+inline int sx126xTryReadData(RadioT& radio, uint8_t* data, size_t max_len, size_t* out_len = nullptr) {
+  int16_t state = radio.mod->SPIcheckStream();
+  uint16_t irq = radio.getIrqFlags();
+  if ((state == RADIOLIB_ERR_SPI_CMD_TIMEOUT) && (irq & RADIOLIB_SX126X_IRQ_TIMEOUT)) {
+    return RADIOLIB_ERR_RX_TIMEOUT;
+  }
+  if (state != RADIOLIB_ERR_NONE) {
+    return state;
+  }
+
+  int16_t crcState = RADIOLIB_ERR_NONE;
+  if ((irq & RADIOLIB_SX126X_IRQ_CRC_ERR) || ((irq & RADIOLIB_SX126X_IRQ_HEADER_ERR) && !(irq & SX126X_HELPER_IRQ_HEADER_VALID))) {
+    crcState = RADIOLIB_ERR_CRC_MISMATCH;
+  }
+
+  uint8_t offset = 0;
+  size_t length = radio.implicitLen;
+  if (radio.headerType != RADIOLIB_SX126X_LORA_HEADER_IMPLICIT) {
+    uint8_t rxBufStatus[2] = {0, 0};
+    state = radio.mod->SPIreadStream(RADIOLIB_SX126X_CMD_GET_RX_BUFFER_STATUS, rxBufStatus, 2);
+    if (state != RADIOLIB_ERR_NONE) {
+      return state;
+    }
+
+    offset = rxBufStatus[1];
+    length = (size_t)rxBufStatus[0];
+  }
+
+  if ((max_len != 0) && (max_len < length)) {
+    length = max_len;
+  }
+
+  state = radio.readBuffer(data, length, offset);
+  if (state != RADIOLIB_ERR_NONE) {
+    return state;
+  }
+
+  state = sx126xClearAllIrqs(radio);
+  if (crcState != RADIOLIB_ERR_NONE) {
+    return crcState;
+  }
+  if (state != RADIOLIB_ERR_NONE) {
+    return state;
+  }
+
+  if (out_len) {
+    *out_len = length;
+  }
+  return RADIOLIB_ERR_NONE;
+}


### PR DESCRIPTION
## Summary
This change makes MeshCore's SX126x-family receive path error-aware at the wrapper boundary instead of relying exclusively on RadioLib's high-level packet-length helper.

For SX1262, SX1268, LLCC68, and STM32WLx integrations, MeshCore now reads receive metadata through a dedicated low-level hook path that can propagate failures from `GET_RX_BUFFER_STATUS` and the subsequent buffer read. The common wrapper logic treats those failures as receive errors instead of collapsing them into a benign-looking empty packet.

The result is that SX126x-family boards no longer silently treat metadata-read failures as "no packet" when a receive interrupt has already fired.

## Problem Addressed
MeshCore's generic `RadioLibWrapper::recvRaw()` used `getPacketLength()` before calling `readData()`. On SX126x-family radios, that path depended on RadioLib behavior that can fail open when receive metadata cannot be read successfully.

In practice, that means a real metadata-read failure can be misinterpreted as a valid zero-length outcome, which causes MeshCore to drop the receive event without incrementing receive-error stats and without surfacing that the radio operation failed.

This change closes that gap for the SX126x-family radios MeshCore actively uses.

## Approach
The implementation adds a wrapper hook for metadata-aware raw reads and uses it only where MeshCore has the radio-specific knowledge needed to do better than the generic `PhysicalLayer` API:

- the common wrapper gains a default hook that preserves existing generic behavior
- SX126x-family wrappers override that hook
- SX126x-family custom radio classes provide a low-level `tryReadData(...)` path that:
  - checks the stream state first
  - preserves RadioLib timeout and CRC behavior
  - reads RX buffer status directly
  - preserves implicit-header cached-length semantics
  - propagates metadata-read and buffer-read failures

The shared SX126x receive logic is centralized in one helper so the four supported SX126x-family classes do not diverge.

## Why This Tradeoff Is Good
This is a deliberate middle path between two broader alternatives:

1. A RadioLib-level refactor to introduce new public error-aware receive metadata APIs.
2. A larger MeshCore-side rewrite that bypasses more of RadioLib's higher-level receive behavior for every radio family.

Those alternatives are reasonable long-term directions, but they are larger in scope and carry more compatibility and maintenance risk.

This change is a good tradeoff because it:
- fixes the specific live issue on MeshCore's active SX126x-family receive path
- keeps the change local to MeshCore's existing radio integration layer
- avoids broad API churn in RadioLib or MeshCore's generic radio abstraction
- preserves current behavior for non-SX126x radios
- creates a reusable hook boundary for future radio-family-specific receive fixes

## Broader RadioLib Error-Model Context
The larger problem behind this bug is that some RadioLib convenience APIs return only values, not values plus status. Once a helper such as `getPacketLength()` collapses an SPI or command failure into an ordinary-looking value, MeshCore no longer has enough information at the wrapper layer to tell the difference between:

- a legitimate radio state
- a transport or metadata-read failure that happened underneath it

That limitation is not uniform across all radios. In some places RadioLib still exposes lower-level operations with a real error channel, and in others the higher-level helper has already erased it. That is why a full library-wide fix would likely require a broader RadioLib API refactor rather than just more MeshCore wrapper code.

This PR does not claim to solve that general problem. It addresses one concrete case where MeshCore can recover correctness locally: the SX126x-family receive path still gives MeshCore enough low-level access to read buffer metadata directly and preserve the failure signal. That makes this a bounded fix with clear value, while leaving room for a larger RadioLib-side cleanup later if the project wants a consistent error-aware model across all radio families.

## Validation
- focused host-side wrapper test for hook behavior and receive-error accounting
- `Heltec_v3_repeater` build
- `wio-e5_repeater` build

## Notes
This PR intentionally does not try to solve the broader RadioLib error-model problem across every radio family. It addresses the concrete SX126x-family receive-metadata failure mode in MeshCore with a bounded change that is easy to review and reason about.
