### PR TITLE
Add stddef.h to fix compilation issue on MacOS 

### DIFF
--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 #include <math.h>
 
 #define MAX_HASH_SIZE        8


### PR DESCRIPTION
Small bug fix that allows developers to run the unit test suite on MacOS. Including this header file shouldn't have any impact to other platforms.

Before this change:
```
% pio test -e native -vv                 
Collected 1 tests (test_utils)

Processing test_utils in native environment
---------------------------------------------------------------------------------------------------------------------------------------------------------
Building...
Verbose mode can be enabled via `-v, --verbose` option
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 4 compatible libraries
Scanning dependencies...
Dependency Graph
|-- googletest @ 1.17.0
Building in test mode
Compiling .pio/build/native/src/Utils.o
Compiling .pio/build/native/lib8bf/googletest/googletest/src/gtest-typed-test.o
Compiling .pio/build/native/lib8bf/googletest/googletest/src/gtest.o
In file included from src/Utils.cpp:1:
In file included from src/Utils.h:3:
src/MeshCore.h:59:52: error: unknown type name 'size_t'; did you mean 'std::size_t'?
   59 |   virtual bool getBootloaderVersion(char* version, size_t max_len) { return false; }
      |                                                    ^~~~~~
      |                                                    std::size_t
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__cstddef/size_t.h:20:7: note: 'std::size_t' declared here
   20 | using size_t = decltype(sizeof(int));
      |       ^
1 error generated.
*** [.pio/build/native/src/Utils.o] Error 1
Building stage has failed, see errors above. Use `pio test -vvv` option to enable verbose output.
----------------------------------------------------- native:test_utils [ERRORED] Took 1.14 seconds -----------------------------------------------------
```

After the change the test suite runs without issue