### PR TITLE
board: add Ebyte E77 variant (based on Tiny Relay)

### DIFF
--- a/variants/ebyte_e77/platformio.ini
+++ b/variants/ebyte_e77/platformio.ini
@@ -1,0 +1,50 @@
+[Ebyte_E77]
+extends = stm32_base
+board = ebyte_e77_dev
+board_upload.maximum_size = 229376 ; 32kb for FS
+build_flags = ${stm32_base.build_flags}
+  -D RADIO_CLASS=CustomSTM32WLx
+  -D WRAPPER_CLASS=CustomSTM32WLxWrapper
+  -D SPI_INTERFACES_COUNT=0
+  -D RX_BOOSTED_GAIN=true
+;  -D STM32WL_TCXO_VOLTAGE=1.6 ; defaults to 0 if undef
+;  -D LORA_TX_POWER=14 ; Defaults to 22 for HP, 14 is for LP version
+  -D LORA_TX_POWER=22 ; Enable 22dBm transmission
+  -D MAX_LORA_TX_POWER=22 ; Allow setting up to 22dBm in companion radio
+  -I variants/ebyte_e77
+build_src_filter = ${stm32_base.build_src_filter}
+  +<../variants/ebyte_e77>
+
+[env:Ebyte_E77_repeater]
+extends = Ebyte_E77
+build_flags = ${Ebyte_E77.build_flags}
+  -D ADVERT_NAME='"ebyte_e77 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+build_src_filter = ${Ebyte_E77.build_src_filter}
+  +<../examples/simple_repeater>
+
+[env:Ebyte_E77_sensor]
+extends = Ebyte_E77
+build_flags = ${Ebyte_E77.build_flags}
+  -D ADVERT_NAME='"ebyte_e77 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+build_src_filter = ${Ebyte_E77.build_src_filter}
+  +<../examples/simple_sensor>
+
+[env:Ebyte_E77_companion_radio_usb]
+extends = Ebyte_E77
+build_flags = ${Ebyte_E77.build_flags}
+;  -D FORMAT_FS=true
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D MAX_LORA_TX_POWER=22
+build_src_filter = ${Ebyte_E77.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps = ${Ebyte_E77.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/ebyte_e77/target.cpp
+++ b/variants/ebyte_e77/target.cpp
@@ -1,0 +1,82 @@
+#include "target.h"
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+EbyteE77Board board;
+
+RADIO_CLASS radio = new STM32WLx_Module();
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+static const uint32_t rfswitch_pins[] = {LORAWAN_RFSWITCH_PINS, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC};
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+    {STM32WLx::MODE_IDLE, {LOW, LOW}},
+    {STM32WLx::MODE_RX, {HIGH, LOW}},
+    {STM32WLx::MODE_TX_LP, {LOW, HIGH}},
+    {STM32WLx::MODE_TX_HP, {LOW, HIGH}},
+    END_OF_MODE_TABLE,
+};
+
+VolatileRTCClock rtc_clock;
+SensorManager sensors;
+
+#ifndef LORA_CR
+#define LORA_CR 5
+#endif
+
+#ifndef STM32WL_TCXO_VOLTAGE
+// TCXO set to 0 for RAK3172
+#define STM32WL_TCXO_VOLTAGE 0
+#endif
+
+#ifndef LORA_TX_POWER
+#define LORA_TX_POWER 22
+#endif
+
+bool radio_init()
+{
+    //  rtc_clock.begin(Wire);
+
+    radio.setRfSwitchTable(rfswitch_pins, rfswitch_table);
+
+    int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16,
+                             STM32WL_TCXO_VOLTAGE, 0);
+
+    if (status != RADIOLIB_ERR_NONE) {
+        Serial.print("ERROR: radio init failed: ");
+        Serial.println(status);
+        return false; // fail
+    }
+
+#ifdef RX_BOOSTED_GAIN
+    radio.setRxBoostedGainMode(RX_BOOSTED_GAIN);
+#endif
+
+    radio.setCRC(1);
+
+    return true; // success
+}
+
+uint32_t radio_get_rng_seed()
+{
+    return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr)
+{
+    radio.setFrequency(freq);
+    radio.setSpreadingFactor(sf);
+    radio.setBandwidth(bw);
+    radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm)
+{
+    radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity()
+{
+    RadioNoiseListener rng(radio);
+    return mesh::LocalIdentity(&rng); // create new random identity
+}

--- a/variants/ebyte_e77/target.h
+++ b/variants/ebyte_e77/target.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/SensorManager.h>
+#include <helpers/radiolib/CustomSTM32WLxWrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/stm32/STM32Board.h>
+
+#define PIN_VBAT_READ PIN_A0
+#define ADC_MULTIPLIER (5 * 1.73 * 1000)
+
+class EbyteE77Board : public STM32Board
+{
+  public:
+    void begin() override
+    {
+        STM32Board::begin();
+        pinMode(P_LORA_TX_LED, OUTPUT);
+        pinMode(P_LORA_RX_LED, OUTPUT);
+        pinMode(PIN_BUTTON1, INPUT_PULLUP);
+        pinMode(PIN_BUTTON2, INPUT_PULLUP);
+    }
+
+    const char *getManufacturerName() const override { return "Ebyte E77"; }
+
+    uint16_t getBattMilliVolts() override
+    {
+        analogReadResolution(12);
+        uint32_t raw = 0;
+        for (int i = 0; i < 8; i++) {
+            raw += analogRead(PIN_VBAT_READ);
+        }
+        return ((double)raw) * ADC_MULTIPLIER / 8 / 4096;
+    }
+
+    #if defined(P_LORA_TX_LED)
+    void onBeforeTransmit() override {
+        digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+    }
+    void onAfterTransmit() override {
+        digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+    }
+    #endif
+};
+
+extern EbyteE77Board board;
+extern WRAPPER_CLASS radio_driver;
+extern VolatileRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();

--- a/variants/ebyte_e77/variant.h
+++ b/variants/ebyte_e77/variant.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <variant_generic.h>
+
+#define LORAWAN_RFSWITCH_PINS           PA7, PA6 // RX_EN, TX_EN
+#define LORAWAN_RFSWITCH_PIN_COUNT      2
+#define LORAWAN_RFSWITCH_OFF_VALUES     LOW, LOW
+#define LORAWAN_RFSWITCH_RX_VALUES      HIGH, LOW
+#define LORAWAN_RFSWITCH_RFO_LP_VALUES  LOW, HIGH
+#define LORAWAN_RFSWITCH_RFO_HP_VALUES  LOW, HIGH
+
+#define STM32WL_TCXO_VOLTAGE            1.6
+
+#define P_LORA_TX_LED                   PB4 // LED1
+#define P_LORA_RX_LED                   PB3 // LED2 -- not used
+#define PIN_BUTTON1                     PA0 // Just information
+#define PIN_BUTTON2                     PA1 // Just information
+// PA2 UART2_TX
+// PA3 UART2_RX
+// PB7 UART1_RX => USB port
+// PB6 UART1_TX => USB port
+
+#undef RNG


### PR DESCRIPTION
This board variant is based on the existing Tiny Relay implementation, with minimal hardware-specific adjustments.

🔧 Key differences / notes
LED behavior
Only the TX LED is actively supported and functional There is no available RX event hook in the current MainBoard interface, therefore RX activity cannot be indicated via LED Buttons
GPIO pins for two buttons are defined
However, they are currently not used in the firmware and have no assigned functionality TCXO configuration

The following definition was required for stable operation:

`#define STM32WL_TCXO_VOLTAGE 1.6`
Without this setting, the device consistently failed with error -707 The value may require further validation depending on hardware revision 📡 Testing
The device has been tested in repeater mode, where it operates as expected Sensor and companion-specific tests were not performed, due to hardware limitations and the intended use case of this variant.

This variant targets a low-cost and low-power hardware platform (Ebyte E77), making it suitable for simple repeater deployments where minimal hardware complexity and power consumption are required.