### PR TITLE
fix(bme680): fix gas resistance variable to produce usable data

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -359,7 +359,7 @@ bool EnvironmentSensorManager::querySensors(uint8_t requester_permissions, Cayen
         telemetry.addRelativeHumidity(TELEM_CHANNEL_SELF, BME680.humidity);
         telemetry.addBarometricPressure(TELEM_CHANNEL_SELF, BME680.pressure / 100);
         telemetry.addAltitude(TELEM_CHANNEL_SELF, 44330.0 * (1.0 - pow((BME680.pressure / 100) / TELEM_BME680_SEALEVELPRESSURE_HPA, 0.1903)));
-        telemetry.addAnalogInput(next_available_channel, BME680.gas_resistance);
+        telemetry.addGenericSensor(next_available_channel, BME680.gas_resistance);
         next_available_channel++;
       }
     }


### PR DESCRIPTION
This fixes the gas resistance output of the BME680 sensor so the data can be usable. In its current state, the value can loop and go negative, and never actually show the correct values from the sensor.

- Gas resistance should be a Cayenne LPP generic sensor, type 100, uint32 BE.
- addAnalogInput overflows int16×0.01 for typical 10k–500k Ω measurements.
- Tested on RAK19003 with a BME680 sensor on board.