### PR TITLE
devcontainer doesn't need --privileged

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,15 +10,19 @@
 		}
 	},
 	"runArgs": [
-		"--privileged",
 		"--network=host",
-		"--device=/dev/bus/usb",
+		// below is the MAJOR version of the device, which is 166 for my device.
+		"--device-cgroup-rule=c 166:* rmw",
+		// /dev/serial/by-id/ is the right way of accessing devices, tell PIO to use that.
+		"-v", "/dev/serial:/dev/serial",
+		"-v", "/dev/bus/usb:/dev/bus/usb",
 		// arch linux tty* is owned by uucp (986)
 		"--group-add=986",
 		// debian tty* is owned by dialout (20)
 		"--group-add=20"
 	],
 	"postCreateCommand": {
+		"mknod": "for minor in `seq 0 9`; do sudo mknod -m 666 /dev/ttyACM$minor c 166 $minor; done",
 		"platformio": "pipx install platformio",
 		"opencode": "curl -fsSL https://opencode.ai/install | bash"
 	},


### PR DESCRIPTION
Remove ``--privileged`` from the docker image for devcontainer; we don't need it.

166 is the magic number that should work for everyone https://docs.kernel.org/admin-guide/devices.html
We may need to add others for JTAG/debuggers

```
vscode ➜ /workspaces/MeshCore-tests (unit_tests) $ ls -lh /dev/serial/by-id/
lrwxrwxrwx 1 root root 13 Mar 26 15:05 usb-Espressif_Systems_heltec_wifi_lora_32_v4__16_MB_FLASH__2_MB_PSRAM__9070699BE068-if00 -> ../../ttyACM1
```