### PR TITLE
suspend the radio before blocking io

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1291,8 +1291,21 @@ void MyMesh::loop() {
 
   // is pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() > 0 || isRadioBusy()) {
+      // Radio is active on SPI — defer to avoid flash/SPI conflict on nRF52
+      dirty_contacts_expiry = futureMillis(200);
+      if (++dirty_contacts_defer_count > 50) {  // cap at ~10s to guarantee save
+        _radio->suspendRadio();
+        acl.save(_fs);
+        dirty_contacts_expiry = 0;
+        dirty_contacts_defer_count = 0;
+      }
+    } else {
+      _radio->suspendRadio();
+      acl.save(_fs);
+      dirty_contacts_expiry = 0;
+      dirty_contacts_defer_count = 0;
+    }
   }
 
   // update uptime

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1122,6 +1122,7 @@ void MyMesh::startRegionsLoad() {
 }
 
 bool MyMesh::saveRegions() {
+  _radio->suspendRadio();
   return region_map.save(_fs);
 }
 

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -190,6 +190,7 @@ public:
   }
 
   void savePrefs() override {
+    _radio->suspendRadio();
     _cli.savePrefs(_fs);
   }
 

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -103,6 +103,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   unsigned long pending_discover_until;
   bool region_load_active;
   unsigned long dirty_contacts_expiry;
+  uint8_t dirty_contacts_defer_count;
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -1011,8 +1011,20 @@ void MyMesh::loop() {
 
   // is pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs, MyMesh::saveFilter);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() > 0 || isRadioBusy()) {
+      dirty_contacts_expiry = futureMillis(200);
+      if (++dirty_contacts_defer_count > 50) {
+        _radio->suspendRadio();
+        acl.save(_fs, MyMesh::saveFilter);
+        dirty_contacts_expiry = 0;
+        dirty_contacts_defer_count = 0;
+      }
+    } else {
+      _radio->suspendRadio();
+      acl.save(_fs, MyMesh::saveFilter);
+      dirty_contacts_expiry = 0;
+      dirty_contacts_defer_count = 0;
+    }
   }
 
   // TODO: periodically check for OLD/inactive entries in known_clients[], and evict

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -101,6 +101,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   ClientACL acl;
   CommonCLI _cli;
   unsigned long dirty_contacts_expiry;
+  uint8_t dirty_contacts_defer_count;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   unsigned long next_push;
   uint16_t _num_posted, _num_post_pushes;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -184,6 +184,7 @@ public:
   }
 
   void savePrefs() override {
+    _radio->suspendRadio();
     _cli.savePrefs(_fs);
   }
 

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -968,7 +968,19 @@ void SensorMesh::loop() {
 
   // is there are pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() > 0 || isRadioBusy()) {
+      dirty_contacts_expiry = futureMillis(200);
+      if (++dirty_contacts_defer_count > 50) {
+        _radio->suspendRadio();
+        acl.save(_fs);
+        dirty_contacts_expiry = 0;
+        dirty_contacts_defer_count = 0;
+      }
+    } else {
+      _radio->suspendRadio();
+      acl.save(_fs);
+      dirty_contacts_expiry = 0;
+      dirty_contacts_defer_count = 0;
+    }
   }
 }

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -138,6 +138,7 @@ private:
   CommonCLI _cli;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   unsigned long dirty_contacts_expiry;
+  uint8_t dirty_contacts_defer_count;
   CayenneLPP telemetry;
   TransportKeyStore key_store;
   RegionMap region_map;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -59,7 +59,10 @@ public:
   const char* getRole() override { return FIRMWARE_ROLE; }
   const char* getNodeName() { return _prefs.node_name; }
   NodePrefs* getNodePrefs() { return &_prefs; }
-  void savePrefs() override { _cli.savePrefs(_fs); }
+  void savePrefs() override {
+    _radio->suspendRadio();
+    _cli.savePrefs(_fs);
+  }
   bool formatFileSystem() override;
   void sendSelfAdvertisement(int delay_millis, bool flood) override;
   void updateAdvertTimer() override;

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -70,6 +70,14 @@ public:
   virtual bool isInRecvMode() const = 0;
 
   /**
+   * \brief  Put radio into standby.  Next recvRaw() call will retsart receive.
+   *         Used to quiesce the SPI bus before flash I/O on nRF52.
+   *         
+   *         Introduced as fix for #2283
+  */
+  virtual void suspendRadio() { }
+
+  /**
    * \returns  true if the radio is currently mid-receive of a packet.
   */
   virtual bool isReceiving() { return false; }
@@ -192,6 +200,9 @@ public:
   // helper methods
   bool millisHasNowPassed(unsigned long timestamp) const;
   unsigned long futureMillis(int millis_from_now) const;
+
+  /// True when a packet is mid-transmit (dequeued, SPI active).
+  bool isRadioBusy() const { return outbound != NULL; }
 
 private:
   bool tryParsePacket(Packet* pkt, const uint8_t* raw, int len);

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -29,6 +29,7 @@ public:
   bool isSendComplete() override;
   void onSendFinished() override;
   bool isInRecvMode() const override;
+  void suspendRadio() override { idle(); }
   bool isChannelActive();
 
   bool isReceiving() override { 


### PR DESCRIPTION
acl.save() is blocking IO - during this time the nrf52 CPU is halted. If this happens in between a spi transaction with the sx1262 the bus is corrupted and the radio is stuck. the issue does _not_ occur on esp32 as esp32 has a separate flash controller. 

This behaviour is correctly detected by the repeater and the _err_flags are set:
`     _err_flags |= ERR_EVENT_STARTRX_TIMEOUT;
`
However - no action is taken upon that error yet.

There are two countermeasures - and one general countermeasure:
 - use non-blocking io (not trivial to near impossible on nrf52)
 - suspend the radio before writing the acls to prevent spi bus corruption
 - (restart the transmitter after a error was detected)

The last one is described within a separate PR - see #2347 - in order to have cleaner PRs.  This PR is a attempt to mitigate the spi bus corruption by suspending the radio before the blocking operation. 

