### PR TITLE
Don't play startup tune if buzzer pref disabled

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -575,6 +575,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 #ifdef PIN_BUZZER
   buzzer.begin();
   buzzer.quiet(_node_prefs->buzzer_quiet);
+  buzzer.startup();
 #endif
 
 #ifdef PIN_VIBRATION

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -57,6 +57,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 #ifdef PIN_BUZZER
   buzzer.begin();
   buzzer.quiet(_node_prefs->buzzer_quiet);
+  buzzer.startup();
 #endif
 
   // Initialize digital button if available

--- a/src/helpers/ui/buzzer.cpp
+++ b/src/helpers/ui/buzzer.cpp
@@ -12,7 +12,6 @@ void genericBuzzer::begin() {
     quiet(false);
     pinMode(PIN_BUZZER, OUTPUT);
     digitalWrite(PIN_BUZZER, LOW); // need to pull low by default to avoid extreme power draw
-    startup();
 }
 
 void genericBuzzer::play(const char *melody) {


### PR DESCRIPTION
If a user disables the buzzer by triple pressing the user button, the buzzer is silenced for all incoming messages, however when the user reboots the node, it still plays the startup tune.

This PR prevents the startup tune from playing if the user has disabled the buzzer in preferences.

Instead of calling `buzzer.startup()` in `buzzer.begin()`, it is deferred until after the quiet mode has been configured from the node preferences.

Fixes: https://github.com/meshcore-dev/MeshCore/issues/2160
Supersedes: https://github.com/meshcore-dev/MeshCore/pull/1803

Tested on:
- Wio Tracker L1 Pro
- RAK WisMesh Tag