### PR TITLE
xiao nrf52 companion usb: Add OFFLINE_QUEUE_SIZE=256

### DIFF
--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -72,11 +72,11 @@ build_flags =
   -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
   -D QSPIFLASH=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Xiao_nrf52.build_src_filter}
-  +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =


### PR DESCRIPTION
usb role had default 16 messages, this bumps it to standard 256