### PR TITLE
ESP32 Arduino SDK 3.x fixes

### DIFF
--- a/src/helpers/esp32/ESPNOWRadio.cpp
+++ b/src/helpers/esp32/ESPNOWRadio.cpp
@@ -1,5 +1,6 @@
 #include "ESPNOWRadio.h"
 #include <esp_now.h>
+#include <esp_mac.h>
 #include <WiFi.h>
 #include <esp_wifi.h>
 

--- a/src/helpers/esp32/ESPNOWRadio.cpp
+++ b/src/helpers/esp32/ESPNOWRadio.cpp
@@ -16,7 +16,11 @@ static void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
   ESPNOW_DEBUG_PRINTLN("Send Status: %d", (int)status);
 }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+static void OnDataRecv(const esp_now_recv_info_t *info, const uint8_t *data, int len) {
+#else
 static void OnDataRecv(const uint8_t *mac, const uint8_t *data, int len) {
+#endif
   ESPNOW_DEBUG_PRINTLN("Recv: len = %d", len);
   memcpy(rx_buf, data, len);
   last_rx_len = len;

--- a/src/helpers/esp32/ESPNOWRadio.cpp
+++ b/src/helpers/esp32/ESPNOWRadio.cpp
@@ -12,7 +12,11 @@ static uint8_t rx_buf[256];
 static uint8_t last_rx_len = 0;
 
 // callback when data is sent
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+static void OnDataSent(const esp_now_send_info_t *tx_info, esp_now_send_status_t status) {
+#else
 static void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
+#endif
   is_send_complete = true;
   ESPNOW_DEBUG_PRINTLN("Send Status: %d", (int)status);
 }

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -29,8 +29,10 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   BLEDevice::setMTU(MAX_FRAME_SIZE);
 
   BLESecurity  sec;
-  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   sec.setPassKey(true, pin_code);
+  sec.setCapability(ESP_IO_CAP_OUT);
+  sec.setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 #else
   sec.setStaticPIN(pin_code);
 #endif

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -29,7 +29,11 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   BLEDevice::setMTU(MAX_FRAME_SIZE);
 
   BLESecurity  sec;
+  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+  sec.setPassKey(true, pin_code);
+#else
   sec.setStaticPIN(pin_code);
+#endif
   sec.setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
 
   //BLEDevice::setPower(ESP_PWR_LVL_N8);

--- a/src/helpers/ui/SSD1306Display.h
+++ b/src/helpers/ui/SSD1306Display.h
@@ -8,11 +8,11 @@
 #include <helpers/RefCountedDigitalPin.h>
 
 #ifndef PIN_OLED_RESET
-  #define PIN_OLED_RESET        21 // Reset pin # (or -1 if sharing Arduino reset pin)
+#define PIN_OLED_RESET -1
 #endif
 
 #ifndef DISPLAY_ADDRESS
-  #define DISPLAY_ADDRESS   0x3C
+#define DISPLAY_ADDRESS 0x3C
 #endif
 
 class SSD1306Display : public DisplayDriver {


### PR DESCRIPTION
Here I will fix incompatible things with SDK 3.x IDF 5

- first thing is mentioned in #2264 
- far for now this contain fix of ESPNow! call back as it changed prototype

TODO for SDK 3 full support:
- Something reinitialize I2C, my guess was XPowerLibs on Tbeam, but if I will comment it out, it still does not works well (OLED for example)
- also PMU seem to works during board  initialization, but later in app is missing bat voltage/percent

```
DEBUG: Warning: Failed to find AXP2101 power management
DEBUG: AXP192 PMU init succeeded, using AXU...
        Found AXP192/AXP2101 PMU
        Found SSD1306/SH1106 display
Scan for devices is complete.

GPS RX pin: 12 GPS TX pin: 34

isCharging:YES
isDischarge:NO
isVbusIn:YES
getBattVoltage:4193mV
getVbusVoltage:5049mV
getSystemVoltage:4949mV
getBatteryPercent:100%

/// and since this one... So something deinitalized I2C or using different instance

[   792][E][esp32-hal-i2c.c:307] i2cSetClock(): bus is not initialized
[   798][E][esp32-hal-i2c.c:193] i2cWrite(): bus is not initialized
```