### PR TITLE
Disable NRF52 undervoltage bootlock feature

### DIFF
--- a/variants/gat562_30s_mesh_kit/platformio.ini
+++ b/variants/gat562_30s_mesh_kit/platformio.ini
@@ -7,7 +7,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/gat562_30s_mesh_kit
   -D RAK_4631
   -D RAK_BOARD
-  -D NRF52_POWER_MANAGEMENT
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_OLED_RESET=-1

--- a/variants/gat562_mesh_evb_pro/platformio.ini
+++ b/variants/gat562_mesh_evb_pro/platformio.ini
@@ -5,7 +5,6 @@ board_check = true
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/gat562_mesh_evb_pro
-  -D NRF52_POWER_MANAGEMENT
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D RADIO_CLASS=CustomSX1262

--- a/variants/gat562_mesh_tracker_pro/platformio.ini
+++ b/variants/gat562_mesh_tracker_pro/platformio.ini
@@ -5,7 +5,6 @@ board_check = true
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/gat562_mesh_tracker_pro
-  -D NRF52_POWER_MANAGEMENT
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_OLED_RESET=-1

--- a/variants/gat562_mesh_watch13/platformio.ini
+++ b/variants/gat562_mesh_watch13/platformio.ini
@@ -8,7 +8,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/gat562_mesh_watch13
   -D RAK_4631
   -D RAK_BOARD
-  -D NRF52_POWER_MANAGEMENT
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_OLED_RESET=-1

--- a/variants/heltec_t096/platformio.ini
+++ b/variants/heltec_t096/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/heltec_t096
   -I src/helpers/ui
   -D HELTEC_T096
-  -D NRF52_POWER_MANAGEMENT
   -D P_LORA_DIO_1=21
   -D P_LORA_NSS=5
   -D P_LORA_RESET=16

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -12,7 +12,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/heltec_t114
   -I src/helpers/ui
   -D HELTEC_T114
-  -D NRF52_POWER_MANAGEMENT
   -D P_LORA_DIO_1=20
   -D P_LORA_NSS=24
   -D P_LORA_RESET=25

--- a/variants/muziworks_r1_neo/platformio.ini
+++ b/variants/muziworks_r1_neo/platformio.ini
@@ -7,7 +7,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/muziworks_r1_neo
   -I src/helpers/ui
   -D R1Neo
-  -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,7 +6,6 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
-  -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -7,7 +7,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/rak4631
   -D RAK_4631
   -D RAK_BOARD
-  -D NRF52_POWER_MANAGEMENT
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_GPS_TX=PIN_SERIAL1_RX

--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -10,7 +10,6 @@ build_flags = ${nrf52_base.build_flags}
   -I src/helpers/nrf52
   -D NRF52_PLATFORM=1
   -D USE_SX1262
-  -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D P_LORA_TX_LED=11

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/xiao_nrf52
   -UENV_INCLUDE_GPS
   -D NRF52_PLATFORM
-  -D NRF52_POWER_MANAGEMENT
   -D XIAO_NRF52
   -D USE_SX1262
   -D RADIO_CLASS=CustomSX1262


### PR DESCRIPTION
The NRF52 undervoltage bootlock feature implemented behind NRF52_POWER_MANAGEMENT was introduced in v1.12.

It configures a fixed voltage level of 3.3V and prevents the software from booting if the battery voltage is below that level.

This is problematic for various reasons. The most important one being that it breaks devices that use cell chemistries other than Li-Ion, such as LFP, LTO or SIB which have much lower minimum voltages.

As a quick fix to prevent devices from failing, disable the feature until it has been decided how to handle this in the future and a proper implementation has been provided.

This solves https://github.com/meshcore-dev/MeshCore/issues/1572.