### PR TITLE
feat: add USB Companion Radio env for Heltec Wireless Paper

### DIFF
--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -64,6 +64,25 @@ lib_deps =
   densaugeo/base64 @ ~1.4.0
   bakercp/CRC32 @ ^2.0.0
 
+[env:Heltec_Wireless_Paper_companion_radio_usb]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=E213Display
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
 [env:Heltec_Wireless_Paper_repeater]
 extends = Heltec_Wireless_Paper_base
 build_flags =


### PR DESCRIPTION
## Summary

Adds USB Companion Radio firmware environment for the Heltec Wireless Paper (ESP32-S3 + SX1262 + E-Ink).

Closes #2237

## Changes

- Added `[env:Heltec_Wireless_Paper_companion_radio_usb]` to `variants/heltec_wireless_paper/platformio.ini`

## Testing

Tested on hardware (Heltec Wireless Paper):

- Build: SUCCESS
- Flashed and connected via USB (CP2102) using MeshCore Android app over USB OTG
- E-Ink display renders Companion UI correctly

**Note:** Full flash erase required before flashing (`pio run -t erase`) to clear any data left by previously flashed firmware. Without erase, remnants in LittleFS from a previous firmware caused the Companion firmware to not initialize correctly.

**Note:** The Heltec Wireless Paper uses a CP2102 USB-UART bridge (not native USB CDC). Connection via browser Web Serial API (e.g. meshcore.liamcottle.net) may fail due to DTR/RTS reset behavior. The MeshCore Android app connected via USB cable directly to the device worked correctly.