### PR TITLE
feat: add flood path hop limit and related preferences

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -558,6 +558,18 @@ bool MyMesh::filterRecvFloodPacket(mesh::Packet* pkt) {
   } else {
     recv_pkt_region = NULL;
   }
+  // Drop flood REQ/RESPONSE/PATH packets that exceed the path hop limit
+  if (_prefs.flood_path_max > 0 && pkt->isRouteFlood()) {
+    uint8_t pt = pkt->getPayloadType();
+    if (pt == PAYLOAD_TYPE_REQ || pt == PAYLOAD_TYPE_RESPONSE || pt == PAYLOAD_TYPE_PATH) {
+      if (pkt->getPathHashCount() > _prefs.flood_path_max) {
+        MESH_DEBUG_PRINTLN("filterRecvFloodPacket: flood path too long (%d > %d), dropping!",
+          pkt->getPathHashCount(), (uint32_t)_prefs.flood_path_max);
+        return true;
+      }
+    }
+  }
+
   // do normal processing
   return false;
 }
@@ -886,6 +898,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.advert_interval = 1;        // default to 2 minutes for NEW installs
   _prefs.flood_advert_interval = 12; // 12 hours
   _prefs.flood_max = 64;
+  _prefs.flood_path_max = DEFAULT_FLOOD_PATH_MAX; // default 12
   _prefs.interference_threshold = 0; // disabled
 
   // bridge defaults

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -78,6 +78,8 @@ struct NeighbourInfo {
 
 #define FIRMWARE_ROLE "repeater"
 
+#define DEFAULT_FLOOD_PATH_MAX 12
+
 #define PACKET_LOG_FILE  "/packet_log"
 
 class MyMesh : public mesh::Mesh, public CommonCLICallbacks {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -88,7 +88,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.read((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.read((uint8_t *)&_prefs->flood_path_max, sizeof(_prefs->flood_path_max));                  // 291
+    // next: 292
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -118,6 +119,7 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
 
     // sanitise settings
     _prefs->rx_boosted_gain = constrain(_prefs->rx_boosted_gain, 0, 1); // boolean
+    _prefs->flood_path_max = constrain(_prefs->flood_path_max, 0, 255);
 
     file.close();
   }
@@ -179,7 +181,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.write((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.write((uint8_t *)&_prefs->flood_path_max, sizeof(_prefs->flood_path_max));                  // 291
+    // next: 292
 
     file.close();
   }
@@ -605,6 +608,15 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     } else {
       strcpy(reply, "Error, max 64");
     }
+  } else if (memcmp(config, "flood.path.max ", 15) == 0) {
+    int val = _atoi(&config[15]);
+    if (val < 0 || val > 255) {
+      strcpy(reply, "Error: range is 0-255 (0=off, default=12)");
+    } else {
+      _prefs->flood_path_max = (uint8_t)val;
+      savePrefs();
+      strcpy(reply, "OK");
+    }
   } else if (memcmp(config, "direct.txdelay ", 15) == 0) {
     float f = atof(&config[15]);
     if (f >= 0) {
@@ -779,6 +791,8 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->rx_delay_base));
   } else if (memcmp(config, "txdelay", 7) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->tx_delay_factor));
+  } else if (memcmp(config, "flood.path.max", 14) == 0) {
+    sprintf(reply, "> %d", (uint32_t) _prefs->flood_path_max);
   } else if (memcmp(config, "flood.max", 9) == 0) {
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
   } else if (memcmp(config, "direct.txdelay", 14) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -61,6 +61,7 @@ struct NodePrefs { // persisted to file
   uint8_t rx_boosted_gain; // power settings
   uint8_t path_hash_mode;   // which path mode to use when sending
   uint8_t loop_detect;
+  uint8_t flood_path_max;     // max path hops for flood REQ/RESPONSE/PATH, 0 = off. Default 12.
 };
 
 class CommonCLICallbacks {


### PR DESCRIPTION
I noticed recently that i was seeing a bunch of request, response, and path packets that were ranging from 10 to even one was 33 hops!! As far as i understand logging into a repeater further than 12 hops away is unlikely to succeed, so therefore these packets don't serve any function going further.