### PR TITLE
feat(techo-lite): add Non-Shell companion BLE variant

### DIFF
--- a/boards/t-echo.json
+++ b/boards/t-echo.json
@@ -53,10 +53,13 @@
     "protocols": [
       "jlink",
       "nrfjprog",
+      "nrfutil",
       "stlink",
       "cmsis-dap",
       "blackmagic"
-    ]
+    ],
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
   },
   "url": "https://os.mbed.com/platforms/Nordic-nRF52840-DK/",
   "vendor": "Nordic"

--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -96,3 +96,47 @@ build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
 lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:LilyGo_T-Echo-Lite_non_shell_companion_radio_ble]
+extends = LilyGo_T-Echo-Lite
+upload_protocol = nrfutil
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${nrf52_base.build_flags}
+  -I variants/lilygo_techo_lite
+  -I src/helpers/nrf52
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D LILYGO_TECHO
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_POWER_EN=30
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D P_LORA_TX_LED=LED_GREEN
+  -D DISABLE_DIAGNOSTIC_OUTPUT
+  -D ENV_INCLUDE_GPS=1
+  -D GPS_BAUD_RATE=9600
+  -D PIN_GPS_EN=GPS_EN
+  -D AUTO_OFF_MILLIS=0
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  -D UI_RECENT_LIST_SIZE=9
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<helpers/*.cpp>
+  +<TechoBoard.cpp>
+  +<helpers/sensors/EnvironmentSensorManager.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../variants/lilygo_techo_lite>
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_T-Echo-Lite.lib_deps}
+  densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
## Note on T-Echo Lite variants

LilyGO sells three distinct T-Echo Lite variants:
- **T-Echo Lite** — full version with 1.22" ePaper display
- **T-Echo Lite Non-Shell** — USB + Qwiic, no ePaper display, no enclosure
- **T-Echo Lite Core** — minimal castellated module, no USB, no display

This PR adds a firmware env for the **Non-Shell** variant.
The Core variant may require a separate env due to different hardware
(no USB interface).

## Problem

T-Echo Lite Non-Shell (screenless) users cannot connect via BLE.
The existing companion BLE env inherits `DISPLAY_CLASS=GxEPDDisplay`
from the base env. This causes `display.begin()` to run on
non-existent hardware, corrupting BLE initialization.

The result: a random PIN is generated with no way to display it,
making BLE connection impossible.

Note: Issue #1183 and PR #2287 involve related hardware (screenless
T-Echo Lite variants), but address different bugs (battery voltage).
This PR focuses solely on the BLE initialization issue.

## Fix

Add `LilyGo_T-Echo-Lite_non_shell_companion_radio_ble` env:
- excludes `DISPLAY_CLASS` and ePaper-related build flags
- removes `GxEPDDisplay.cpp` and `ui-new` from build sources
- uses static `BLE_PIN_CODE=123456`

Also fix `boards/t-echo.json`:
- add `nrfutil` to upload protocols list
- add `use_1200bps_touch=true` and `wait_for_upload_port=true`

## Testing

Tested on T-Echo Lite Non-Shell hardware:
- BLE advertises correctly after flashing
- MeshCore app connects successfully via BLE with PIN 123456
- Upload via PlatformIO Upload button works (nrfutil + 1200bps touch)

### DFU mode (UF2 flashing) for T-Echo Lite Non-Shell

1. Press and hold RESET button (BLUE LED may or may not flash)
2. Release RESET
3. Quickly press and release RESET again
4. A USB drive appears — copy the .uf2 file onto it

Note: BLUE LED flash may not occur on all units, but the drive
still appears and UF2 flashing works correctly.

Related to #1183, #2287