### PR TITLE
Add Heltec V4 RS232 Bridge variant

### DIFF
--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -124,6 +124,30 @@ lib_deps =
   ${heltec_v4_oled.lib_deps}
   ${esp32_ota.lib_deps}
 
+[env:heltec_v4_repeater_bridge_rs232]
+extends = heltec_v4_oled
+build_flags =
+  ${heltec_v4_oled.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"RS232 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=Serial2
+  -D WITH_RS232_BRIDGE_RX=44
+  -D WITH_RS232_BRIDGE_TX=43
+;  -D BRIDGE_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_oled.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
+
 [env:heltec_v4_room_server]
 extends = heltec_v4_oled
 build_flags =


### PR DESCRIPTION
This PR adds the 'Heltec V4 Bridge RS232' variant.

Currently only the ESPNow Bridge variant is available, so this will add the RS232 Bridge too.