### PR TITLE
handleLoginReq: layer ACL between admin pw and guest/blank pw

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -89,7 +89,7 @@ void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float sn
 
 uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood) {
   ClientInfo* client = NULL;
-  if (data[0] == 0) {   // blank password, just check if sender is in ACL
+  if (strcmp((char *)data, _prefs.password) != 0) {  // admin pw bypasses ACL (allows upgrade)
     client = acl.getClient(sender.pub_key, PUB_KEY_SIZE);
     if (client == NULL) {
     #if MESH_DEBUG


### PR DESCRIPTION
Reorder login auth so that, in priority:

  1. Admin password match -> ADMIN (overrides ACL — an ACL'd client who knows the admin pw can still upgrade).
  2. Sender pubkey is in the ACL -> use the stored permissions (no password required; pubkey is itself an identity assertion).
  3. Guest password match (or blank pw when guest pw is unset) -> GUEST.
  4. Otherwise -> reject.

Previously the ACL was consulted only when `data[0] == 0` (blank pw), so a non-blank password would skip the ACL entirely and fall through to the password block. Phones that sent any non-empty password field — even a stale one — would never see their ACL-granted role; they'd either be rejected or assigned the role implied by the password match.

Implementation is a single-line change: gate the ACL lookup on "the admin pw did NOT match". When admin matches, we skip the lookup so the existing password block sets ADMIN unconditionally (the right behavior for the upgrade case). When admin does not match, the ACL takes over; only on an ACL miss do we fall through to guest/reject.

This change is needed to allow the upcoming region manager PR (#2438) to function properly. It should not break any existing functionality.

Tested in tandem with the region manager code changes with a change to meshcore-open on Android that adds permissionLevel 4 and shows the correct controls (CLI) in the app. Was able to exercise all region commands and was denied access to commands that the admin has access to, showing that the ACL was respected as sent. After authenticating as admin with the password, the acl on the repeater was changed to 3 for my pubkey and all admin functions were available. On login without a password after that, admin permissions were granted again (sticky). I think this is fine behavior.