### PR TITLE
fix: expose radio.rxgain CLI to Companion firmware

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2046,9 +2046,20 @@ void MyMesh::checkCLIRescueCmd() {
         _prefs.ble_pin = atoi(&config[4]);
         savePrefs();
         Serial.printf("  > pin is now %06d\n", _prefs.ble_pin);
+
+      } else if (memcmp(config, "radio.rxgain ", 13) == 0) {
+        _prefs.rx_boosted_gain = memcmp(&config[13], "on", 2) == 0;
+        savePrefs();
+        radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
+        Serial.println("  > OK");
+
       } else {
         Serial.printf("  Error: unknown config: %s\n", config);
       }
+
+    } else if (memcmp(cli_command, "get radio.rxgain", 16) == 0) {
+      Serial.printf("  > %s\n", _prefs.rx_boosted_gain ? "on" : "off");
+
     } else if (strcmp(cli_command, "rebuild") == 0) {
       bool success = _store->formatFileSystem();
       if (success) {


### PR DESCRIPTION
## Problem
`get/set radio.rxgain` commands were only available on Repeater and 
Room Server firmware via CommonCLI. Companion firmware returned 
"unknown config" for these commands.

This was noted as a follow-up in PR #1653 by jbrazio:
> "That could probably be added in a follow up PR"

## Changes
- Added `get radio.rxgain` to Companion CLI rescue mode
- Added `set radio.rxgain on/off` to Companion CLI rescue mode
- Setting is persisted via `savePrefs()` and applied immediately 
  via `radio_driver.setRxBoostedGainMode()`

## Testing
Tested on WisMesh Tag (nRF52840 + SX1262):
- `get radio.rxgain` → returns current state
- `set radio.rxgain on` / `set radio.rxgain off` → confirmed working
- Setting persists after reboot