### PR TITLE
fix: correct device model name for Heltec Wireless Paper

### DIFF
--- a/variants/heltec_wireless_paper/target.cpp
+++ b/variants/heltec_wireless_paper/target.cpp
@@ -1,7 +1,7 @@
 #include "target.h"
 #include <Arduino.h>
 
-HeltecV3Board board;
+HeltecWirelessPaperBoard board;
 
 #if defined(P_LORA_SCLK)
   static SPIClass spi;

--- a/variants/heltec_wireless_paper/target.h
+++ b/variants/heltec_wireless_paper/target.h
@@ -4,6 +4,12 @@
 #include <RadioLib.h>
 #include <helpers/radiolib/RadioLibWrappers.h>
 #include <../heltec_v3/HeltecV3Board.h>
+class HeltecWirelessPaperBoard : public HeltecV3Board {
+public:
+  const char* getManufacturerName() const override {
+    return "Heltec Wireless Paper";
+  }
+};
 #include <helpers/radiolib/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
@@ -12,7 +18,7 @@
 #include <helpers/ui/MomentaryButton.h>
 #endif
 
-extern HeltecV3Board board;
+extern HeltecWirelessPaperBoard board;
 extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
 extern SensorManager sensors;


### PR DESCRIPTION
## Summary

Fixes incorrect device model name displayed in the MeshCore app for Heltec Wireless Paper.

Previously, the app showed **"Heltec V3"** because `target.h` and `target.cpp` used `HeltecV3Board` directly, which returns `"Heltec V3"` from `getManufacturerName()`.

This PR introduces `HeltecWirelessPaperBoard`, a minimal subclass of `HeltecV3Board` that overrides `getManufacturerName()` to return `"Heltec Wireless Paper"`.

## Changes

- `variants/heltec_wireless_paper/target.h`: Added `HeltecWirelessPaperBoard` subclass; updated `extern` declaration
- `variants/heltec_wireless_paper/target.cpp`: Updated board instance to use `HeltecWirelessPaperBoard`

## Testing

Tested on hardware (Heltec Wireless Paper) with both BLE and USB Companion firmware. Device model now correctly shows **"Heltec Wireless Paper"** in the MeshCore Android app settings.

This was discovered while testing the USB Companion firmware added in #2315.