### PR TITLE
fix: correct ADVERT_NAME for ThinkNode M5 (was M2)

### DIFF
--- a/variants/thinknode_m5/platformio.ini
+++ b/variants/thinknode_m5/platformio.ini
@@ -58,7 +58,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 build_flags =
   ${ThinkNode_M5.build_flags}
-  -D ADVERT_NAME='"Thinknode M2 Repeater"'
+  -D ADVERT_NAME='"Thinknode M5 Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
@@ -116,7 +116,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/simple_room_server>
 build_flags =
   ${ThinkNode_M5.build_flags}
-  -D ADVERT_NAME='"Thinknode M2 Room Server"'
+  -D ADVERT_NAME='"Thinknode M5 Room Server"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'


### PR DESCRIPTION
## Summary

`variants/thinknode_m5/platformio.ini` had the wrong `ADVERT_NAME` in two
environments, causing ThinkNode M5 nodes to advertise themselves as
"Thinknode M2" on the mesh.

## Changes

- `env:ThinkNode_M5_Repeater`: `"Thinknode M2 Repeater"` → `"Thinknode M5 Repeater"`
- `env:ThinkNode_M5_room_server`: `"Thinknode M2 Room Server"` → `"Thinknode M5 Room Server"`

## Related

Noticed while investigating #1319.