### PR TITLE
check the app_data_len before actually reading out of bounds and fix a possible buffer overflow

### DIFF
--- a/src/helpers/AdvertDataHelpers.cpp
+++ b/src/helpers/AdvertDataHelpers.cpp
@@ -54,7 +54,7 @@
         nlen = app_data_len - i;  // remainder of app_data
       }
       if (nlen > 0) {
-        if (nlen > MAX_NAME_SIZE - 1) nlen = MAX_NAME_SIZE - 1;  // Prevent buffer overflow
+        if (nlen > MAX_ADVERT_DATA_SIZE - 1) nlen = MAX_ADVERT_DATA_SIZE - 1;  // Prevent buffer overflow
         memcpy(_name, &app_data[i], nlen);
         _name[nlen] = 0;  // set null terminator
       }

--- a/src/helpers/AdvertDataHelpers.cpp
+++ b/src/helpers/AdvertDataHelpers.cpp
@@ -35,13 +35,16 @@
   
     int i = 1;
     if (_flags & ADV_LATLON_MASK) {
+      if (i + 8 > app_data_len) return;  // Need 8 bytes for lat and lon
       memcpy(&_lat, &app_data[i], 4); i += 4;
       memcpy(&_lon, &app_data[i], 4); i += 4;
     }
     if (_flags & ADV_FEAT1_MASK) {
+      if (i + 2 > app_data_len) return;  // Need 2 bytes for _extra1
       memcpy(&_extra1, &app_data[i], 2); i += 2;
     }
     if (_flags & ADV_FEAT2_MASK) {
+      if (i + 2 > app_data_len) return;  // Need 2 bytes for _extra2
       memcpy(&_extra2, &app_data[i], 2); i += 2;
     }
 
@@ -51,6 +54,7 @@
         nlen = app_data_len - i;  // remainder of app_data
       }
       if (nlen > 0) {
+        if (nlen > MAX_NAME_SIZE - 1) nlen = MAX_NAME_SIZE - 1;  // Prevent buffer overflow
         memcpy(_name, &app_data[i], nlen);
         _name[nlen] = 0;  // set null terminator
       }


### PR DESCRIPTION
This will fix two bugs:
- check the actual length of the app_data before memcpy in order to prevent a oob read (3x). 
- validate that the length of the remaining advert fits actually inside _name to prevent a buffer overflow. 

This could cause a crash of a device (companion, repeater, ..) if a malformed advert is received. 


