### PR TITLE
feat: add gps support for the lilygo_t3s3_SX1276

### DIFF
--- a/variants/lilygo_t3s3_sx1276/platformio.ini
+++ b/variants/lilygo_t3s3_sx1276/platformio.ini
@@ -24,11 +24,16 @@ build_flags =
   -D SX176X_RXEN=21
   -D SX176X_TXEN=10
   -D LORA_TX_POWER=20
+  -D PIN_GPS_RX=44
+  -D PIN_GPS_TX=43
+  -D ENV_INCLUDE_GPS=1
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/lilygo_t3s3_sx1276>
+  +<helpers/sensors>
 lib_deps =
   ${esp32_base.lib_deps}
   adafruit/Adafruit SSD1306 @ ^2.5.13
+  stevemarple/MicroNMEA @ ^2.0.6
 
 ; === LilyGo T3S3 with SX1276 environments ===
 [env:LilyGo_T3S3_sx1276_repeater]

--- a/variants/lilygo_t3s3_sx1276/target.cpp
+++ b/variants/lilygo_t3s3_sx1276/target.cpp
@@ -14,7 +14,14 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 ESP32RTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
-SensorManager sensors;
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;

--- a/variants/lilygo_t3s3_sx1276/target.h
+++ b/variants/lilygo_t3s3_sx1276/target.h
@@ -6,7 +6,7 @@
 #include <helpers/ESP32Board.h>
 #include <helpers/radiolib/CustomSX1276Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
-#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
 #ifdef DISPLAY_CLASS
   #include <helpers/ui/SSD1306Display.h>
   #include <helpers/ui/MomentaryButton.h>
@@ -15,7 +15,7 @@
 extern ESP32Board board;
 extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
-extern SensorManager sensors;
+extern EnvironmentSensorManager sensors;
 
 #ifdef DISPLAY_CLASS
   extern DISPLAY_CLASS display;


### PR DESCRIPTION
This PR adds GPS support for the lilygo t3s3 with the SX1276 using pin 44 for RX and 43 for TX.
The pins were chosen since they are the only ones available without soldering https://wiki.lilygo.cc/get_started/en/LoRa_GPS/T3S3/T3S3.html#1276