### PR TITLE
Fix FEM/LNA enbaled by default for Heltec T096, Heltec Wireless Tracker v2

### DIFF
--- a/variants/heltec_t096/LoRaFEMControl.cpp
+++ b/variants/heltec_t096/LoRaFEMControl.cpp
@@ -9,7 +9,7 @@ void LoRaFEMControl::init(void)
     pinMode(P_LORA_KCT8103L_PA_CSD, OUTPUT);
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     pinMode(P_LORA_KCT8103L_PA_CTX, OUTPUT);
-    digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
+    digitalWrite(P_LORA_KCT8103L_PA_CTX, lna_enabled ? LOW : HIGH);
     setLnaCanControl(true);
 }
 

--- a/variants/heltec_t096/LoRaFEMControl.h
+++ b/variants/heltec_t096/LoRaFEMControl.h
@@ -16,6 +16,6 @@ class LoRaFEMControl
     void setLnaCanControl(bool can_control) { lna_can_control = can_control; }
 
   private:
-    bool lna_enabled = false;
+    bool lna_enabled = true;
     bool lna_can_control = false;
 };

--- a/variants/heltec_tracker_v2/LoRaFEMControl.cpp
+++ b/variants/heltec_tracker_v2/LoRaFEMControl.cpp
@@ -14,7 +14,7 @@ void LoRaFEMControl::init(void)
     pinMode(P_LORA_KCT8103L_PA_CSD, OUTPUT);
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     pinMode(P_LORA_KCT8103L_PA_CTX, OUTPUT);
-    digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
+    digitalWrite(P_LORA_KCT8103L_PA_CTX, lna_enabled ? LOW : HIGH);
     setLnaCanControl(true);
 }
 

--- a/variants/heltec_tracker_v2/LoRaFEMControl.h
+++ b/variants/heltec_tracker_v2/LoRaFEMControl.h
@@ -16,6 +16,6 @@ class LoRaFEMControl
     void setLnaCanControl(bool can_control) { lna_can_control = can_control; }
 
   private:
-    bool lna_enabled = false;
+    bool lna_enabled = true;
     bool lna_can_control = false;
 };


### PR DESCRIPTION
Should only really be disabled when it causes issues. It's enabled by default on all similar Heltec boards.