### PR TITLE
waveshare_rp2040_lora: fix radio init, antenna switch and BLE build error 🤖🤖

### DIFF
--- a/variants/waveshare_rp2040_lora/platformio.ini
+++ b/variants/waveshare_rp2040_lora/platformio.ini
@@ -20,6 +20,7 @@ build_flags = ${rp2040_base.build_flags}
   -D P_LORA_MOSI=15
   -D P_LORA_TX_LED=25
   -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_RXEN=17
   -D SX126X_DIO3_TCXO_VOLTAGE=0
   -D SX126X_RX_BOOSTED_GAIN=1
   -D LORA_TX_POWER=22
@@ -33,6 +34,7 @@ build_src_filter = ${rp2040_base.build_src_filter}
   +<WaveshareBoard.cpp>
   +<../variants/waveshare_rp2040_lora>
 lib_deps = ${rp2040_base.lib_deps}
+lib_ignore = BLE
 
 [env:waveshare_rp2040_lora_repeater]
 extends = waveshare_rp2040_lora

--- a/variants/waveshare_rp2040_lora/target.cpp
+++ b/variants/waveshare_rp2040_lora/target.cpp
@@ -15,17 +15,7 @@ SensorManager sensors;
 bool radio_init() {
   rtc_clock.begin(Wire);
 
-  SPI1.setSCK(P_LORA_SCLK);
-  SPI1.setTX(P_LORA_MOSI);
-  SPI1.setRX(P_LORA_MISO);
-
-  pinMode(P_LORA_NSS, OUTPUT);
-  digitalWrite(P_LORA_NSS, HIGH);
-
-  SPI1.begin(false);
-
-  //passing NULL skips init of SPI
-  return radio.std_init(NULL);
+  return radio.std_init(&SPI1);
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
Problem
Building and flashing waveshare_rp2040_lora firmware resulted in two issues preventing the device from working:

Radio did not initialize — ERROR: radio init failed: -2 (RADIOLIB_ERR_CHIP_NOT_FOUND), SX1262 was not responding over SPI
Build failed — earlephilhower's BLE library was pulled in by PlatformIO's LDF despite not being used, causing a compile-time assertion error
Additionally, the antenna switch was not being controlled correctly due to a missing RXEN pin definition.

Changes
variants/waveshare_rp2040_lora/target.cpp
Replaced manual SPI1 setup (setSCK/setTX/setRX/begin(false) + std_init(NULL)) with radio.std_init(&SPI1). This is the same pattern used by other working RP2040 variants in this project (rak11310, rpi_picow). The manual approach failed to properly establish SPI communication with the SX1262.

variants/waveshare_rp2040_lora/platformio.ini
Added -D SX126X_RXEN=17 (GPIO17 / DIO4). The Waveshare RP2040-LoRa uses a PE4259 antenna switch with complementary control: DIO2 handles the CTRL signal via SX126X_DIO2_AS_RF_SWITCH, and GPIO17 must drive the inverted !CTRL signal. Without this, the antenna switch state during TX/RX was undefined.
Added lib_ignore = BLE to prevent PlatformIO LDF from picking up the earlephilhower BLE framework library, which requires Bluetooth hardware not present on this board.
Tested on
Waveshare RP2040-LoRa (HF) with waveshare_rp2040_lora_companion_radio_usb

(PS: pull request created by human, testing if 🤖🤖 in title is trap or repo is agent frendly 😅)