### PR TITLE
Add JOYSTICK_ROTATION build flag for joystick-equipped boards

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -29,6 +29,11 @@
   #define PRESS_LABEL "long press"
 #endif
 
+#if defined(JOYSTICK_ROTATION) && (JOYSTICK_ROTATION == 1 || JOYSTICK_ROTATION == 3) \
+    && (!defined(JOYSTICK_UP) || !defined(JOYSTICK_DOWN))
+  #error "JOYSTICK_ROTATION 1/3 requires JOYSTICK_UP and JOYSTICK_DOWN pin definitions"
+#endif
+
 #include "icons.h"
 
 class SplashScreen : public UIScreen {
@@ -711,6 +716,49 @@ void UITask::loop() {
   } else if (ev == BUTTON_EVENT_LONG_PRESS) {
     c = handleLongPress(KEY_ENTER);  // REVISIT: could be mapped to different key code
   }
+#if defined(JOYSTICK_ROTATION) && JOYSTICK_ROTATION == 1
+  // 90 deg clockwise: physical up/down map to right/left on screen
+  ev = joystick_down.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_LEFT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_LEFT);
+  }
+  ev = joystick_up.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_RIGHT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_RIGHT);
+  }
+#elif defined(JOYSTICK_ROTATION) && JOYSTICK_ROTATION == 2
+  // 180 deg: physical left/right are swapped
+  ev = joystick_right.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_LEFT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_LEFT);
+  }
+  ev = joystick_left.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_RIGHT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_RIGHT);
+  }
+#elif defined(JOYSTICK_ROTATION) && JOYSTICK_ROTATION == 3
+  // 270 deg (90 deg counter-clockwise): physical up/down map to left/right on screen
+  ev = joystick_up.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_LEFT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_LEFT);
+  }
+  ev = joystick_down.check();
+  if (ev == BUTTON_EVENT_CLICK) {
+    c = checkDisplayOn(KEY_RIGHT);
+  } else if (ev == BUTTON_EVENT_LONG_PRESS) {
+    c = handleLongPress(KEY_RIGHT);
+  }
+#else
   ev = joystick_left.check();
   if (ev == BUTTON_EVENT_CLICK) {
     c = checkDisplayOn(KEY_LEFT);
@@ -723,6 +771,7 @@ void UITask::loop() {
   } else if (ev == BUTTON_EVENT_LONG_PRESS) {
     c = handleLongPress(KEY_RIGHT);
   }
+#endif
   ev = back_btn.check();
   if (ev == BUTTON_EVENT_TRIPLE_CLICK) {
     c = handleTripleClick(KEY_SELECT);

--- a/variants/gat562_30s_mesh_kit/target.cpp
+++ b/variants/gat562_30s_mesh_kit/target.cpp
@@ -15,6 +15,10 @@ GAT56230SMeshKitBoard board;
   MomentaryButton joystick_left(JOYSTICK_LEFT, 1000, true, false, false);
   MomentaryButton joystick_right(JOYSTICK_RIGHT, 1000, true, false, false);
   MomentaryButton back_btn(PIN_BACK_BTN, 1000, true, false, true);
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    MomentaryButton joystick_up(JOYSTICK_UP, 1000, true, false, false);
+    MomentaryButton joystick_down(JOYSTICK_DOWN, 1000, true, false, false);
+  #endif
 #endif
 
 

--- a/variants/gat562_30s_mesh_kit/target.h
+++ b/variants/gat562_30s_mesh_kit/target.h
@@ -16,6 +16,10 @@
   extern MomentaryButton joystick_left;
   extern MomentaryButton joystick_right;
   extern MomentaryButton back_btn;
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    extern MomentaryButton joystick_up;
+    extern MomentaryButton joystick_down;
+  #endif
 #endif
 
 extern GAT56230SMeshKitBoard board;

--- a/variants/gat562_mesh_tracker_pro/target.cpp
+++ b/variants/gat562_mesh_tracker_pro/target.cpp
@@ -15,6 +15,10 @@ GAT562MeshTrackerProBoard board;
   MomentaryButton joystick_left(JOYSTICK_LEFT, 1000, true, false, false);
   MomentaryButton joystick_right(JOYSTICK_RIGHT, 1000, true, false, false);
   MomentaryButton back_btn(PIN_BACK_BTN, 1000, true, false, true);
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    MomentaryButton joystick_up(JOYSTICK_UP, 1000, true, false, false);
+    MomentaryButton joystick_down(JOYSTICK_DOWN, 1000, true, false, false);
+  #endif
 #endif
 
 

--- a/variants/gat562_mesh_tracker_pro/target.h
+++ b/variants/gat562_mesh_tracker_pro/target.h
@@ -16,6 +16,10 @@
   extern MomentaryButton joystick_left;
   extern MomentaryButton joystick_right;
   extern MomentaryButton back_btn;
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    extern MomentaryButton joystick_up;
+    extern MomentaryButton joystick_down;
+  #endif
 #endif
 
 extern GAT562MeshTrackerProBoard board;

--- a/variants/wio-tracker-l1-eink/platformio.ini
+++ b/variants/wio-tracker-l1-eink/platformio.ini
@@ -51,6 +51,7 @@ build_flags = ${WioTrackerL1Eink.build_flags}
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=GxEPDDisplay
   -D UI_HAS_JOYSTICK=1
+  ; -D JOYSTICK_ROTATION=1  ; rotate joystick 90 deg CW (display mounted beside joystick)
   -D PIN_BUZZER=12
   -D QSPIFLASH=1
   ; -D MESH_PACKET_LOGGING=1

--- a/variants/wio-tracker-l1/target.cpp
+++ b/variants/wio-tracker-l1/target.cpp
@@ -25,6 +25,10 @@ EnvironmentSensorManager sensors = EnvironmentSensorManager();
   MomentaryButton joystick_left(JOYSTICK_LEFT, 1000, true, false, false);
   MomentaryButton joystick_right(JOYSTICK_RIGHT, 1000, true, false, false);
   MomentaryButton back_btn(PIN_BACK_BTN, 1000, true, false, true);
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    MomentaryButton joystick_up(JOYSTICK_UP, 1000, true, false, false);
+    MomentaryButton joystick_down(JOYSTICK_DOWN, 1000, true, false, false);
+  #endif
 #endif
 
 bool radio_init() {

--- a/variants/wio-tracker-l1/target.h
+++ b/variants/wio-tracker-l1/target.h
@@ -28,6 +28,10 @@ extern EnvironmentSensorManager sensors;
   extern MomentaryButton joystick_left;
   extern MomentaryButton joystick_right;
   extern MomentaryButton back_btn;
+  #if defined(JOYSTICK_UP) && defined(JOYSTICK_DOWN)
+    extern MomentaryButton joystick_up;
+    extern MomentaryButton joystick_down;
+  #endif
 #endif
 
 bool radio_init();


### PR DESCRIPTION
  ## Motivation                                                                                                                                                                                                                                                        
  
  Some 3D-printed enclosures for the Wio Tracker L1 eInk (e.g.                                                                                                                                                                                                         
  [this one on Printables](https://www.printables.com/model/1420534-seeed-wio-tracker-l1-e-ink-enclosure))
  mount the display beside the joystick rather than above it. In this                                                                                                                                                                                                  
  orientation the physical up/down buttons align with left/right navigation                                                                                                                                                                                            
  on screen, making the default joystick mapping unusable.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                       
  I tried working around this with `DISPLAY_ROTATION` but the current UI                                                                                                                                                                                               
  does not handle portrait orientation well — that would need more involved
  changes. This PR takes the simpler approach of remapping the joystick                                                                                                                                                                                                
  input to match the physical orientation, which is sufficient for normal
  use. (Happy to also look into proper portrait UI support if that's of                                                                                                                                                                                                
  interest to maintainers.)                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                       
  ## Changes                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                       
  Adds a `JOYSTICK_ROTATION` build flag following the same `0`–`3`                                                                                                                                                                                                     
  convention as `DISPLAY_ROTATION`:
                                                                                                                                                                                                                                                                       
  | Value | Effect |                                                                                                                                                                                                                                                   
  |-------|--------|
  | `0` (default) | no change — left/right navigate left/right |                                                                                                                                                                                                       
  | `1` | 90° CW — up/down navigate right/left |                                                                                                                                                                                                                       
  | `2` | 180° — left/right are swapped |
  | `3` | 270° — up/down navigate left/right |                                                                                                                                                                                                                         
                                                            
  Variants that define `JOYSTICK_UP`/`JOYSTICK_DOWN` pins                                                                                                                                                                                                              
  (`wio-tracker-l1`, `gat562_mesh_tracker_pro`, `gat562_30s_mesh_kit`)
  now instantiate `joystick_up` and `joystick_down` `MomentaryButton`                                                                                                                                                                                                  
  objects so they are available when rotation 1 or 3 is selected.                                                                                                                                                                                                      
  A compile-time `#error` catches misconfigured builds (rotation 1/3                                                                                                                                                                                                   
  without the required pin definitions).                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                       
  To enable on Wio Tracker L1 eInk, uncomment in `platformio.ini`:                                                                                                                                                                                                     
  ```ini                                                                                                                                                                                                                                                               
  -D JOYSTICK_ROTATION=1                                                                                                                                                                                                                                               
 ```
                                                           
## Testing

  Tested on physical Wio Tracker L1 eInk hardware with the enclosure                                                                                                                                                                                                   
  linked above.
