### PR TITLE
Minor documentation fix for Advert packet type

### DIFF
--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -35,14 +35,14 @@ This kind of payload notifies receivers that a node exists, and gives informatio
 
 Appdata
 
-| Field         | Size (bytes)    | Description                                           |
-|---------------|-----------------|-------------------------------------------------------|
-| flags         | 1               | specifies which of the fields are present, see below  |
-| latitude      | 4 (optional)    | decimal latitude multiplied by 1000000, integer       |
-| longitude     | 4 (optional)    | decimal longitude multiplied by 1000000, integer      |
-| feature 1     | 2  (optional)   | reserved for future use                               |
-| feature 2     | 2  (optional)   | reserved for future use                               |
-| name          | rest of appdata | name of the node                                      |
+| Field         | Size (bytes)    | Description                                                |
+|---------------|-----------------|------------------------------------------------------------|
+| flags         | 1               | specifies which of the fields are present, see below       |
+| latitude      | 4 (optional)    | decimal latitude multiplied by 1000000, integer            |
+| longitude     | 4 (optional)    | decimal longitude multiplied by 1000000, integer           |
+| feature 1     | 2  (optional)   | reserved for future use                                    |
+| feature 2     | 2  (optional)   | reserved for future use                                    |
+| name          | 0-32            | name of the node (capped at 32 bytes/MAX_ADVERT_DATA_SIZE) |
 
 Appdata Flags
 

--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -46,16 +46,17 @@ Appdata
 
 Appdata Flags
 
-| Value  | Name           | Description                           |
-|--------|----------------|---------------------------------------|
-| `0x01` | is chat node   | advert is for a chat node             |
-| `0x02` | is repeater    | advert is for a repeater              |
-| `0x03` | is room server | advert is for a room server           |
-| `0x04` | is sensor      | advert is for a sensor server         |
-| `0x10` | has location   | appdata contains lat/long information |
-| `0x20` | has feature 1  | Reserved for future use.              |
-| `0x40` | has feature 2  | Reserved for future use.              |
-| `0x80` | has name       | appdata contains a node name          |
+| Value  | Name           | Description                            |
+|--------|----------------|----------------------------------------|
+| `0x00` | no node type   | advert is for an unspecified node type |
+| `0x01` | is chat node   | advert is for a chat node              |
+| `0x02` | is repeater    | advert is for a repeater               |
+| `0x03` | is room server | advert is for a room server            |
+| `0x04` | is sensor      | advert is for a sensor server          |
+| `0x10` | has location   | appdata contains lat/long information  |
+| `0x20` | has feature 1  | Reserved for future use.               |
+| `0x40` | has feature 2  | Reserved for future use.               |
+| `0x80` | has name       | appdata contains a node name           |
 
 # Acknowledgement
 


### PR DESCRIPTION
AdvertDataHelpers.h declares 0x00 / ADV_TYPE_NONE for the advert appdata flag value. This PR reflects that flag in the documentation.

See https://github.com/meshcore-dev/MeshCore/blob/dev/src/helpers/AdvertDataHelpers.h#L7