### PR TITLE
Add LilyGo T-ETH Elite SX1262 board support

### DIFF
--- a/variants/lilygo_teth_elite/TETHEliteBoard.h
+++ b/variants/lilygo_teth_elite/TETHEliteBoard.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <helpers/ESP32Board.h>
+
+class TETHEliteBoard : public ESP32Board {
+public:
+  const char* getManufacturerName() const override {
+    return "LilyGO T-ETH Elite";
+  }
+};

--- a/variants/lilygo_teth_elite/platformio.ini
+++ b/variants/lilygo_teth_elite/platformio.ini
@@ -1,0 +1,99 @@
+[LilyGo_TETH_Elite_sx1262]
+extends = esp32_base
+board = esp32s3box
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/lilygo_teth_elite
+  -D BOARD_HAS_PSRAM
+  -D LILYGO_TETH_ELITE
+  -D LILYGO_T_ETH_ELITE_ESP32S3
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D P_LORA_DIO_1=8
+  -D P_LORA_NSS=40
+  -D P_LORA_RESET=46
+  -D P_LORA_BUSY=16
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=9
+  -D P_LORA_MOSI=11
+  -D P_LORA_TX_LED=38
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=8
+  -D SX126X_RX_BOOSTED_GAIN=1
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lilygo_teth_elite>
+lib_deps =
+  ${esp32_base.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_repeater]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_room_server]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_usb]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_ble]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_teth_elite/target.cpp
+++ b/variants/lilygo_teth_elite/target.cpp
@@ -1,0 +1,43 @@
+#include <Arduino.h>
+#include "target.h"
+
+TETHEliteBoard board;
+
+static SPIClass spi(HSPI);
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+#ifndef LORA_CR
+  #define LORA_CR      5
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&spi);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/lilygo_teth_elite/target.h
+++ b/variants/lilygo_teth_elite/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include "TETHEliteBoard.h"
+
+extern TETHEliteBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
Adds a new variant for the Add LilyGo T-ETH Elite SX1262 board.

This is more of a core board support for now, I feel that adding other accessories and support to it should be separate feature requests, let me know if this is the correct approach. 
I'm unsure what to do for ethernet, so it is not utilized, but still provides board power. In the future it should be trivial to integrate, I've done so in other work but it is more involved than a simple board support PR should be I feel.

validated to build and flash to hardware as repeater and ble companion
