### PR TITLE
fix: add zombie radio recovery for TX fail reset and RX stuck reboot

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -7,6 +7,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - [Operational](#operational)
 - [Neighbors](#neighbors-repeater-only)
 - [Statistics](#statistics)
+  - [Radio diagnostics](#radio-diagnostics)
 - [Logging](#logging)
 - [Information](#info)
 - [Configuration](#configuration)
@@ -139,6 +140,37 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Usage:** `stats-packets`
 
 **Serial Only:** Yes
+
+---
+
+### Radio diagnostics - Zombie and error flag queries
+
+#### Query zombie radio state
+**Usage:** `get radio.zombie`
+
+**Note:** Returns `1` if the radio has entered a zombie state (stuck count exceeded the RX fail threshold and a reboot has been attempted), `0` otherwise. Cleared automatically when the radio recovers or on firmware reboot.
+
+---
+
+#### Query dead radio state
+**Usage:** `get radio.dead`
+
+**Note:** Returns `1` if all reboot attempts have been exhausted and the radio cannot self-recover. A physical power cycle is required. Cleared on firmware reboot.
+
+---
+
+#### Query all radio error flags
+**Usage:** `get radio.err`
+
+**Note:** Returns all radio error flags as a 4-digit hex value (e.g. `0x0018`). Flags accumulate since last boot or `clear stats`. Use `get radio.zombie` and `get radio.dead` for simple boolean checks.
+
+| Bit | Flag                        | Meaning                                   |
+|-----|-----------------------------|-------------------------------------------|
+| 0   | `ERR_EVENT_FULL`            | Packet pool exhausted                     |
+| 1   | `ERR_EVENT_CAD_TIMEOUT`     | Channel activity detection timeout        |
+| 2   | `ERR_EVENT_STARTRX_TIMEOUT` | Radio failed to return to RX within 8s    |
+| 3   | `ERR_EVENT_RADIO_ZOMBIE`    | Radio stuck; reboot attempted             |
+| 4   | `ERR_EVENT_RADIO_DEAD`      | Radio unrecoverable; power cycle required |
 
 ---
 
@@ -538,6 +570,34 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `value`: Interval in seconds rounded down to a multiple of 4 (17 becomes 16)
 
 **Default:** `0.0`
+
+---
+
+#### View or change the TX fail reset threshold
+**Usage:**
+- `get tx.fail.threshold`
+- `set tx.fail.threshold <value>`
+
+**Parameters:**
+- `value`: Number of consecutive TX failures before the radio is reset (0-10). `0` disables the feature.
+
+**Default:** `3`
+
+**Note:** On each TX failure the packet is re-queued for retry. When the consecutive failure count reaches this threshold, `onTxStuck()` is called (AGC reset by default) and the counter resets.
+
+---
+
+#### View or change the RX fail reboot threshold
+**Usage:**
+- `get rx.fail.threshold`
+- `set rx.fail.threshold <value>`
+
+**Parameters:**
+- `value`: Number of consecutive 8-second RX-stuck windows before a reboot is triggered (0-10). `0` disables the feature.
+
+**Default:** `3`
+
+**Note:** Each 8-second window where the radio is not in receive mode increments the stuck counter and calls `onRxStuck()` (force AGC reset). When the counter reaches this threshold, `onRxUnrecoverable()` is called (reboot by default). The counter resets to this threshold value after each reboot attempt so retries fire every 8 seconds rather than waiting another full threshold cycle.
 
 ---
 

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -231,6 +231,13 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     file.read((uint8_t *)&_prefs.autoadd_config, sizeof(_prefs.autoadd_config));           // 87
     file.read((uint8_t *)&_prefs.autoadd_max_hops, sizeof(_prefs.autoadd_max_hops));       // 88
     file.read((uint8_t *)&_prefs.rx_boosted_gain, sizeof(_prefs.rx_boosted_gain)); // 89
+    if (!file.read((uint8_t *)&_prefs.tx_fail_reset_threshold, sizeof(_prefs.tx_fail_reset_threshold))) { // 90
+      _prefs.tx_fail_reset_threshold = 3;
+    }
+    if (!file.read((uint8_t *)&_prefs.rx_fail_reboot_threshold, sizeof(_prefs.rx_fail_reboot_threshold))) { // 91
+      _prefs.rx_fail_reboot_threshold = 3;
+    }
+    // next: 92
 
     file.close();
   }
@@ -269,6 +276,9 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write((uint8_t *)&_prefs.autoadd_config, sizeof(_prefs.autoadd_config));           // 87
     file.write((uint8_t *)&_prefs.autoadd_max_hops, sizeof(_prefs.autoadd_max_hops));       // 88
     file.write((uint8_t *)&_prefs.rx_boosted_gain, sizeof(_prefs.rx_boosted_gain)); // 89
+    file.write((uint8_t *)&_prefs.tx_fail_reset_threshold, sizeof(_prefs.tx_fail_reset_threshold)); // 90
+    file.write((uint8_t *)&_prefs.rx_fail_reboot_threshold, sizeof(_prefs.rx_fail_reboot_threshold)); // 91
+    // next: 92
 
     file.close();
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -257,6 +257,15 @@ float MyMesh::getAirtimeBudgetFactor() const {
 int MyMesh::getInterferenceThreshold() const {
   return 0; // disabled for now, until currentRSSI() problem is resolved
 }
+uint8_t MyMesh::getTxFailResetThreshold() const {
+  return _prefs.tx_fail_reset_threshold;
+}
+uint8_t MyMesh::getRxFailRebootThreshold() const {
+  return _prefs.rx_fail_reboot_threshold;
+}
+void MyMesh::onRxUnrecoverable() {
+  board.reboot();
+}
 
 int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
   if (_prefs.rx_delay_base <= 0.0f) return 0;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -105,6 +105,9 @@ public:
 protected:
   float getAirtimeBudgetFactor() const override;
   int getInterferenceThreshold() const override;
+  uint8_t getTxFailResetThreshold() const override;
+  uint8_t getRxFailRebootThreshold() const override;
+  void onRxUnrecoverable() override;
   int calcRxDelay(float score, uint32_t air_time) const override;
   uint32_t getRetransmitDelay(const mesh::Packet *packet) override;
   uint32_t getDirectRetransmitDelay(const mesh::Packet *packet) override;

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -32,4 +32,6 @@ struct NodePrefs {  // persisted to file
   uint8_t client_repeat;
   uint8_t path_hash_mode;    // which path mode to use when sending
   uint8_t autoadd_max_hops;  // 0 = no limit, 1 = direct (0 hops), N = up to N-1 hops (max 64)
+  uint8_t tx_fail_reset_threshold;  // 0=disabled, 1-10, default 3
+  uint8_t rx_fail_reboot_threshold; // 0=disabled, 1-10, default 3
 };

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1066,6 +1066,10 @@ void MyMesh::removeNeighbor(const uint8_t *pubkey, int key_len) {
 #endif
 }
 
+void MyMesh::onRxUnrecoverable() {
+  board.reboot();
+}
+
 void MyMesh::formatStatsReply(char *reply) {
   StatsFormatHelper::formatCoreStats(reply, board, *_ms, _err_flags, _mgr);
 }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -153,6 +153,13 @@ protected:
   int getAGCResetInterval() const override {
     return ((int)_prefs.agc_reset_interval) * 4000;   // milliseconds
   }
+  uint8_t getTxFailResetThreshold() const override {
+    return _prefs.tx_fail_reset_threshold;
+  }
+  uint8_t getRxFailRebootThreshold() const override {
+    return _prefs.rx_fail_reboot_threshold;
+  }
+  void onRxUnrecoverable() override;
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;
   }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -159,6 +159,7 @@ protected:
   uint8_t getRxFailRebootThreshold() const override {
     return _prefs.rx_fail_reboot_threshold;
   }
+  uint16_t getRadioErrFlags() const override { return getErrFlags(); }
   void onRxUnrecoverable() override;
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -199,6 +199,10 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
   return 0; // unknown command
 }
 
+void MyMesh::onRxUnrecoverable() {
+  board.reboot();
+}
+
 void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
 #if MESH_PACKET_LOGGING
   Serial.print(getLogDateTime());

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -146,6 +146,7 @@ protected:
   uint8_t getRxFailRebootThreshold() const override {
     return _prefs.rx_fail_reboot_threshold;
   }
+  uint16_t getRadioErrFlags() const override { return getErrFlags(); }
   void onRxUnrecoverable() override;
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -140,6 +140,13 @@ protected:
   int getAGCResetInterval() const override {
     return ((int)_prefs.agc_reset_interval) * 4000;   // milliseconds
   }
+  uint8_t getTxFailResetThreshold() const override {
+    return _prefs.tx_fail_reset_threshold;
+  }
+  uint8_t getRxFailRebootThreshold() const override {
+    return _prefs.rx_fail_reboot_threshold;
+  }
+  void onRxUnrecoverable() override;
   uint8_t getExtraAckTransmitCount() const override {
     return _prefs.multi_acks;
   }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -326,6 +326,15 @@ int SensorMesh::getInterferenceThreshold() const {
 int SensorMesh::getAGCResetInterval() const {
   return ((int)_prefs.agc_reset_interval) * 4000;   // milliseconds
 }
+uint8_t SensorMesh::getTxFailResetThreshold() const {
+  return _prefs.tx_fail_reset_threshold;
+}
+uint8_t SensorMesh::getRxFailRebootThreshold() const {
+  return _prefs.rx_fail_reboot_threshold;
+}
+void SensorMesh::onRxUnrecoverable() {
+  board.reboot();
+}
 
 uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood) {
   ClientInfo* client;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -122,6 +122,7 @@ protected:
   int getAGCResetInterval() const override;
   uint8_t getTxFailResetThreshold() const override;
   uint8_t getRxFailRebootThreshold() const override;
+  uint16_t getRadioErrFlags() const override { return getErrFlags(); }
   void onRxUnrecoverable() override;
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -120,6 +120,9 @@ protected:
   uint32_t getDirectRetransmitDelay(const mesh::Packet* packet) override;
   int getInterferenceThreshold() const override;
   int getAGCResetInterval() const override;
+  uint8_t getTxFailResetThreshold() const override;
+  uint8_t getRxFailRebootThreshold() const override;
+  void onRxUnrecoverable() override;
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -76,10 +76,28 @@ void Dispatcher::loop() {
     prev_isrecv_mode = is_recv;
     if (!is_recv) {
       radio_nonrx_start = _ms->getMillis();
+    } else {
+      rx_stuck_count = 0;  // radio recovered — reset counter
     }
   }
   if (!is_recv && _ms->getMillis() - radio_nonrx_start > 8000) {   // radio has not been in Rx mode for 8 seconds!
     _err_flags |= ERR_EVENT_STARTRX_TIMEOUT;
+
+    rx_stuck_count++;
+    MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX stuck (attempt %d), calling onRxStuck()", getLogDateTime(), rx_stuck_count);
+    onRxStuck();
+
+    uint8_t reboot_threshold = getRxFailRebootThreshold();
+    if (reboot_threshold > 0 && rx_stuck_count >= reboot_threshold) {
+      MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX unrecoverable after %d attempts", getLogDateTime(), rx_stuck_count);
+      onRxUnrecoverable();
+    }
+
+    // Reset state to give recovery the full 8s window before re-triggering
+    radio_nonrx_start = _ms->getMillis();
+    prev_isrecv_mode = true;
+    cad_busy_start = 0;
+    next_agc_reset_time = futureMillis(getAGCResetInterval());
   }
 
   if (outbound) {  // waiting for outbound send to be completed
@@ -327,14 +345,31 @@ void Dispatcher::checkSend() {
       outbound_start = _ms->getMillis();
       bool success = _radio->startSendRaw(raw, len);
       if (!success) {
-        MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): ERROR: send start failed!", getLogDateTime());
+        MESH_DEBUG_PRINTLN("%s Dispatcher::checkSend(): ERROR: send start failed!", getLogDateTime());
 
         logTxFail(outbound, outbound->getRawLength());
-  
-        releasePacket(outbound);  // return to pool
+
+        // re-queue packet for retry instead of dropping it
+        int retry_delay = getCADFailRetryDelay();
+        unsigned long retry_time = futureMillis(retry_delay);
+        _mgr->queueOutbound(outbound, 0, retry_time);
         outbound = NULL;
+        next_tx_time = retry_time;
+
+        // count consecutive failures and reset radio if stuck
+        uint8_t threshold = getTxFailResetThreshold();
+        if (threshold > 0) {
+          tx_fail_count++;
+          if (tx_fail_count >= threshold) {
+            MESH_DEBUG_PRINTLN("%s Dispatcher::checkSend(): TX stuck (%d failures), resetting radio", getLogDateTime(), tx_fail_count);
+            onTxStuck();
+            tx_fail_count = 0;
+            next_tx_time = futureMillis(2000);
+          }
+        }
         return;
       }
+      tx_fail_count = 0;  // clear counter on successful TX start
       outbound_expiry = futureMillis(max_airtime);
 
     #if MESH_PACKET_LOGGING

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -60,7 +60,7 @@ uint32_t Dispatcher::getCADFailRetryDelay() const {
   return 200;
 }
 uint32_t Dispatcher::getCADFailMaxDuration() const {
-  return 4000;   // 4 seconds
+  return 6000;   // 6 seconds; allows more recovery time on congested nodes
 }
 
 void Dispatcher::loop() {
@@ -78,19 +78,40 @@ void Dispatcher::loop() {
       radio_nonrx_start = _ms->getMillis();
     } else {
       rx_stuck_count = 0;  // radio recovered — reset counter
+      rx_reboot_count = 0;
+      _err_flags &= ~(ERR_EVENT_RADIO_ZOMBIE | ERR_EVENT_RADIO_DEAD);
     }
+  } else if (is_recv && rx_stuck_count > 0) {
+    // After onRxStuck() we force prev_isrecv_mode = true. If recovery succeeds,
+    // is_recv == prev_isrecv_mode == true so the transition block above never fires
+    // and rx_stuck_count is never cleared. Catch that here.
+    rx_stuck_count = 0;
+    rx_reboot_count = 0;  // radio recovered; reset reboot attempt counter too
+    _err_flags &= ~(ERR_EVENT_RADIO_ZOMBIE | ERR_EVENT_RADIO_DEAD);  // radio is healthy again
   }
   if (!is_recv && _ms->getMillis() - radio_nonrx_start > 8000) {   // radio has not been in Rx mode for 8 seconds!
     _err_flags |= ERR_EVENT_STARTRX_TIMEOUT;
 
-    rx_stuck_count++;
+    if (rx_stuck_count < UINT8_MAX) rx_stuck_count++;  // saturate; don't wrap
     MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX stuck (attempt %d), calling onRxStuck()", getLogDateTime(), rx_stuck_count);
     onRxStuck();
 
     uint8_t reboot_threshold = getRxFailRebootThreshold();
     if (reboot_threshold > 0 && rx_stuck_count >= reboot_threshold) {
-      MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX unrecoverable after %d attempts", getLogDateTime(), rx_stuck_count);
-      onRxUnrecoverable();
+      _err_flags |= ERR_EVENT_RADIO_ZOMBIE;
+      uint8_t max_reboots = getRxMaxRebootAttempts();
+      if (max_reboots == 0 || rx_reboot_count < max_reboots) {
+        if (rx_reboot_count < UINT8_MAX) rx_reboot_count++;
+        MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX unrecoverable after %d stuck events, reboot attempt %d", getLogDateTime(), rx_stuck_count, rx_reboot_count);
+        onRxUnrecoverable();
+      } else {
+        // All reboot attempts exhausted — radio cannot self-recover, power cycle required.
+        _err_flags |= ERR_EVENT_RADIO_DEAD;
+        MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): RX reboot limit (%d) reached, radio dead (power cycle required)", getLogDateTime(), max_reboots);
+      }
+      // Reset to reboot_threshold (not 0): if reboot didn't happen, retry every 8s
+      // rather than waiting another full threshold * 8s cycle before trying again.
+      rx_stuck_count = reboot_threshold;
     }
 
     // Reset state to give recovery the full 8s window before re-triggering
@@ -148,7 +169,11 @@ void Dispatcher::loop() {
   }
 
   if (getAGCResetInterval() > 0 && millisHasNowPassed(next_agc_reset_time)) {
-    _radio->resetAGC();
+    // Use forceResetAGC so the periodic reset actually fires even when isReceivingPacket()
+    // returns true due to stuck IRQ bits (phantom preamble detection on SX126x/LR11x0/SX1276).
+    // Without this, a stuck isReceivingPacket() would silently block every periodic reset
+    // while the radio remains in a zombie state.
+    _radio->forceResetAGC();
     next_agc_reset_time = futureMillis(getAGCResetInterval());
   }
 
@@ -358,8 +383,10 @@ void Dispatcher::checkSend() {
 
         // count consecutive failures and reset radio if stuck
         uint8_t threshold = getTxFailResetThreshold();
-        if (threshold > 0) {
-          tx_fail_count++;
+        if (threshold == 0) {
+          tx_fail_count = 0;  // keep clean when feature disabled; stale count would fire early if threshold is later re-enabled
+        } else {
+          if (tx_fail_count < UINT8_MAX) tx_fail_count++;  // saturate; don't wrap
           if (tx_fail_count >= threshold) {
             MESH_DEBUG_PRINTLN("%s Dispatcher::checkSend(): TX stuck (%d failures), resetting radio", getLogDateTime(), tx_fail_count);
             onTxStuck();

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -126,6 +126,8 @@ class Dispatcher {
   unsigned long tx_budget_ms;
   unsigned long last_budget_update;
   unsigned long duty_cycle_window_ms;
+  uint8_t tx_fail_count;
+  uint8_t rx_stuck_count;
 
   void processRecvPacket(Packet* pkt);
   void updateTxBudget();
@@ -150,6 +152,8 @@ protected:
     tx_budget_ms = 0;
     last_budget_update = 0;
     duty_cycle_window_ms = 3600000;
+    tx_fail_count = 0;
+    rx_stuck_count = 0;
   }
 
   virtual DispatcherAction onRecvPacket(Packet* pkt) = 0;
@@ -167,6 +171,11 @@ protected:
   virtual uint32_t getCADFailMaxDuration() const;
   virtual int getInterferenceThreshold() const { return 0; }    // disabled by default
   virtual int getAGCResetInterval() const { return 0; }    // disabled by default
+  virtual uint8_t getTxFailResetThreshold() const { return 3; }  // reset radio after N consecutive TX failures; 0=disabled
+  virtual void onTxStuck() { _radio->resetAGC(); }               // override to use doFullRadioReset() when available
+  virtual uint8_t getRxFailRebootThreshold() const { return 3; } // reboot after N failed RX recovery attempts; 0=disabled
+  virtual void onRxStuck() { _radio->resetAGC(); }               // called each time RX stuck for 8s; override for deeper reset
+  virtual void onRxUnrecoverable() { }                           // called when reboot threshold exceeded; override to call _board->reboot()
   virtual unsigned long getDutyCycleWindowMs() const { return 3600000; }
 
 public:

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -66,6 +66,7 @@ public:
   virtual void triggerNoiseFloorCalibrate(int threshold) { }
 
   virtual void resetAGC() { }
+  virtual void forceResetAGC() { resetAGC(); }  // bypasses mid-receive guard; see RadioLibWrapper override
 
   virtual bool isInRecvMode() const = 0;
 
@@ -108,6 +109,13 @@ typedef uint32_t  DispatcherAction;
 #define ERR_EVENT_FULL              (1 << 0)
 #define ERR_EVENT_CAD_TIMEOUT       (1 << 1)
 #define ERR_EVENT_STARTRX_TIMEOUT   (1 << 2)
+// Set when reboot has been attempted but radio remains stuck (clears on recovery).
+// Indicates a zombie radio state that is actively being worked on.
+#define ERR_EVENT_RADIO_ZOMBIE      (1 << 3)
+// Set when getRxMaxRebootAttempts() is exhausted and radio cannot self-recover.
+// Requires a physical power cycle. Clears on recovery if it somehow succeeds.
+// Automatically cleared on MCU reboot (RAM-based).
+#define ERR_EVENT_RADIO_DEAD        (1 << 4)
 
 /**
  * \brief  The low-level task that manages detecting incoming Packets, and the queueing
@@ -128,6 +136,7 @@ class Dispatcher {
   unsigned long duty_cycle_window_ms;
   uint8_t tx_fail_count;
   uint8_t rx_stuck_count;
+  uint8_t rx_reboot_count;  // number of times onRxUnrecoverable() has been called without recovery
 
   void processRecvPacket(Packet* pkt);
   void updateTxBudget();
@@ -154,6 +163,7 @@ protected:
     duty_cycle_window_ms = 3600000;
     tx_fail_count = 0;
     rx_stuck_count = 0;
+    rx_reboot_count = 0;
   }
 
   virtual DispatcherAction onRecvPacket(Packet* pkt) = 0;
@@ -173,9 +183,10 @@ protected:
   virtual int getAGCResetInterval() const { return 0; }    // disabled by default
   virtual uint8_t getTxFailResetThreshold() const { return 3; }  // reset radio after N consecutive TX failures; 0=disabled
   virtual void onTxStuck() { _radio->resetAGC(); }               // override to use doFullRadioReset() when available
-  virtual uint8_t getRxFailRebootThreshold() const { return 3; } // reboot after N failed RX recovery attempts; 0=disabled
-  virtual void onRxStuck() { _radio->resetAGC(); }               // called each time RX stuck for 8s; override for deeper reset
-  virtual void onRxUnrecoverable() { }                           // called when reboot threshold exceeded; override to call _board->reboot()
+  virtual uint8_t getRxFailRebootThreshold() const { return 3; }  // reboot after N failed RX recovery attempts; 0=disabled
+  virtual uint8_t getRxMaxRebootAttempts() const { return 0; }    // max times to call onRxUnrecoverable() before giving up; 0=unlimited
+  virtual void onRxStuck() { _radio->forceResetAGC(); }           // called each time RX stuck for 8s; uses forceResetAGC to bypass stuck IRQ guard
+  virtual void onRxUnrecoverable() { }                            // called when reboot threshold exceeded; override to call _board->reboot()
   virtual unsigned long getDutyCycleWindowMs() const { return 3600000; }
 
 public:
@@ -193,6 +204,9 @@ public:
   uint32_t getNumSentDirect() const { return n_sent_direct; }
   uint32_t getNumRecvFlood() const { return n_recv_flood; }
   uint32_t getNumRecvDirect() const { return n_recv_direct; }
+  uint16_t getErrFlags() const { return _err_flags; }
+  bool isRadioZombie() const { return (_err_flags & ERR_EVENT_RADIO_ZOMBIE) != 0; }
+  bool isRadioDead() const   { return (_err_flags & ERR_EVENT_RADIO_DEAD)   != 0; }
   void resetStats() {
     n_sent_flood = n_sent_direct = n_recv_flood = n_recv_direct = 0;
     _err_flags = 0;

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -88,7 +88,13 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.read((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    if (!file.read((uint8_t *)&_prefs->tx_fail_reset_threshold, sizeof(_prefs->tx_fail_reset_threshold))) { // 291
+      _prefs->tx_fail_reset_threshold = 3;
+    }
+    if (!file.read((uint8_t *)&_prefs->rx_fail_reboot_threshold, sizeof(_prefs->rx_fail_reboot_threshold))) { // 292
+      _prefs->rx_fail_reboot_threshold = 3;
+    }
+    // next: 293
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -179,7 +185,9 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.write((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.write((uint8_t *)&_prefs->tx_fail_reset_threshold, sizeof(_prefs->tx_fail_reset_threshold)); // 291
+    file.write((uint8_t *)&_prefs->rx_fail_reboot_threshold, sizeof(_prefs->rx_fail_reboot_threshold)); // 292
+    // next: 293
 
     file.close();
   }
@@ -300,6 +308,10 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         sprintf(reply, "> %d", (uint32_t) _prefs->interference_threshold);
       } else if (memcmp(config, "agc.reset.interval", 18) == 0) {
         sprintf(reply, "> %d", ((uint32_t) _prefs->agc_reset_interval) * 4);
+      } else if (memcmp(config, "tx.fail.threshold", 17) == 0) {
+        sprintf(reply, "> %d", (uint32_t) _prefs->tx_fail_reset_threshold);
+      } else if (memcmp(config, "rx.fail.threshold", 17) == 0) {
+        sprintf(reply, "> %d", (uint32_t) _prefs->rx_fail_reboot_threshold);
       } else if (memcmp(config, "multi.acks", 10) == 0) {
         sprintf(reply, "> %d", (uint32_t) _prefs->multi_acks);
       } else if (memcmp(config, "allow.read.only", 15) == 0) {
@@ -463,6 +475,28 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         _prefs->agc_reset_interval = atoi(&config[19]) / 4;
         savePrefs();
         sprintf(reply, "OK - interval rounded to %d", ((uint32_t) _prefs->agc_reset_interval) * 4);
+      } else if (memcmp(config, "tx.fail.threshold ", 18) == 0) {
+        int val = atoi(&config[18]);
+        if (val < 0) val = 0;
+        if (val > 10) val = 10;
+        _prefs->tx_fail_reset_threshold = (uint8_t) val;
+        savePrefs();
+        if (val == 0) {
+          strcpy(reply, "OK - tx fail reset disabled");
+        } else {
+          sprintf(reply, "OK - tx fail reset after %d failures", val);
+        }
+      } else if (memcmp(config, "rx.fail.threshold ", 18) == 0) {
+        int val = atoi(&config[18]);
+        if (val < 0) val = 0;
+        if (val > 10) val = 10;
+        _prefs->rx_fail_reboot_threshold = (uint8_t) val;
+        savePrefs();
+        if (val == 0) {
+          strcpy(reply, "OK - rx fail reboot disabled");
+        } else {
+          sprintf(reply, "OK - reboot after %d rx recovery failures", val);
+        }
       } else if (memcmp(config, "multi.acks ", 11) == 0) {
         _prefs->multi_acks = atoi(&config[11]);
         savePrefs();

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -339,6 +339,14 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       } else if (memcmp(config, "radio.rxgain", 12) == 0) {
         sprintf(reply, "> %s", _prefs->rx_boosted_gain ? "on" : "off");
 #endif
+      } else if (memcmp(config, "radio.zombie", 12) == 0) {
+        uint16_t flags = _callbacks->getRadioErrFlags();
+        sprintf(reply, "> %s", (flags & ERR_EVENT_RADIO_ZOMBIE) ? "1" : "0");
+      } else if (memcmp(config, "radio.dead", 10) == 0) {
+        uint16_t flags = _callbacks->getRadioErrFlags();
+        sprintf(reply, "> %s", (flags & ERR_EVENT_RADIO_DEAD) ? "1" : "0");
+      } else if (memcmp(config, "radio.err", 9) == 0) {
+        sprintf(reply, "> 0x%04X", (uint32_t)_callbacks->getRadioErrFlags());
       } else if (memcmp(config, "radio", 5) == 0) {
         char freq[16], bw[16];
         strcpy(freq, StrHelper::ftoa(_prefs->freq));

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -60,6 +60,8 @@ struct NodePrefs { // persisted to file
   uint8_t rx_boosted_gain; // power settings
   uint8_t path_hash_mode;   // which path mode to use when sending
   uint8_t loop_detect;
+  uint8_t tx_fail_reset_threshold; // 0=disabled, 1-10, default 3
+  uint8_t rx_fail_reboot_threshold; // 0=disabled, 1-10, default 3
 };
 
 class CommonCLICallbacks {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -101,6 +101,8 @@ public:
   virtual void setRxBoostedGain(bool enable) {
     // no op by default
   };
+
+  virtual uint16_t getRadioErrFlags() const { return 0; }
 };
 
 class CommonCLI {

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -15,13 +15,18 @@ static volatile uint8_t state = STATE_IDLE;
 
 // this function is called when a complete packet
 // is transmitted by the module
-static 
+static
 #if defined(ESP8266) || defined(ESP32)
   ICACHE_RAM_ATTR
 #endif
 void setFlag(void) {
   // we sent a packet, set the flag
   state |= STATE_INT_READY;
+}
+
+// Returns true if there is a completed interrupt event pending (TX done or RX done).
+static inline bool hasPendingRadioEvent() {
+  return (state & STATE_INT_READY) != 0;
 }
 
 void RadioLibWrapper::begin() {
@@ -59,7 +64,7 @@ void RadioLibWrapper::doResetAGC() {
 
 void RadioLibWrapper::resetAGC() {
   // make sure we're not mid-receive of packet!
-  if ((state & STATE_INT_READY) != 0 || isReceivingPacket()) return;
+  if (hasPendingRadioEvent() || isReceivingPacket()) return;
 
   doResetAGC();
   state = STATE_IDLE;   // trigger a startReceive()
@@ -68,6 +73,33 @@ void RadioLibWrapper::resetAGC() {
   // Without this, a stuck _noise_floor of -120 makes the sampling threshold
   // too low (-106) to accept normal samples (~-105), self-reinforcing the
   // stuck value even after the receiver has recovered.
+  _noise_floor = 0;
+  _num_floor_samples = 0;
+  _floor_sample_sum = 0;
+}
+
+// Force reset, bypassing isReceivingPacket().
+//
+// On SX126x/LR11x0, isReceiving() reads live hardware IRQ flags (PREAMBLE_DETECTED,
+// HEADER_VALID/SYNC_WORD_HEADER_VALID). These flags are non-destructive reads and
+// can get persistently stuck when strong interference triggers preamble detection
+// without a completing packet. normal resetAGC() returns early in that case,
+// permanently blocking recovery.
+//
+// On SX1276, getModemStatus() bits (SIGNAL_DETECTED, SIGNAL_SYNCHRONIZED) can
+// similarly get stuck via false preamble detection on noise.
+//
+// For all radio types, doResetAGC() already handles the chip-specific reset
+// sequence (SX126x: sleep+standby+Calibrate(0x7F)+image recal; LR11x0: same via
+// lr11x0ResetAGC; SX1276: warm sleep). The sleep/standby/calibrate sequence on
+// SX126x/LR11x0 clears the stuck IRQ bits as a side effect.
+//
+// A pending completed interrupt (STATE_INT_READY) is still respected to avoid
+// discarding a packet that has already been received into the FIFO.
+void RadioLibWrapper::forceResetAGC() {
+  if (hasPendingRadioEvent()) return;
+  doResetAGC();
+  state = STATE_IDLE;
   _noise_floor = 0;
   _num_floor_samples = 0;
   _floor_sample_sum = 0;

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -42,6 +42,7 @@ public:
   int getNoiseFloor() const override { return _noise_floor; }
   void triggerNoiseFloorCalibrate(int threshold) override;
   void resetAGC() override;
+  void forceResetAGC() override;
 
   void loop() override;
 


### PR DESCRIPTION
## Problem

Two silent failure modes can leave the radio non-functional with no
recovery path:

1. **TX zombie:** `startSendRaw()` fails but the packet is silently
   dropped. The node appears to be running but nothing is transmitted.
2. **RX zombie:** The radio leaves RX mode and never returns.
   `ERR_EVENT_STARTRX_TIMEOUT` was already detecting this after 8s but
   no recovery action was taken.

## Changes

### Dispatcher

On `startSendRaw()` failure, re-queue the packet instead of dropping it.
Increment `tx_fail_count` on each failure and call `onTxStuck()` when the
count reaches the configured threshold. Reset to 0 on any successful TX.

On `STARTRX_TIMEOUT`, increment `rx_stuck_count` and call `onRxStuck()`
each 8s window. When the count reaches the threshold, call
`onRxUnrecoverable()`. After each recovery attempt, reset
`radio_nonrx_start`, `prev_isrecv_mode`, `cad_busy_start`, and
`next_agc_reset_time` so the 8s window restarts cleanly. Reset
`rx_stuck_count` to 0 when the radio returns to RX.

### Virtual hook API

```cpp
virtual uint8_t getTxFailResetThreshold() const { return 3; }
virtual void    onTxStuck()                     { _radio->resetAGC(); }
virtual uint8_t getRxFailRebootThreshold() const { return 3; }
virtual void    onRxStuck()                     { _radio->resetAGC(); }
virtual void    onRxUnrecoverable()             { }
```

Defaults are conservative (threshold 3, AGC reset as first attempt,
no-op unrecoverable). Subclasses override to reboot or do a deeper reset.

### NodePrefs / CLI

Thresholds are persisted and adjustable at runtime:

```
get tx.fail.threshold       -> current value (default 3)
set tx.fail.threshold 5     -> "OK - tx fail reset after 5 failures"
set tx.fail.threshold 0     -> "OK - tx fail reset disabled"

get rx.fail.threshold       -> current value (default 3)
set rx.fail.threshold 5     -> "OK - reboot after 5 rx recovery failures"
set rx.fail.threshold 0     -> "OK - rx fail reboot disabled"
```

CommonCLI stores these at fields 291/292 (next free: 293).
Companion radio stores at its own DataStore fields 90/91 (next free: 92).
Both default to 3 on first boot or upgrade from older firmware.

### Example overrides

All four examples override the threshold getters to return the persisted
prefs value and implement `onRxUnrecoverable()` to call `board.reboot()`.

---

## Follow-up: error flags, counter fixes, and forceResetAGC

The initial fix was confirmed non-functional when a radio entered zombie
mode in the field. Investigation identified several bugs:

**Root cause of failed recovery:** `resetAGC()` guards on
`isReceivingPacket()`, which reads live hardware IRQ flags
(`PREAMBLE_DETECTED`, `HEADER_VALID` on SX126x/LR11x0;
`SIGNAL_DETECTED`/`SIGNAL_SYNCHRONIZED` on SX1276). These flags can be
permanently stuck from interference, causing every recovery attempt to
silently no-op.

**Counter bugs:** `rx_stuck_count` was never reset after a forced
recovery attempt because `onRxStuck()` sets `prev_isrecv_mode = true`,
which prevents the normal transition check from firing. Both `uint8_t`
counters could also wrap to 0 at 255, defeating the threshold check.
After calling `onRxUnrecoverable()`, resetting the counter to 0 caused
the next retry to wait `threshold * 8s` instead of 8s.

### Additional changes

**`forceResetAGC()`** — new method on `RadioLibWrapper` that bypasses
the `isReceivingPacket()` guard. The chip-specific reset sequence
(SX126x/LR11x0: sleep + standby + calibrate; SX1276: warm sleep) already
clears stuck IRQ bits as a side effect. A pending completed interrupt is
still respected to avoid discarding a packet already in the FIFO.
`onRxStuck()` now calls `forceResetAGC()` instead of `resetAGC()`.

**Counter fixes:**
- All three `uint8_t` counters saturate at `UINT8_MAX` instead of wrapping
- `rx_stuck_count` resets to `reboot_threshold` (not 0) after a reboot attempt, so retries fire every 8s
- `rx_reboot_count` tracks how many times `onRxUnrecoverable()` has been called without recovery
- `tx_fail_count` is zeroed when the threshold is disabled (0) to prevent stale accumulation

**Max reboot attempts:**

```cpp
virtual uint8_t getRxMaxRebootAttempts() const { return 0; }  // 0 = unlimited
```

**Error flags** — two new queryable flags in `_err_flags`, cleared on
`begin()` and `resetStats()`:

- `ERR_EVENT_RADIO_ZOMBIE` (bit 3) — set when the stuck count exceeds the
  reboot threshold; cleared on recovery
- `ERR_EVENT_RADIO_DEAD` (bit 4) — set when `getRxMaxRebootAttempts()` is
  exhausted; requires a power cycle

Exposed via CLI on repeater, room server, and sensor firmware:

```
get radio.zombie    -> 0 or 1
get radio.dead      -> 0 or 1
get radio.err       -> 0x0000  (all flags as hex)
```

Also exposed programmatically:

```cpp
bool     isRadioZombie() const;
bool     isRadioDead()   const;
uint16_t getErrFlags()   const;
```

### Documentation

`docs/cli_commands.md` updated to document all new CLI commands:
- `get radio.zombie` / `get radio.dead` / `get radio.err` with error flag bit table
- `get`/`set tx.fail.threshold` and `get`/`set rx.fail.threshold`