### PR TITLE
Add WiFi reconnection to companion radio

### DIFF
--- a/src/helpers/esp32/SerialWifiInterface.cpp
+++ b/src/helpers/esp32/SerialWifiInterface.cpp
@@ -53,6 +53,15 @@ void SerialWifiInterface::resetReceivedFrameHeader() {
 }
 
 size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
+  // periodic WiFi health check (every 60s, only after first successful connection)
+  if (WiFi.status() == WL_CONNECTED) {
+    _wifi_was_connected = true;
+  } else if (_wifi_was_connected && millis() >= _wifi_check_time) {
+    WIFI_DEBUG_PRINTLN("WiFi disconnected, attempting reconnect...");
+    WiFi.reconnect();
+    _wifi_check_time = millis() + 60000;
+  }
+
   // check if new client connected
   auto newClient = server.available();
   if (newClient) {

--- a/src/helpers/esp32/SerialWifiInterface.h
+++ b/src/helpers/esp32/SerialWifiInterface.h
@@ -8,6 +8,8 @@ class SerialWifiInterface : public BaseSerialInterface {
   bool _isEnabled;
   unsigned long _last_write;
   unsigned long adv_restart_time;
+  bool _wifi_was_connected;
+  unsigned long _wifi_check_time;
 
   WiFiServer server;
   WiFiClient client;
@@ -39,6 +41,8 @@ public:
     deviceConnected = false;
     _isEnabled = false;
     _last_write = 0;
+    _wifi_was_connected = false;
+    _wifi_check_time = 0;
     send_queue_len = recv_queue_len = 0;
     received_frame_header.type = 0;
     received_frame_header.length = 0;


### PR DESCRIPTION
## Summary
- Adds periodic WiFi health check (every 60s) in `SerialWifiInterface::checkRecvFrame()`
- Only attempts reconnect after WiFi has successfully connected at least once (won't interfere with initial connection on startup)
- Fixes issue where companion radio WiFi firmware never rejoins the AP after losing connectivity

Fixes #2300

## Context
On ESP32 Arduino core 2.x (espressif32@6.11.0), the built-in `WiFi.setAutoReconnect()` is unreliable. This adds an explicit reconnection loop as a more dependable alternative.

## Test plan
- [x] Build `heltec_v4_companion_radio_wifi` target
- [x] Flash and confirm WiFi connects on startup (IP shown on display)
- [x] Disable/reboot the AP, wait >60s, re-enable AP
- [x] Confirm device reconnects and IP reappears on display
- [x] Cold boot with AP unavailable — confirm no reconnect spam