### PR TITLE
fix: use max estimated airtime for duty cycle enforcement

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -271,19 +271,21 @@ void Dispatcher::processRecvPacket(Packet* pkt) {
   }
 }
 
-void Dispatcher::checkSend() {
-  if (_mgr->getOutboundCount(_ms->getMillis()) == 0) return;
-  
-  updateTxBudget();
-  
-  uint32_t est_airtime = _radio->getEstAirtimeFor(MAX_TRANS_UNIT);
+void Dispatcher::ensureTxDutyCycle(int tx_len) {
+  uint32_t est_airtime = _radio->getEstAirtimeFor(tx_len);
   if (tx_budget_ms < est_airtime / MIN_TX_BUDGET_AIRTIME_DIV) {
     float duty_cycle = 1.0f / (1.0f + getAirtimeBudgetFactor());
     unsigned long needed = est_airtime / MIN_TX_BUDGET_AIRTIME_DIV - tx_budget_ms;
     next_tx_time = futureMillis((unsigned long)(needed / duty_cycle));
-    return;
   }
-  
+}
+
+void Dispatcher::checkSend() {
+  if (_mgr->getOutboundCount(_ms->getMillis()) == 0) return;
+
+  updateTxBudget();
+  ensureTxDutyCycle(MAX_TRANS_UNIT);
+
   if (!millisHasNowPassed(next_tx_time)) return;
   if (_radio->isReceiving()) {
     if (cad_busy_start == 0) {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -11,6 +11,8 @@ namespace mesh {
 #define MAX_RX_DELAY_MILLIS        32000  // 32 seconds
 #define MIN_TX_BUDGET_RESERVE_MS   100    // min budget (ms) required before allowing next TX
 #define MIN_TX_BUDGET_AIRTIME_DIV  2      // require at least 1/N of estimated airtime as budget before TX
+/// add some time to get the max allowed airtime for the est. airtime
+#define MAX_TX_AIRTIME_FOR_EST(est_airtime) (((est_airtime) * 3) / 2)
 
 #ifndef NOISE_FLOOR_CALIB_INTERVAL
   #define NOISE_FLOOR_CALIB_INTERVAL   2000     // 2 seconds
@@ -325,7 +327,7 @@ void Dispatcher::checkSend() {
     } else {
       memcpy(&raw[len], outbound->payload, outbound->payload_len); len += outbound->payload_len;
 
-      uint32_t max_airtime = _radio->getEstAirtimeFor(len)*3/2;
+      uint32_t max_airtime = MAX_TX_AIRTIME_FOR_EST(_radio->getEstAirtimeFor(len));
       outbound_start = _ms->getMillis();
       bool success = _radio->startSendRaw(raw, len);
       if (!success) {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -10,7 +10,6 @@ namespace mesh {
 
 #define MAX_RX_DELAY_MILLIS        32000  // 32 seconds
 #define MIN_TX_BUDGET_RESERVE_MS   100    // min budget (ms) required before allowing next TX
-#define MIN_TX_BUDGET_AIRTIME_DIV  2      // require at least 1/N of estimated airtime as budget before TX
 /// add some time to get the max allowed airtime for the est. airtime
 #define MAX_TX_AIRTIME_FOR_EST(est_airtime) (((est_airtime) * 3) / 2)
 
@@ -275,9 +274,9 @@ void Dispatcher::processRecvPacket(Packet* pkt) {
 
 void Dispatcher::ensureTxDutyCycle(int tx_len) {
   uint32_t est_airtime = _radio->getEstAirtimeFor(tx_len);
-  if (tx_budget_ms < est_airtime / MIN_TX_BUDGET_AIRTIME_DIV) {
+  if (tx_budget_ms < MAX_TX_AIRTIME_FOR_EST(est_airtime)) {
     float duty_cycle = 1.0f / (1.0f + getAirtimeBudgetFactor());
-    unsigned long needed = est_airtime / MIN_TX_BUDGET_AIRTIME_DIV - tx_budget_ms;
+    unsigned long needed = MAX_TX_AIRTIME_FOR_EST(est_airtime) - tx_budget_ms;
     next_tx_time = futureMillis((unsigned long)(needed / duty_cycle));
   }
 }

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -195,6 +195,13 @@ public:
 
 private:
   bool tryParsePacket(Packet* pkt, const uint8_t* raw, int len);
+  /**
+   * \brief ensure the next tx time obeys the duty cycle
+   * 
+   * Internally this updates the next_tx_time so that the Tx
+   * is executed by earliest the next allowed time slot.
+   */
+  void ensureTxDutyCycle(int tx_len);
   void checkRecv();
   void checkSend();
 };


### PR DESCRIPTION
Previously the max required airtime to enter the next transmit slot was computed to be half the estimated time. However, the transmit logic uses 1.5 times the estimated time as maximum TX duration. By that, the duty cycle could still be violated as the actual transmit logic might send for longer than what we ensured to stay within the cycle.

We fix this by aligning both computations and always use 1.5 times the estimated airtime.

Xref: #817