### PR TITLE
fix: correct ADVERT_NAME for Generic ESPNow room server (was 'Heltec Room')

### DIFF
--- a/variants/generic_espnow/platformio.ini
+++ b/variants/generic_espnow/platformio.ini
@@ -69,7 +69,7 @@ lib_deps =
 extends = Generic_ESPNOW
 build_flags =
   ${Generic_ESPNOW.build_flags}
-  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_NAME='"Generic ESPNow Room"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'


### PR DESCRIPTION
## Summary

`env:Generic_ESPNOW_room_svr` in `variants/generic_espnow/platformio.ini`
had `ADVERT_NAME` set to `"Heltec Room"` — a copy-paste error from the
Heltec variant. This causes Generic ESPNow room server nodes to advertise
with the wrong device name on the mesh.

## Change

- `"Heltec Room"` → `"Generic ESPNow Room"`