### PR TITLE
feat: Enable GPS on RAK 1W kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ There are a number of fairly major features in the pipeline, with no particular 
 
 - Report bugs and request features on the [GitHub Issues](https://github.com/ripplebiz/MeshCore/issues) page.
 - Find additional guides and components on [my site](https://buymeacoffee.com/ripplebiz).
-- Join [MeshCore Discord](https://discord.gg/BMwCtwHj5V) to chat with the developers and get help from the community.
+- Join [MeshCore Discord](https://meshcore.gg) to chat with the developers and get help from the community.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -194,7 +194,7 @@ Recently, as of October 2025, many regions have moved to the "narrow" setting, a
 
 After extensive testing, many regions have switched or about to switch over to BW62.5 and SF7, 8, or 9.  Narrower bandwidth setting and lower SF setting allow MeshCore's radio signals to fit between interference in the ISM band, provide for a lower noise floor, better SNR, and faster transmissions.
 
-If you have consensus from your community in your region to update your region's preset recommendation, please post your update request on  the [#meshcore-app](https://discord.com/channels/1343693475589263471/1391681655911088241) channel on the [MeshCore Discord server ](https://discord.gg/cYtQNYCCRK) to let Liam Cottle know.
+If you have consensus from your community in your region to update your region's preset recommendation, please post your update request on  the [#meshcore-app](https://discord.com/channels/1343693475589263471/1391681655911088241) channel on the [MeshCore Discord server ](https://meshcore.gg) to let Liam Cottle know.
 
 
 
@@ -526,7 +526,7 @@ The third character is the capital letter 'O', not zero `0`
 - Firmware repo: https://github.com/meshcore-dev/MeshCore
 
 ### 5.8. Q: How can I support MeshCore?
-**A:** Provide your honest feedback on GitHub and on [MeshCore Discord server](https://discord.gg/BMwCtwHj5V). Spread the word of MeshCore to your friends and communities; help them get started with MeshCore. Support Scott's MeshCore development at <https://buymeacoffee.com/ripplebiz>.
+**A:** Provide your honest feedback on GitHub and on [MeshCore Discord server](https://meshcore.gg). Spread the word of MeshCore to your friends and communities; help them get started with MeshCore. Support Scott's MeshCore development at <https://buymeacoffee.com/ripplebiz>.
 
 Support Liam Cottle's smartphone client development by unlocking the server administration wait gate with in-app purchase
 

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,6 +6,7 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
+  -D RAK_BOARD
   -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
@@ -82,6 +83,7 @@ board_upload.maximum_size = 712704
 build_flags =
   ${rak3401.build_flags}
   -I examples/companion_radio/ui-new
+  -D PIN_GPS_EN=-1
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40


### PR DESCRIPTION
Enables GPS on the RAK 1W Kit (RAK3401 + RAK13302) using the RAK12500 GPS module in slot A

The RAK12501 is not compatible at all from testing, and the RAK12500 is only compatible in slot A, not slot D