### PR TITLE
Bootstrap stale repeater clocks from signed repeater adverts

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -617,16 +617,34 @@ static bool isShare(const mesh::Packet *packet) {
   return false;
 }
 
+void MyMesh::considerAdvertTimeSync(const mesh::Identity &id, uint32_t timestamp) {
+  uint32_t curr = getRTCClock()->getCurrentTime();
+  uint32_t synced_time;
+  if (clock_sync.considerAdvert(id.pub_key, timestamp, (uint32_t)_ms->getMillis(), curr, synced_time)) {
+    getRTCClock()->setCurrentTime(synced_time);
+    MESH_DEBUG_PRINTLN("Clock auto-synced from repeater adverts");
+  }
+}
+
 void MyMesh::onAdvertRecv(mesh::Packet *packet, const mesh::Identity &id, uint32_t timestamp,
                           const uint8_t *app_data, size_t app_data_len) {
   mesh::Mesh::onAdvertRecv(packet, id, timestamp, app_data, app_data_len); // chain to super impl
 
+  if (isShare(packet)) {
+    return;
+  }
+  if (app_data_len == 0) {
+    return;
+  }
+
+  AdvertDataParser parser(app_data, app_data_len);
+  if (parser.isValid() && parser.getType() == ADV_TYPE_REPEATER) {
+    considerAdvertTimeSync(id, timestamp);
+  }
+
   // if this a zero hop advert (and not via 'Share'), add it to neighbours
-  if (packet->path_len == 0 && !isShare(packet)) {
-    AdvertDataParser parser(app_data, app_data_len);
-    if (parser.isValid() && parser.getType() == ADV_TYPE_REPEATER) { // just keep neigbouring Repeaters
-      putNeighbour(id, timestamp, packet->getSNR());
-    }
+  if (packet->path_len == 0 && parser.isValid() && parser.getType() == ADV_TYPE_REPEATER) {
+    putNeighbour(id, timestamp, packet->getSNR());
   }
 }
 

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -34,6 +34,7 @@
 #include <helpers/TxtDataHelpers.h>
 #include <helpers/RegionMap.h>
 #include "RateLimiter.h"
+#include "RepeaterClockSync.h"
 
 #ifdef WITH_BRIDGE
 extern AbstractBridge* bridge;
@@ -105,6 +106,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif
+  RepeaterClockSync clock_sync;
   CayenneLPP telemetry;
   unsigned long set_radio_at, revert_radio_at;
   float pending_freq;
@@ -126,6 +128,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   uint8_t handleAnonClockReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
   int handleRequest(ClientInfo* sender, uint32_t sender_timestamp, uint8_t* payload, size_t payload_len);
   mesh::Packet* createSelfAdvert();
+  void considerAdvertTimeSync(const mesh::Identity& id, uint32_t timestamp);
 
   File openAppend(const char* fname);
   bool isLooped(const mesh::Packet* packet, const uint8_t max_counters[]);

--- a/examples/simple_repeater/RepeaterClockSync.cpp
+++ b/examples/simple_repeater/RepeaterClockSync.cpp
@@ -1,0 +1,91 @@
+#include "RepeaterClockSync.h"
+
+RepeaterClockSync::RepeaterClockSync() {
+  reset();
+}
+
+void RepeaterClockSync::reset() {
+  _candidate_count = 0;
+}
+
+bool RepeaterClockSync::considerAdvert(const uint8_t pub_key[PUB_KEY_SIZE], uint32_t advert_timestamp,
+                                       uint32_t heard_millis, uint32_t local_time, uint32_t& sync_time) {
+#if REPEATER_CLOCK_SYNC_ENABLED
+  if (local_time >= REPEATER_CLOCK_SYNC_STALE_BEFORE || advert_timestamp < REPEATER_CLOCK_SYNC_STALE_BEFORE) {
+    return false;
+  }
+
+  RepeaterClockSyncCandidate* candidate = NULL;
+  for (uint8_t i = 0; i < _candidate_count; i++) {
+    if (memcmp(pub_key, _candidates[i].pub_key, PUB_KEY_SIZE) == 0) {
+      candidate = &_candidates[i];
+      break;
+    }
+  }
+
+  if (candidate == NULL) {
+    if (_candidate_count < REPEATER_CLOCK_SYNC_MAX_CANDIDATES) {
+      candidate = &_candidates[_candidate_count++];
+    } else {
+      candidate = &_candidates[0];
+      for (uint8_t i = 1; i < REPEATER_CLOCK_SYNC_MAX_CANDIDATES; i++) {
+        if ((int32_t)(_candidates[i].heard_millis - candidate->heard_millis) < 0) {
+          candidate = &_candidates[i];
+        }
+      }
+    }
+  }
+
+  memcpy(candidate->pub_key, pub_key, PUB_KEY_SIZE);
+  candidate->advert_timestamp = advert_timestamp;
+  candidate->heard_millis = heard_millis;
+
+  uint32_t times[REPEATER_CLOCK_SYNC_MAX_CANDIDATES];
+  uint8_t count = 0;
+  for (uint8_t i = 0; i < _candidate_count; i++) {
+    RepeaterClockSyncCandidate* c = &_candidates[i];
+    uint32_t age_millis = heard_millis - c->heard_millis;
+    if (age_millis > ((uint32_t)REPEATER_CLOCK_SYNC_WINDOW_SECS) * 1000UL) {
+      continue;
+    }
+    times[count++] = c->advert_timestamp + age_millis / 1000UL;
+  }
+
+  if (count < REPEATER_CLOCK_SYNC_QUORUM) {
+    return false;
+  }
+
+  for (uint8_t i = 1; i < count; i++) {
+    uint32_t v = times[i];
+    int j = i - 1;
+    while (j >= 0 && times[j] > v) {
+      times[j + 1] = times[j];
+      j--;
+    }
+    times[j + 1] = v;
+  }
+
+  uint8_t cluster_start = count;
+  for (uint8_t i = 0; i + REPEATER_CLOCK_SYNC_QUORUM <= count; i++) {
+    uint8_t cluster_end = i + REPEATER_CLOCK_SYNC_QUORUM - 1;
+    if (times[cluster_end] - times[i] <= REPEATER_CLOCK_SYNC_MAX_SPREAD_SECS) {
+      cluster_start = i;
+      break;
+    }
+  }
+
+  if (cluster_start == count) {
+    return false;
+  }
+
+  sync_time = times[cluster_start + REPEATER_CLOCK_SYNC_QUORUM / 2];
+  return sync_time > local_time;
+#else
+  (void)pub_key;
+  (void)advert_timestamp;
+  (void)heard_millis;
+  (void)local_time;
+  (void)sync_time;
+  return false;
+#endif
+}

--- a/examples/simple_repeater/RepeaterClockSync.h
+++ b/examples/simple_repeater/RepeaterClockSync.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+#include <MeshCore.h>
+
+#ifndef REPEATER_CLOCK_SYNC_ENABLED
+  #define REPEATER_CLOCK_SYNC_ENABLED 1
+#endif
+#ifndef REPEATER_CLOCK_SYNC_MAX_CANDIDATES
+  #define REPEATER_CLOCK_SYNC_MAX_CANDIDATES 4
+#endif
+#ifndef REPEATER_CLOCK_SYNC_QUORUM
+  #define REPEATER_CLOCK_SYNC_QUORUM 2
+#endif
+#ifndef REPEATER_CLOCK_SYNC_WINDOW_SECS
+  #define REPEATER_CLOCK_SYNC_WINDOW_SECS 7200
+#endif
+#ifndef REPEATER_CLOCK_SYNC_MAX_SPREAD_SECS
+  #define REPEATER_CLOCK_SYNC_MAX_SPREAD_SECS 300
+#endif
+#ifndef REPEATER_CLOCK_SYNC_STALE_BEFORE
+  #define REPEATER_CLOCK_SYNC_STALE_BEFORE 1735689600UL  // 1 Jan 2025 00:00:00 UTC
+#endif
+
+struct RepeaterClockSyncCandidate {
+  uint8_t pub_key[PUB_KEY_SIZE];
+  uint32_t advert_timestamp;
+  uint32_t heard_millis;
+};
+
+class RepeaterClockSync {
+  RepeaterClockSyncCandidate _candidates[REPEATER_CLOCK_SYNC_MAX_CANDIDATES];
+  uint8_t _candidate_count;
+
+public:
+  RepeaterClockSync();
+
+  void reset();
+  uint8_t getCandidateCount() const { return _candidate_count; }
+
+  bool considerAdvert(const uint8_t pub_key[PUB_KEY_SIZE], uint32_t advert_timestamp,
+                      uint32_t heard_millis, uint32_t local_time, uint32_t& sync_time);
+};

--- a/tests/repeater_clock_sync_test.cpp
+++ b/tests/repeater_clock_sync_test.cpp
@@ -1,0 +1,116 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../examples/simple_repeater/RepeaterClockSync.h"
+
+static void makeKey(uint8_t pub_key[PUB_KEY_SIZE], uint8_t seed) {
+  for (int i = 0; i < PUB_KEY_SIZE; i++) {
+    pub_key[i] = seed + i;
+  }
+}
+
+static bool consider(RepeaterClockSync& sync, uint8_t seed, uint32_t advert_time,
+                     uint32_t heard_millis, uint32_t local_time, uint32_t& sync_time) {
+  uint8_t key[PUB_KEY_SIZE];
+  makeKey(key, seed);
+  return sync.considerAdvert(key, advert_time, heard_millis, local_time, sync_time);
+}
+
+static void valid_local_clock_is_not_adjusted() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 100, 0,
+                   REPEATER_CLOCK_SYNC_STALE_BEFORE, sync_time));
+}
+
+static void stale_remote_time_is_ignored() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE - 1, 0, 1715770351, sync_time));
+}
+
+static void one_candidate_is_not_enough() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 100, 0, 1715770351, sync_time));
+}
+
+static void two_close_candidates_sync() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 100, 0, 1715770351, sync_time));
+  assert(consider(sync, 2, REPEATER_CLOCK_SYNC_STALE_BEFORE + 160, 1000, 1715770351, sync_time));
+  assert(sync_time == REPEATER_CLOCK_SYNC_STALE_BEFORE + 160);
+}
+
+static void two_distant_candidates_do_not_sync() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 100, 0, 1715770351, sync_time));
+  assert(!consider(sync, 2, REPEATER_CLOCK_SYNC_STALE_BEFORE + REPEATER_CLOCK_SYNC_MAX_SPREAD_SECS + 102,
+                   1000, 1715770351, sync_time));
+}
+
+static void sparse_candidates_are_normalized_by_elapsed_time() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+  uint32_t first_time = REPEATER_CLOCK_SYNC_STALE_BEFORE + 1000;
+  uint32_t one_hour = 60 * 60;
+
+  assert(!consider(sync, 1, first_time, 0, 1715770351, sync_time));
+  assert(consider(sync, 2, first_time + one_hour + 20, one_hour * 1000UL, 1715770351, sync_time));
+  assert(sync_time == first_time + one_hour + 20);
+}
+
+static void duplicate_repeater_updates_existing_candidate() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 100, 0, 1715770351, sync_time));
+  assert(sync.getCandidateCount() == 1);
+  assert(!consider(sync, 1, REPEATER_CLOCK_SYNC_STALE_BEFORE + 200, 1000, 1715770351, sync_time));
+  assert(sync.getCandidateCount() == 1);
+}
+
+static void outlier_does_not_block_agreeing_quorum() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+  uint32_t base = REPEATER_CLOCK_SYNC_STALE_BEFORE + 1000;
+
+  assert(!consider(sync, 1, base, 0, 1715770351, sync_time));
+  assert(!consider(sync, 2, base + 10000, 1000, 1715770351, sync_time));
+  assert(consider(sync, 3, base + 90, 2000, 1715770351, sync_time));
+  assert(sync_time == base + 90);
+}
+
+static void expired_candidates_are_ignored() {
+  RepeaterClockSync sync;
+  uint32_t sync_time = 0;
+  uint32_t base = REPEATER_CLOCK_SYNC_STALE_BEFORE + 1000;
+
+  assert(!consider(sync, 1, base, 0, 1715770351, sync_time));
+  assert(!consider(sync, 2, base + REPEATER_CLOCK_SYNC_WINDOW_SECS + 1,
+                   (REPEATER_CLOCK_SYNC_WINDOW_SECS + 1) * 1000UL, 1715770351, sync_time));
+}
+
+int main() {
+  valid_local_clock_is_not_adjusted();
+  stale_remote_time_is_ignored();
+  one_candidate_is_not_enough();
+  two_close_candidates_sync();
+  two_distant_candidates_do_not_sync();
+  sparse_candidates_are_normalized_by_elapsed_time();
+  duplicate_repeater_updates_existing_candidate();
+  outlier_does_not_block_agreeing_quorum();
+  expired_candidates_are_ignored();
+
+  puts("repeater_clock_sync_test: OK");
+  return 0;
+}


### PR DESCRIPTION
  ## What changed
 ```markdown
  This adds repeater-only clock bootstrapping from signed repeater adverts.

  The target case is a repeater without persistent RTC rebooting into the fallback date. If its local time is clearly stale, it collects advert timestamps from unique repeaters and moves its clock forward once an
  agreeing quorum is found.

  The candidate list is RAM-only, uses full pubkeys for uniqueness, adjusts older candidates by elapsed local millis, and only runs while local time is before `2025-01-01`.
  ```

  ## Validation

  ```bash
  g++ -std=c++11 -Isrc tests/repeater_clock_sync_test.cpp examples/simple_repeater/RepeaterClockSync.cpp -o /tmp/repeater_clock_sync_test && /tmp/repeater_clock_sync_test
  platformio run -e Heltec_v3_repeater
  platformio run -e RAK_4631_repeater
  ```