### PR TITLE
Use a  tempfile / rename for atomic writes in order to prevent dataloss during a HardFault on a repeater

### DIFF
--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -1,9 +1,9 @@
 #include "ClientACL.h"
 
-static File openWrite(FILESYSTEM* _fs, const char* filename) {
+static File openWriteTemp(FILESYSTEM* _fs, const char* filename, const char* tmp_filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
-    _fs->remove(filename);
-    return _fs->open(filename, FILE_O_WRITE);
+    _fs->remove(tmp_filename);
+    return _fs->open(tmp_filename, FILE_O_WRITE);
   #elif defined(RP2040_PLATFORM)
     return _fs->open(filename, "w");
   #else
@@ -54,7 +54,9 @@ void ClientACL::load(FILESYSTEM* fs, const mesh::LocalIdentity& self_id) {
 
 void ClientACL::save(FILESYSTEM* fs, bool (*filter)(ClientInfo*)) {
   _fs = fs;
-  File file = openWrite(_fs, "/s_contacts");
+  const char* tmp_path = "/s_contacts.tmp";
+  const char* real_path = "/s_contacts";
+  File file = openWriteTemp(_fs, real_path, tmp_path);
   if (file) {
     uint8_t unused[2];
     memset(unused, 0, sizeof(unused));
@@ -74,6 +76,13 @@ void ClientACL::save(FILESYSTEM* fs, bool (*filter)(ClientInfo*)) {
       if (!success) break; // write failed
     }
     file.close();
+
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    if (!_fs->rename(tmp_path, real_path)) {
+      _fs->remove(tmp_path);
+      MESH_DEBUG_PRINTLN("ERROR: ClientACL::save rename failed!");
+    }
+#endif
   }
 }
 

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -1,7 +1,14 @@
 #include "ClientACL.h"
 
-static File openWriteTemp(FILESYSTEM* _fs, const char* filename, const char* tmp_filename) {
+static char* getTmpPath(const char* filename) {
+  static char tmp_filename[32];
+  snprintf(tmp_filename, sizeof(tmp_filename), "%s.tmp", filename);
+  return tmp_filename;
+}
+
+static File openWrite(FILESYSTEM* _fs, const char* filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    char* tmp_filename = getTmpPath(filename);
     _fs->remove(tmp_filename);
     return _fs->open(tmp_filename, FILE_O_WRITE);
   #elif defined(RP2040_PLATFORM)
@@ -54,9 +61,8 @@ void ClientACL::load(FILESYSTEM* fs, const mesh::LocalIdentity& self_id) {
 
 void ClientACL::save(FILESYSTEM* fs, bool (*filter)(ClientInfo*)) {
   _fs = fs;
-  const char* tmp_path = "/s_contacts.tmp";
   const char* real_path = "/s_contacts";
-  File file = openWriteTemp(_fs, real_path, tmp_path);
+  File file = openWrite(_fs, real_path);
   if (file) {
     uint8_t unused[2];
     memset(unused, 0, sizeof(unused));
@@ -78,6 +84,7 @@ void ClientACL::save(FILESYSTEM* fs, bool (*filter)(ClientInfo*)) {
     file.close();
 
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    char* tmp_path = getTmpPath(real_path);
     if (!_fs->rename(tmp_path, real_path)) {
       _fs->remove(tmp_path);
       MESH_DEBUG_PRINTLN("ERROR: ClientACL::save rename failed!");

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -126,8 +126,12 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
 
 void CommonCLI::savePrefs(FILESYSTEM* fs) {
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
-  fs->remove("/com_prefs");
-  File file = fs->open("/com_prefs", FILE_O_WRITE);
+  // Atomic write: write to temp file, then rename over the real file.
+  // LittleFS rename() is a single metadata commit -- atomic even on power loss.
+  const char* tmp_path = "/com_prefs.tmp";
+  const char* real_path = "/com_prefs";
+  fs->remove(tmp_path);  // clean up any stale temp from previous failed write
+  File file = fs->open(tmp_path, FILE_O_WRITE);
 #elif defined(RP2040_PLATFORM)
   File file = fs->open("/com_prefs", "w");
 #else
@@ -183,6 +187,13 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     // next: 291
 
     file.close();
+
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    if (!fs->rename(tmp_path, real_path)) {
+      fs->remove(tmp_path);
+      MESH_DEBUG_PRINTLN("ERROR: savePrefs rename failed!");
+    }
+#endif
   }
 }
 

--- a/src/helpers/RegionMap.cpp
+++ b/src/helpers/RegionMap.cpp
@@ -1,6 +1,6 @@
 #include "RegionMap.h"
 #include <helpers/TxtDataHelpers.h>
-#include <SHA256.h>
+#include <SHA256.h> 
 
 // helper class for region map exporter, we emulate Stream with a safe buffer writer.
 
@@ -58,8 +58,15 @@ static const char* skip_hash(const char* name) {
   return *name == '#' ? name + 1 : name;
 }
 
-static File openWriteTemp(FILESYSTEM* _fs, const char* filename, const char* tmp_filename) {
+static char* getTmpPath(const char* filename) {
+  static char tmp_filename[32];
+  snprintf(tmp_filename, sizeof(tmp_filename), "%s.tmp", filename);
+  return tmp_filename;
+}
+
+static File openWrite(FILESYSTEM* _fs, const char* filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    char* tmp_filename = getTmpPath(filename);
     _fs->remove(tmp_filename);
     return _fs->open(tmp_filename, FILE_O_WRITE);
   #elif defined(RP2040_PLATFORM)
@@ -116,9 +123,7 @@ bool RegionMap::load(FILESYSTEM* _fs, const char* path) {
 
 bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
   const char* real_path = path ? path : "/regions2";
-  char tmp_path[32];
-  snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", real_path);
-  File file = openWriteTemp(_fs, real_path, tmp_path);
+  File file = openWrite(_fs, real_path);
   if (file) {
     uint8_t pad[128];
     memset(pad, 0, sizeof(pad));
@@ -144,6 +149,7 @@ bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
     file.close();
 
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    char* tmp_path = getTmpPath(real_path);
     if (!_fs->rename(tmp_path, real_path)) {
       _fs->remove(tmp_path);
       MESH_DEBUG_PRINTLN("ERROR: RegionMap::save rename failed!");

--- a/src/helpers/RegionMap.cpp
+++ b/src/helpers/RegionMap.cpp
@@ -58,10 +58,10 @@ static const char* skip_hash(const char* name) {
   return *name == '#' ? name + 1 : name;
 }
 
-static File openWrite(FILESYSTEM* _fs, const char* filename) {
+static File openWriteTemp(FILESYSTEM* _fs, const char* filename, const char* tmp_filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
-    _fs->remove(filename);
-    return _fs->open(filename, FILE_O_WRITE);
+    _fs->remove(tmp_filename);
+    return _fs->open(tmp_filename, FILE_O_WRITE);
   #elif defined(RP2040_PLATFORM)
     return _fs->open(filename, "w");
   #else
@@ -115,7 +115,10 @@ bool RegionMap::load(FILESYSTEM* _fs, const char* path) {
 }
 
 bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
-  File file = openWrite(_fs, path ? path : "/regions2");
+  const char* real_path = path ? path : "/regions2";
+  char tmp_path[32];
+  snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", real_path);
+  File file = openWriteTemp(_fs, real_path, tmp_path);
   if (file) {
     uint8_t pad[128];
     memset(pad, 0, sizeof(pad));
@@ -139,6 +142,14 @@ bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
       }
     }
     file.close();
+
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+    if (!_fs->rename(tmp_path, real_path)) {
+      _fs->remove(tmp_path);
+      MESH_DEBUG_PRINTLN("ERROR: RegionMap::save rename failed!");
+      return false;
+    }
+#endif
     return true;
   }
   return false;  // failed


### PR DESCRIPTION
This is the first patch to make repeaters more reliable in the field - even if errors occur.

On a repeater the atomic write (tmpfile + rename) should work even on nrf52 Repeaters with internal flash, the amount of data stored is much smaller than the data used on a companion. I estimated the total size needed to be around 40-50kB  with MAX_CLIENTS and MAX_REGIONS = 32.

This patch should ensure that no setting is lost during a failed write operation into the flash on a repeater. The repeater will be still stuck - but after restart all settings are preserved. 

This is most likely the first of several smaller patches to mitigate this bug #2283. 

