### PR TITLE
fix: skip GPS auto-detect on SenseCAP Solar (P1 Pro)

### DIFF
--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -27,6 +27,7 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D ENV_INCLUDE_GPS=1
+  -D ENV_SKIP_GPS_DETECT=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/sensors>


### PR DESCRIPTION
## Problem

The GPS detection in `EnvironmentSensorManager::initBasicGPS()` waits only 1 second before checking `Serial1.available() > 0`. Cold-starting GPS modules commonly need 2–5 seconds before outputting NMEA sentences. On the SenseCAP Solar (P1 Pro) the GPS doesn't respond within that window, so `gps_detected` stays `false`, hiding all GPS CLI commands and preventing GPS time sync entirely. See #2258 for the underlying issue affecting most GPS-equipped variants.

## Workaround

Sets `ENV_SKIP_GPS_DETECT=1` in the SenseCAP Solar build flags, bypassing the unreliable detection check and marking the GPS as present unconditionally. This is consistent with how other affected variants are handled (LilyGo TBeam 1W, ThinkNode M1/M5, Station G2).

```ini
build_flags = ...
  -D ENV_SKIP_GPS_DETECT=1
```

## Note

This is a stopgap until #2258 is resolved with a proper fix in `initBasicGPS()` (e.g. a retry loop up to 5 seconds). Once that lands, this flag becomes redundant.