### PR TITLE
fix: remove real WiFi credentials from ThinkNode M5 variant

### DIFF
--- a/variants/thinknode_m5/platformio.ini
+++ b/variants/thinknode_m5/platformio.ini
@@ -193,8 +193,8 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D OFFLINE_QUEUE_SIZE=256
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"Livebox-633C"'
-  -D WIFI_PWD='"vvQUHGSxsWd7fKMYSr"'
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
 build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<helpers/ui/MomentaryButton.cpp>


### PR DESCRIPTION
## Summary

`variants/thinknode_m5/platformio.ini` contained actual WiFi credentials
(SSID: Livebox-633C) committed by mistake. Replaced with placeholder
values `myssid`/`mypwd`, consistent with all other variants.

## Change

- `WIFI_SSID`: `"Livebox-633C"` → `"myssid"`
- `WIFI_PWD`: `"vvQUHGSxsWd7fKMYSr"` → `"mypwd"`