### PR TITLE
Added Power Saving for NRF52 companions to have extra 30% battery life

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2144,3 +2144,11 @@ bool MyMesh::advert() {
     return false;
   }
 }
+
+// To check if there is pending work
+bool MyMesh::hasPendingWork() const {
+#if defined(WITH_BRIDGE)
+  if (bridge.isRunning()) return true; // bridge needs WiFi radio, can't sleep
+#endif
+  return _mgr->getOutboundTotal() > 0;
+}

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2222,3 +2222,11 @@ bool MyMesh::advert() {
     return false;
   }
 }
+
+// To check if there is pending work
+bool MyMesh::hasPendingWork() const {
+#if defined(WITH_BRIDGE)
+  if (bridge.isRunning()) return true; // bridge needs WiFi radio, can't sleep
+#endif
+  return _mgr->getOutboundTotal() > 0;
+}

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2225,8 +2225,5 @@ bool MyMesh::advert() {
 
 // To check if there is pending work
 bool MyMesh::hasPendingWork() const {
-#if defined(WITH_BRIDGE)
-  if (bridge.isRunning()) return true; // bridge needs WiFi radio, can't sleep
-#endif
   return _mgr->getOutboundTotal() > 0;
 }

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -174,6 +174,9 @@ public:
       sensors.setSettingValue("gps_interval", interval_str);
     }
   }
+
+  // To check if there is pending work
+  bool hasPendingWork() const;
 #endif
 
 private:

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -174,10 +174,10 @@ public:
       sensors.setSettingValue("gps_interval", interval_str);
     }
   }
+#endif
 
   // To check if there is pending work
   bool hasPendingWork() const;
-#endif
 
 private:
   void writeOKFrame();

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -175,10 +175,10 @@ public:
       sensors.setSettingValue("gps_interval", interval_str);
     }
   }
+#endif
 
   // To check if there is pending work
   bool hasPendingWork() const;
-#endif
 
 private:
   void writeOKFrame();

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -175,6 +175,9 @@ public:
       sensors.setSettingValue("gps_interval", interval_str);
     }
   }
+
+  // To check if there is pending work
+  bool hasPendingWork() const;
 #endif
 
 private:

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -229,4 +229,10 @@ void loop() {
   ui_task.loop();
 #endif
   rtc_clock.tick();
+
+  if (!the_mesh.hasPendingWork()) {
+#if defined(NRF52_PLATFORM)
+    board.sleep(0); // nrf ignores seconds param, sleeps whenever possible
+#endif
+  }
 }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -248,13 +248,19 @@ void loop() {
 #endif
   rtc_clock.tick();
 
+  if (!the_mesh.hasPendingWork()) {
+#if defined(NRF52_PLATFORM)
+    board.sleep(0); // nrf ignores seconds param, sleeps whenever possible
+#endif
+  }
+
 #if defined(ESP32) && defined(WIFI_SSID)
   // Safely attempt to reconnect every 10 seconds if flagged
   if (wifi_needs_reconnect && (millis() - last_wifi_reconnect_attempt > 10000)) {
-      WIFI_DEBUG_PRINTLN("Attempting manual WiFi reconnect...");
-      WiFi.disconnect();
-      WiFi.reconnect();
-      last_wifi_reconnect_attempt = millis();
+    WIFI_DEBUG_PRINTLN("Attempting manual WiFi reconnect...");
+    WiFi.disconnect();
+    WiFi.reconnect();
+    last_wifi_reconnect_attempt = millis();
   }
 #endif
 }


### PR DESCRIPTION
Hi friends,
This PR is to reduce 30% power consumption for NRF52 companions.
- From 9.3mA down to 6.5mA. Measured at battery cable.
- It is enabled by default as there is no CLI in companion.
- BLE connection will be maintained in any case.

Expected behavior: You will not see any differences against MeshCore dev. Except the battery life is longer.
Your NRF52 companions can virtually have extra 30% more battery capacity.
Enjoy.