### PR TITLE
Add LilyGo T-Connect Pro target and ST7796 driver

### DIFF
--- a/boards/t-connect-pro.json
+++ b/boards/t-connect-pro.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": ["wifi", "bluetooth"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "LilyGo T-Connect Pro (16M Flash 8M PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.lilygo.cc",
+  "vendor": "LilyGo"
+}

--- a/src/helpers/ui/ST7796LCDDisplay.cpp
+++ b/src/helpers/ui/ST7796LCDDisplay.cpp
@@ -1,0 +1,170 @@
+#include "ST7796LCDDisplay.h"
+
+#ifndef DISPLAY_ROTATION
+  #define DISPLAY_ROTATION 3
+#endif
+
+#ifndef DISPLAY_SCALE_X
+  #define DISPLAY_SCALE_X 2.5f // 320 / 128
+#endif
+
+#ifndef DISPLAY_SCALE_Y
+  #define DISPLAY_SCALE_Y 3.75f // 240 / 64
+#endif
+
+#ifndef DISPLAY_WIDTH
+   #define DISPLAY_WIDTH 222
+#endif
+
+#ifndef DISPLAY_HEIGHT
+   #define DISPLAY_HEIGHT 480
+#endif
+
+
+bool ST7796LCDDisplay::i2c_probe(TwoWire& wire, uint8_t addr) {
+  return true;
+}
+
+bool ST7796LCDDisplay::begin() {
+  if (!_isOn) {
+    if (_peripher_power) _peripher_power->claim();
+
+    if (PIN_TFT_LEDA_CTL != -1) {
+      pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
+      digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+    }
+    if (PIN_TFT_RST != -1) {
+      pinMode(PIN_TFT_RST, OUTPUT);
+      digitalWrite(PIN_TFT_RST, LOW); 
+      delay(10);
+      digitalWrite(PIN_TFT_RST, HIGH);
+    }
+
+    display.init(DISPLAY_WIDTH, DISPLAY_HEIGHT, 0, 49, ST7796S_BGR); // width, height, row offset, column offset, colour mode
+    display.setRotation(DISPLAY_ROTATION);
+
+    display.setSPISpeed(40e6);
+
+    display.fillScreen(ST77XX_BLACK);
+    display.setTextColor(ST77XX_WHITE);
+    display.setTextSize(2 * DISPLAY_SCALE_X); 
+    display.cp437(true); // Use full 256 char 'Code Page 437' font
+  
+    _isOn = true;
+  }
+
+  return true;
+}
+
+void ST7796LCDDisplay::turnOn() {
+  ST7796LCDDisplay::begin();
+}
+
+void ST7796LCDDisplay::turnOff() {
+  if (_isOn) {
+    if (PIN_TFT_LEDA_CTL != -1) {
+      digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+    }
+    if (PIN_TFT_RST != -1) {
+      digitalWrite(PIN_TFT_RST, LOW);
+    }
+    if (PIN_TFT_LEDA_CTL != -1) {
+      digitalWrite(PIN_TFT_LEDA_CTL, LOW);
+    }
+    _isOn = false;
+
+    if (_peripher_power) _peripher_power->release();
+  }
+}
+
+void ST7796LCDDisplay::clear() {
+  display.fillScreen(ST77XX_BLACK);
+}
+
+void ST7796LCDDisplay::startFrame(Color bkg) {
+  display.fillScreen(ST77XX_BLACK);
+  display.setTextColor(ST77XX_WHITE);
+  display.setTextSize(1 * DISPLAY_SCALE_X); // This one affects size of Please wait... message
+  display.cp437(true); // Use full 256 char 'Code Page 437' font
+}
+
+void ST7796LCDDisplay::setTextSize(int sz) {
+  display.setTextSize(sz * DISPLAY_SCALE_X);
+}
+
+void ST7796LCDDisplay::setColor(Color c) {
+  switch (c) {
+    case DisplayDriver::DARK :
+      _color = ST77XX_BLACK;
+      break;
+    case DisplayDriver::LIGHT : 
+      _color = ST77XX_WHITE;
+      break;
+    case DisplayDriver::RED : 
+      _color = ST77XX_RED;
+      break;
+    case DisplayDriver::GREEN : 
+      _color = ST77XX_GREEN;
+      break;
+    case DisplayDriver::BLUE : 
+      _color = ST77XX_BLUE;
+      break;
+    case DisplayDriver::YELLOW : 
+      _color = ST77XX_YELLOW;
+      break;
+    case DisplayDriver::ORANGE : 
+      _color = ST77XX_ORANGE;
+      break;
+    default:
+      _color = ST77XX_WHITE;
+      break;
+  }
+  display.setTextColor(_color);
+}
+
+void ST7796LCDDisplay::setCursor(int x, int y) {
+  display.setCursor(x * DISPLAY_SCALE_X, y * DISPLAY_SCALE_Y);
+}
+
+void ST7796LCDDisplay::print(const char* str) {
+  display.print(str);
+}
+
+void ST7796LCDDisplay::fillRect(int x, int y, int w, int h) {
+  display.fillRect(x * DISPLAY_SCALE_X, y * DISPLAY_SCALE_Y, w * DISPLAY_SCALE_X, h * DISPLAY_SCALE_Y, _color);
+}
+
+void ST7796LCDDisplay::drawRect(int x, int y, int w, int h) {
+  display.drawRect(x * DISPLAY_SCALE_X, y * DISPLAY_SCALE_Y, w * DISPLAY_SCALE_X, h * DISPLAY_SCALE_Y, _color);
+}
+
+void ST7796LCDDisplay::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+  uint8_t byteWidth = (w + 7) / 8;
+
+  for (int j = 0; j < h; j++) {
+    for (int i = 0; i < w; i++) {
+      uint8_t byte = bits[j * byteWidth + i / 8];
+      bool pixelOn = byte & (0x80 >> (i & 7));
+
+      if (pixelOn) {
+        for (int dy = 0; dy < DISPLAY_SCALE_X; dy++) {
+          for (int dx = 0; dx < DISPLAY_SCALE_X; dx++) {
+            display.drawPixel(x * DISPLAY_SCALE_X + i * DISPLAY_SCALE_X + dx, y * DISPLAY_SCALE_Y + j * DISPLAY_SCALE_X + dy, _color);
+          }
+        }
+      }
+    }
+  }
+}
+
+uint16_t ST7796LCDDisplay::getTextWidth(const char* str) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+
+  return w / DISPLAY_SCALE_X;
+}
+
+void ST7796LCDDisplay::endFrame() {
+  // display.display();
+}

--- a/src/helpers/ui/ST7796LCDDisplay.h
+++ b/src/helpers/ui/ST7796LCDDisplay.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "DisplayDriver.h"
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7796S.h>
+#include <helpers/RefCountedDigitalPin.h>
+
+class ST7796LCDDisplay : public DisplayDriver {
+  Adafruit_ST7796S display;
+  bool _isOn;
+  uint16_t _color;
+  RefCountedDigitalPin* _peripher_power;
+
+  bool i2c_probe(TwoWire& wire, uint8_t addr);
+public:
+#ifdef USE_PIN_TFT
+  ST7796LCDDisplay(RefCountedDigitalPin* peripher_power=NULL) : DisplayDriver(128, 64), 
+      display(PIN_TFT_CS, PIN_TFT_DC, PIN_TFT_SDA, PIN_TFT_SCL, PIN_TFT_RST),
+      _peripher_power(peripher_power)
+  {
+    _isOn = false;
+  }
+#else
+  ST7796LCDDisplay(RefCountedDigitalPin* peripher_power=NULL) : DisplayDriver(128, 64), 
+      display(&SPI, PIN_TFT_CS, PIN_TFT_DC, PIN_TFT_RST),
+      _peripher_power(peripher_power)
+  {
+    _isOn = false;
+  }
+#endif
+  bool begin();
+
+  bool isOn() override { return _isOn; }
+  void turnOn() override;
+  void turnOff() override;
+  void clear() override;
+  void startFrame(Color bkg = DARK) override;
+  void setTextSize(int sz) override;
+  void setColor(Color c) override;
+  void setCursor(int x, int y) override;
+  void print(const char* str) override;
+  void fillRect(int x, int y, int w, int h) override;
+  void drawRect(int x, int y, int w, int h) override;
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
+  void endFrame() override;
+};

--- a/variants/lilygo_tconnect_pro/TConnectProBoard.cpp
+++ b/variants/lilygo_tconnect_pro/TConnectProBoard.cpp
@@ -1,0 +1,31 @@
+#include <Arduino.h>
+#include "TConnectProBoard.h"
+
+uint32_t deviceOnline = 0x00;
+
+void TConnectProBoard::begin() {
+  
+  ESP32Board::begin();
+  
+  // Configure user button
+  pinMode(PIN_USER_BTN, INPUT);
+
+  // Configure LoRa Pins
+  pinMode(P_LORA_MISO, INPUT_PULLUP);
+  // pinMode(P_LORA_DIO_1, INPUT_PULLUP);
+
+  #ifdef P_LORA_TX_LED
+    digitalWrite(P_LORA_TX_LED, HIGH); // inverted pin for SX1276 - HIGH for off
+  #endif
+
+  esp_reset_reason_t reason = esp_reset_reason();
+  if (reason == ESP_RST_DEEPSLEEP) {
+    long wakeup_source = esp_sleep_get_ext1_wakeup_status();
+    if (wakeup_source & (1 << P_LORA_DIO_1)) {
+      startup_reason = BD_STARTUP_RX_PACKET; // received a LoRa packet (while in deep sleep)
+    }
+
+    rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
+    rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
+  }
+}

--- a/variants/lilygo_tconnect_pro/TConnectProBoard.h
+++ b/variants/lilygo_tconnect_pro/TConnectProBoard.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Wire.h>
+#include <Arduino.h>
+#include "helpers/ESP32Board.h"
+#include <driver/rtc_io.h>
+
+
+class TConnectProBoard : public ESP32Board {
+public:
+  void begin();
+
+  #ifdef P_LORA_TX_LED
+    void onBeforeTransmit() override{
+      digitalWrite(P_LORA_TX_LED, LOW); // turn TX LED on - invert pin for SX1276
+    }
+
+    void onAfterTransmit() override{
+      digitalWrite(P_LORA_TX_LED, HIGH); // turn TX LED off - invert pin for SX1276
+    }
+  #endif
+
+  void enterDeepSleep(uint32_t secs, int pin_wake_btn) {
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
+    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
+    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
+
+    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
+
+    if (pin_wake_btn < 0) {
+      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // wake up on: recv LoRa packet
+    } else {
+      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH); // wake up on: recv LoRa packet OR wake btn
+    }
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup(secs * 1000000);
+    }
+
+    // Finally set ESP32 into sleep
+    esp_deep_sleep_start(); // CPU halts here and never returns!
+  }
+
+  const char* getManufacturerName() const{
+    return "LilyGo T-Connect-Pro";
+  }
+};

--- a/variants/lilygo_tconnect_pro/platformio.ini
+++ b/variants/lilygo_tconnect_pro/platformio.ini
@@ -1,0 +1,117 @@
+[lilygo_tconnect_pro]
+extends = esp32_base
+board = esp32-s3-devkitc-1
+build_flags =
+  ${esp32_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/lilygo_tconnect_pro
+  -D LILYGO_TCONNECTPRO 
+  -D BOARD_HAS_PSRAM=1
+  -D CORE_DEBUG_LEVEL=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D PIN_USER_BTN=0  ; USR button
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_DIO2_AS_RF_SWITCH=false
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8f
+  -D ENV_INCLUDE_GPS=0
+  -D ENV_INCLUDE_AHTX0=0
+  -D ENV_INCLUDE_BME280=0
+  -D ENV_INCLUDE_BMP280=0
+  -D ENV_INCLUDE_SHTC3=0
+  -D ENV_INCLUDE_SHT4X=0
+  -D ENV_INCLUDE_LPS22HB=0
+  -D ENV_INCLUDE_INA3221=0
+  -D ENV_INCLUDE_INA219=0
+  -D ENV_INCLUDE_INA226=0
+  -D ENV_INCLUDE_INA260=0
+  -D ENV_INCLUDE_MLX90614=0
+  -D ENV_INCLUDE_VL53L0X=0
+  -D ENV_INCLUDE_BME680=0
+  -D ENV_INCLUDE_BMP085=0
+  -D PIN_BOARD_SDA=39
+  -D PIN_BOARD_SCL=40
+  -D LORA_TX_POWER=22
+  -D P_LORA_DIO_1=45 ; LORA IRQ pin
+  -D P_LORA_NSS=14    ; LORA SS pin
+  -D P_LORA_RESET=42 ; LORA RST pin
+  -D P_LORA_BUSY=38  ; LORA Busy pin
+  -D P_LORA_SCLK=12  ; LORA SCLK pin
+  -D P_LORA_MISO=13  ; LORA MISO pin
+  -D P_LORA_MOSI=11  ; LORA MOSI pin
+  -D DISPLAY_CLASS=ST7796LCDDisplay ; T-connectPro has ST7796 222x480px
+  -D DISPLAY_SCALE_X=3.75 ; Width : 128 px to 480 is scaled by 3.75,  1.73 scales 128 to 222 , then use DISPLAY_ROTATION=1
+  -D DISPLAY_SCALE_Y=3.46 ; Height: 64px to 222 is scaled by 3.46 , 7.5 scales 64 to 480
+  ; -D DISPLAY_ROTATION=0
+  -D ST7796S=1
+  ; -D USE_PIN_TFT=1 ; bitbang SPI interface for TFT/LCD
+  -D PIN_TFT_RST=-1
+  -D PIN_TFT_VDD_CTL=-1
+  -D PIN_TFT_LEDA_CTL=46
+  -D PIN_TFT_CS=21
+  -D PIN_TFT_DC=41
+  -D PIN_TFT_SCL=12 ; SPI SCK
+  -D PIN_TFT_SDA=11 ; SPI MOSI
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lilygo_tconnect_pro>
+  +<helpers/sensors/*.cpp>
+lib_deps =
+  ${esp32_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
+
+[env:lilygo_tconnect_pro_companion_radio_usb]
+extends = lilygo_tconnect_pro
+build_flags =
+  ${lilygo_tconnect_pro.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${lilygo_tconnect_pro.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+  +<helpers/ui/ST7796LCDDisplay.cpp>
+lib_deps =
+  ${lilygo_tconnect_pro.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:lilygo_tconnect_pro_companion_radio_ble]
+extends = lilygo_tconnect_pro
+build_flags =
+  ${lilygo_tconnect_pro.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${lilygo_tconnect_pro.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+  +<helpers/ui/ST7796LCDDisplay.cpp>
+lib_deps =
+  ${lilygo_tconnect_pro.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:lilygo_tconnect_pro_repeater]
+extends = lilygo_tconnect_pro
+build_flags =
+  ${lilygo_tconnect_pro.build_flags}
+  -D ADVERT_NAME='"TConnectPro Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+build_src_filter = ${lilygo_tconnect_pro.build_src_filter}
+  +<../examples/simple_repeater>
+  +<helpers/ui/ST7796LCDDisplay.cpp>
+lib_deps =
+  ${lilygo_tconnect_pro.lib_deps}
+  ${esp32_ota.lib_deps}

--- a/variants/lilygo_tconnect_pro/target.cpp
+++ b/variants/lilygo_tconnect_pro/target.cpp
@@ -1,0 +1,60 @@
+#include <Arduino.h>
+#include "target.h"
+
+TConnectProBoard board;
+
+#if defined(P_LORA_SCLK)
+  //static SPIClass spi;
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+EnvironmentSensorManager sensors = EnvironmentSensorManager(); // no sensors on PCB
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  
+#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
+#endif
+  Wire.begin();
+
+  rtc_clock.begin(Wire);
+ 
+
+#if defined(P_LORA_SCLK)
+  return radio.std_init(&SPI);
+#else
+  return radio.std_init();
+#endif
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng); // create new random identity
+}

--- a/variants/lilygo_tconnect_pro/target.h
+++ b/variants/lilygo_tconnect_pro/target.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <TConnectProBoard.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/ST7796LCDDisplay.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+#include "helpers/sensors/EnvironmentSensorManager.h"
+
+extern TConnectProBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
Support for the[ LilyGo T-Connect Pro](https://wiki.lilygo.cc/get_started/en/High_speed/T-Connect-Pro/T-Connect-Pro.html#) (16MB flash, 8MB PSRAM),  board has CANbus, Ethernet ,RS485, RS232 ( but none of those are used in Meshcore yet, coudl probably use RS232 for the RS232 gateway )

Added the board definition (boards/t-connect-pro.json), PlatformIO environments (variants/lilygo_tconnect_pro/platformio.ini) and variant-specific target glue (variants/lilygo_tconnect_pro/target.{h,cpp}).
Includes a new ST7796 LCD display driver ( based on the existing and already included Adafruit SS7796S driver in SS77xx )

This was based on the files for the Lilygo T-Echo with some modifications
<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/d5131361-0975-4016-adf0-33e959c3ccea" />
