### PR TITLE
fix: enable radio.rxgain CLI command for LR1110 (T1000-E)

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -547,7 +547,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     _prefs->disable_fwd = memcmp(&config[7], "off", 3) == 0;
     savePrefs();
     strcpy(reply, _prefs->disable_fwd ? "OK - repeat is now OFF" : "OK - repeat is now ON");
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110)
   } else if (memcmp(config, "radio.rxgain ", 13) == 0) {
     _prefs->rx_boosted_gain = memcmp(&config[13], "on", 2) == 0;
     strcpy(reply, "OK");
@@ -769,7 +769,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lat));
   } else if (memcmp(config, "lon", 3) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lon));
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110)
   } else if (memcmp(config, "radio.rxgain", 12) == 0) {
     sprintf(reply, "> %s", _prefs->rx_boosted_gain ? "on" : "off");
 #endif

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -13,6 +13,7 @@ build_flags = ${nrf52_base.build_flags}
   -D USER_BTN_PRESSED=HIGH
   -D PIN_STATUS_LED=24
   -D RADIO_CLASS=CustomLR1110
+  -D USE_LR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper
   -D LORA_TX_POWER=22
   -D RF_SWITCH_TABLE


### PR DESCRIPTION
## Problem

`radio.rxgain` get/set commands were broken on T1000-E (LR1110).

The CLI branches in `CommonCLI.cpp` were guarded by
`#if defined(USE_SX1262) || defined(USE_SX1268)`, but `USE_LR1110` was
not defined in the T1000-E build, so both branches were compiled out.

This caused two different failure modes:

- `get radio.rxgain` → returned the full radio config string (e.g.
  `> 921.000,125.0,10,5`) because `memcmp("radio", 5)` matched the
  next branch
- `set radio.rxgain on` → returned `unknown config: radio.rxgain on`
  because no branch matched

## Fix

- Add `-D USE_LR1110` to `variants/t1000-e/platformio.ini`
- Add `USE_LR1110` to the `#if` guard on both get and set branches

`CustomLR1110Wrapper` already implements `setRxBoostedGainMode()` and
`getRxBoostedGainMode()` via the `RadioLibWrapper` virtual interface —
no radio-layer changes required.

## Testing (T1000-E)

- `get radio.rxgain` → `> off` ✅
- `set radio.rxgain on` → `OK` ✅  
- `get radio.rxgain` after reboot → `> on` ✅