### PR TITLE
Fix missing display driver in Xiao S3 WIO WiFi companion build

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -199,16 +199,18 @@ lib_deps =
 [env:Xiao_S3_WIO_companion_radio_wifi]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
-  +<helpers/ui/NullDisplayDriver.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 build_flags =
   ${Xiao_S3_WIO.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D OFFLINE_QUEUE_SIZE=256
+  -D DISPLAY_CLASS=SSD1306Display
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"password"'
@@ -218,6 +220,7 @@ build_flags =
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit SSD1306 @ ^2.5.13
 
 [env:Xiao_S3_WIO_sensor]
 extends = Xiao_S3_WIO


### PR DESCRIPTION
The **Xiao_S3_WIO_companion_radio_wifi** environment was missing the SSD1306 display configuration and was building with the null display driver instead. As a result, the companion WiFi build did not initialize the display like the BLE, USB, and serial variants.

This change aligns the WiFi environment with the other xiao_s3_wio companion builds.

The fix was successfully tested on a Xiao S3 WIO device.