### PR TITLE
fix(RegionMap): save() returns actual write success instead of hardcoded true

### DIFF
--- a/src/helpers/RegionMap.cpp
+++ b/src/helpers/RegionMap.cpp
@@ -139,7 +139,7 @@ bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
       }
     }
     file.close();
-    return true;
+    return success;
   }
   return false;  // failed
 }


### PR DESCRIPTION
## Problem
RegionMap::save() always returned `true` even when file writes failed,
causing silent data loss. On nRF52840 with LittleFS, if writes fail
(e.g. due to storage limits), regions appear saved but are lost after reboot.

## Fix
Return the `success` variable that already tracks write failures
throughout the function, instead of hardcoded `true`.

## Change
- `src/helpers/RegionMap.cpp`: `return true` → `return success` (1 line)