### PR TITLE
Fix Direct respond on handleLoginReq

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -130,6 +130,8 @@ uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secr
 
   if (is_flood) {
     client->out_path_len = OUT_PATH_UNKNOWN;  // need to rediscover out_path
+  } else if (client->out_path_len != OUT_PATH_UNKNOWN) {
+    reply_path_len = mesh::Packet::writePath(reply_path, client->out_path, client->out_path_len);
   }
 
   uint32_t now = getRTCClock()->getCurrentTimeUnique();

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -131,7 +131,9 @@ uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secr
   if (is_flood) {
     client->out_path_len = OUT_PATH_UNKNOWN;  // need to rediscover out_path
   } else if (client->out_path_len != OUT_PATH_UNKNOWN) {
-    reply_path_len = mesh::Packet::writePath(reply_path, client->out_path, client->out_path_len);
+    reply_path_len = client->out_path_len & 63;
+    reply_path_hash_size = (client->out_path_len >> 6) + 1;
+    memcpy(reply_path, client->out_path, ((uint8_t)reply_path_len) * reply_path_hash_size);
   }
 
   uint32_t now = getRTCClock()->getCurrentTimeUnique();

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -363,7 +363,9 @@ uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* 
   if (is_flood) {
     client->out_path_len = OUT_PATH_UNKNOWN;  // need to rediscover out_path
   } else if (client->out_path_len != OUT_PATH_UNKNOWN) {
-    reply_path_len = mesh::Packet::writePath(reply_path, client->out_path, client->out_path_len);
+    reply_path_len = client->out_path_len & 63;
+    reply_path_hash_size = (client->out_path_len >> 6) + 1;
+    memcpy(reply_path, client->out_path, ((uint8_t)reply_path_len) * reply_path_hash_size);
   }
 
   uint32_t now = getRTCClock()->getCurrentTimeUnique();
@@ -479,7 +481,8 @@ void SensorMesh::onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, con
         if (reply_path_len < 0) {
           sendFlood(reply, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
         } else {
-          sendDirect(reply, reply_path, reply_path_len, SERVER_RESPONSE_DELAY);
+          uint8_t path_len = ((reply_path_hash_size - 1) << 6) | (reply_path_len & 63);
+          sendDirect(reply, reply_path, path_len, SERVER_RESPONSE_DELAY);
         }
       }
     }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -362,6 +362,8 @@ uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* 
 
   if (is_flood) {
     client->out_path_len = OUT_PATH_UNKNOWN;  // need to rediscover out_path
+  } else if (client->out_path_len != OUT_PATH_UNKNOWN) {
+    reply_path_len = mesh::Packet::writePath(reply_path, client->out_path, client->out_path_len);
   }
 
   uint32_t now = getRTCClock()->getCurrentTimeUnique();
@@ -455,6 +457,7 @@ void SensorMesh::onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, con
 
     data[len] = 0;  // ensure null terminator
     uint8_t reply_len;
+    reply_path_len = -1;
     if (data[4] == 0 || data[4] >= ' ') {   // is password, ie. a login request
       reply_len = handleLoginReq(sender, secret, timestamp, &data[4], packet->isRouteFlood());
     //} else if (data[4] == ANON_REQ_TYPE_*) {   // future type codes
@@ -472,7 +475,13 @@ void SensorMesh::onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, con
       if (path) sendFlood(path, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
     } else {
       mesh::Packet* reply = createDatagram(PAYLOAD_TYPE_RESPONSE, sender, secret, reply_data, reply_len);
-      if (reply) sendFlood(reply, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
+      if (reply) {
+        if (reply_path_len < 0) {
+          sendFlood(reply, SERVER_RESPONSE_DELAY, packet->getPathHashSize());
+        } else {
+          sendDirect(reply, reply_path, reply_path_len, SERVER_RESPONSE_DELAY);
+        }
+      }
     }
   }
 }

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -139,6 +139,7 @@ private:
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
   uint8_t reply_path[MAX_PATH_SIZE];
   int8_t  reply_path_len;
+  uint8_t reply_path_hash_size;
   unsigned long dirty_contacts_expiry;
   CayenneLPP telemetry;
   TransportKeyStore key_store;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -137,6 +137,8 @@ private:
   ClientACL  acl;
   CommonCLI _cli;
   uint8_t reply_data[MAX_PACKET_PAYLOAD];
+  uint8_t reply_path[MAX_PATH_SIZE];
+  int8_t  reply_path_len;
   unsigned long dirty_contacts_expiry;
   CayenneLPP telemetry;
   TransportKeyStore key_store;


### PR DESCRIPTION
This PR fixes the _handleLoginReq_ response (which is the first response when doing a login to remote admin), to use the **Direct** path if available.
Current firmware is ALWAYS responding the handleLoginReq with a **Flood** response. With this PR the response will be a **Direct** response if the path for the client is available.
Basically it just made it consistent with the other PAYLOAD_TYPE_ANON_REQ responses code, like _handleAnonRegionsReq_, _handleAnonOwnerReq_ and _handleAnonClockReq_.

This will prevent unnecessary flood messages from traveling all over the mesh, while a direct path was already available.
In the current meshes airtime is already very sparse, so every reduction in unnecessary flood messages is welcome ;)

P.S. No 'fix' needed for _simple-roomserver_, because the direct response was already working.

Initial PR was already done in #1485 by @oltaco, but code was outdated so this is a retry :sweat_smile: 
