### PR TITLE
Fix RAK4631 hang when I2C WisBlock modules are present

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -218,6 +218,11 @@ void setup() {
 #endif
 
 #ifdef DISPLAY_CLASS
+#ifdef RAK_BOARD
+  // sensors.begin() GPS probe may power-cycle 3V3_S rail (via WB_IO2),
+  // which resets the SSD1306. Re-init the display before starting UI.
+  if (disp) display.begin();
+#endif
   ui_task.begin(disp, &sensors, the_mesh.getNodePrefs());  // still want to pass this in as dependency, as prefs might be moved
 #endif
 }

--- a/src/helpers/ArduinoSerialInterface.h
+++ b/src/helpers/ArduinoSerialInterface.h
@@ -14,11 +14,8 @@ class ArduinoSerialInterface : public BaseSerialInterface {
 public:
   ArduinoSerialInterface() { _isEnabled = false; _state = 0; }
 
-  void begin(Stream& serial) { 
-    _serial = &serial; 
-  #ifdef RAK_4631
-    pinMode(WB_IO2, OUTPUT);
-  #endif  
+  void begin(Stream& serial) {
+    _serial = &serial;
   }
 
   // BaseSerialInterface methods

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -655,7 +655,14 @@ void EnvironmentSensorManager::rakGPSInit(){
   //  MESH_DEBUG_PRINTLN("RAK base board is RAK19007/10");
   //  MESH_DEBUG_PRINTLN("GPS is installed on Socket A");
   }
-  else if(gpsIsAwake(WB_IO4)){
+
+  // WB_IO2 controls the 3V3_S switched peripheral rail on RAK these boards.
+  // gpsIsAwake() leaves the pin as INPUT on failure, killing the rail.
+  // Restore it now, before probing other sockets.
+  pinMode(WB_IO2, OUTPUT);
+  digitalWrite(WB_IO2, HIGH);
+
+  if(gpsIsAwake(WB_IO4)){
   //  MESH_DEBUG_PRINTLN("RAK base board is RAK19003/9");
   //  MESH_DEBUG_PRINTLN("GPS is installed on Socket C");
   }

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -16,6 +16,9 @@ void RAK4631Board::initiateShutdown(uint8_t reason) {
   // Disable LoRa module power before shutdown
   digitalWrite(SX126X_POWER_EN, LOW);
 
+  // Disable 3V3 switched peripherals
+  digitalWrite(PIN_3V3_EN, LOW);
+
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
     configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);

--- a/variants/rak4631/variant.cpp
+++ b/variants/rak4631/variant.cpp
@@ -44,6 +44,9 @@ void initVariant()
   ledOff(PIN_LED1);
 
   pinMode(PIN_LED2, OUTPUT);
-  ledOff(PIN_LED2);;
-}
+  ledOff(PIN_LED2);
 
+  // 3V3 Power Rail
+  pinMode(PIN_3V3_EN, OUTPUT);
+  digitalWrite(PIN_3V3_EN, HIGH);
+}

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -59,6 +59,8 @@ extern "C"
 	static const uint8_t WB_SPI_MISO = 29; // IO_SLOT
 	static const uint8_t WB_SPI_MOSI = 30; // IO_SLOT
 
+#define PIN_3V3_EN WB_IO2                  // 3V3_S switched peripheral rail control
+
 // Number of pins defined in PinDescription array
 #define PINS_COUNT (48)
 #define NUM_DIGITAL_PINS (48)


### PR DESCRIPTION
This change fixes a problem where the RAK4631 will hang on startup when I2C based WisBlock modules are present. These can be sensors or the RAK OLED display.

WB_IO2 controls the 3V3_S switched peripheral rail on RAK base boards. gpsIsAwake() left the pin as INPUT on failure, dropping the power rail. Then, when the I2C devices were probed, they couldn't respond and so the boot process hung. This fixes that by making the power rail code match that on the RAK3401, and making sure to restore it after GPS probing, re-init the display before UI start, and disable the 3V3_S rail on shutdown.

Fixes #1874
Refs #2222 and #2215