### PR TITLE
SDK3.x: Fix OTA includes, bump Async version

### DIFF
--- a/arch/esp32/AsyncElegantOTA/src/AsyncElegantOTA.h
+++ b/arch/esp32/AsyncElegantOTA/src/AsyncElegantOTA.h
@@ -15,8 +15,6 @@
     #include "WiFi.h"
     #include "AsyncTCP.h"
     #include "Update.h"
-    #include "esp_int_wdt.h"
-    #include "esp_task_wdt.h"
 #endif
 
 #include "Hash.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ build_src_filter = ${arduino_base.build_src_filter}
 
 [esp32_ota]
 lib_deps =
-  me-no-dev/ESPAsyncWebServer @ ^3.6.0
+  ESP32Async/ESPAsyncWebServer @ 3.10.3
   file://arch/esp32/AsyncElegantOTA
 
 ; esp32c6 uses arduino framework 3.x

--- a/variants/lilygo_tlora_c6/platformio.ini
+++ b/variants/lilygo_tlora_c6/platformio.ini
@@ -46,7 +46,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps =
   ${tlora_c6.lib_deps}
-;  ${esp32_ota.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:LilyGo_Tlora_C6_room_server_]
 extends = tlora_c6
@@ -63,7 +63,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps =
   ${tlora_c6.lib_deps}
-;  ${esp32_ota.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:LilyGo_Tlora_C6_companion_radio_ble_]
 extends = tlora_c6

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -46,7 +46,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps =
   ${Xiao_C6.lib_deps}
-;  ${esp32_ota.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:Xiao_C6_companion_radio_ble_]
 extends = Xiao_C6
@@ -163,7 +163,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps =
   ${WHY2025_badge.lib_deps}
-;  ${esp32_ota.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:WHY2025_badge_companion_radio_ble_]
 extends = WHY2025_badge


### PR DESCRIPTION
Fix build issues with SDK 3.x,

Removed dead code includes in old ElegantOTA

This may replace #2264 update. It will stay on old version, but it works with SDK 3.x aswell