### PR TITLE
Update local clock from trusted advert sources

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -233,6 +233,8 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     file.read((uint8_t *)&_prefs.rx_boosted_gain, sizeof(_prefs.rx_boosted_gain));         // 89
     file.read((uint8_t *)_prefs.default_scope_name, sizeof(_prefs.default_scope_name));    // 90
     file.read((uint8_t *)_prefs.default_scope_key, sizeof(_prefs.default_scope_key));     // 121
+    // appended fields: read may short-return on legacy files; caller pre-initialises defaults
+    file.read((uint8_t *)&_prefs.clock_skew_threshold, sizeof(_prefs.clock_skew_threshold)); // 137
 
     file.close();
   }
@@ -285,13 +287,13 @@ File file = openRead(_getContactsChannelsFS(), "/contacts3");
       while (!full) {
         ContactInfo c;
         uint8_t pub_key[32];
-        uint8_t unused;
 
         bool success = (file.read(pub_key, 32) == 32);
         success = success && (file.read((uint8_t *)&c.name, 32) == 32);
         success = success && (file.read(&c.type, 1) == 1);
         success = success && (file.read(&c.flags, 1) == 1);
-        success = success && (file.read(&unused, 1) == 1);
+        // Was reserved/unused; now flags2. Legacy files stored 0 here, which decodes as no flags set (correct default).
+        success = success && (file.read(&c.flags2, 1) == 1);
         success = success && (file.read((uint8_t *)&c.sync_since, 4) == 4); // was 'reserved'
         success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
         success = success && (file.read((uint8_t *)&c.last_advert_timestamp, 4) == 4);
@@ -314,14 +316,13 @@ void DataStore::saveContacts(DataStoreHost* host) {
   if (file) {
     uint32_t idx = 0;
     ContactInfo c;
-    uint8_t unused = 0;
 
     while (host->getContactForSave(idx, c)) {
       bool success = (file.write(c.id.pub_key, 32) == 32);
       success = success && (file.write((uint8_t *)&c.name, 32) == 32);
       success = success && (file.write(&c.type, 1) == 1);
       success = success && (file.write(&c.flags, 1) == 1);
-      success = success && (file.write(&unused, 1) == 1);
+      success = success && (file.write(&c.flags2, 1) == 1);
       success = success && (file.write((uint8_t *)&c.sync_since, 4) == 4);
       success = success && (file.write((uint8_t *)&c.out_path_len, 1) == 1);
       success = success && (file.write((uint8_t *)&c.last_advert_timestamp, 4) == 4);

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -868,6 +868,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _prefs.tx_power_dbm = LORA_TX_POWER;
   _prefs.gps_enabled = 0;       // GPS disabled by default
   _prefs.gps_interval = 0;      // No automatic GPS updates by default
+  _prefs.clock_skew_threshold = 300; // 5 minutes; opt-in per contact via CONTACT_FLAG2_TRUST_TIME
   //_prefs.rx_delay_base = 10.0f;  enable once new algo fixed
 #if defined(USE_SX1262) || defined(USE_SX1268)
 #ifdef SX126X_RX_BOOSTED_GAIN
@@ -1981,9 +1982,57 @@ void MyMesh::checkCLIRescueCmd() {
         _prefs.ble_pin = atoi(&config[4]);
         savePrefs();
         Serial.printf("  > pin is now %06d\n", _prefs.ble_pin);
+      } else if (memcmp(config, "clock.skew.threshold ", 21) == 0) {
+        int v = atoi(&config[21]);
+        if (v < 0 || v > 65535) {
+          Serial.println("  Error: clock.skew.threshold must be 0..65535 (seconds; 0 disables)");
+        } else {
+          _prefs.clock_skew_threshold = (uint16_t)v;
+          savePrefs();
+          Serial.printf("  > clock.skew.threshold is now %u\n", (unsigned)_prefs.clock_skew_threshold);
+        }
       } else {
         Serial.printf("  Error: unknown config: %s\n", config);
       }
+    } else if (memcmp(cli_command, "trust time ", 11) == 0
+            || memcmp(cli_command, "untrust time ", 13) == 0) {
+      bool enable = (cli_command[0] == 't');
+      const char* arg = enable ? &cli_command[11] : &cli_command[13];
+      ContactInfo* c = NULL;
+      // Try hex pubkey-prefix first (any even length 2..PUB_KEY_SIZE*2). Fall back to name prefix.
+      int hex_len = strlen(arg);
+      if (hex_len >= 2 && (hex_len & 1) == 0 && hex_len <= PUB_KEY_SIZE * 2) {
+        uint8_t key_buf[PUB_KEY_SIZE];
+        memset(key_buf, 0, sizeof(key_buf));
+        if (mesh::Utils::fromHex(key_buf, hex_len / 2, arg)) {
+          c = lookupContactByPubKey(key_buf, hex_len / 2);
+        }
+      }
+      if (c == NULL) c = searchContactsByPrefix(arg);
+      if (c == NULL) {
+        Serial.printf("  Error: no contact matches '%s'\n", arg);
+      } else {
+        if (enable) {
+          c->flags2 |= CONTACT_FLAG2_TRUST_TIME;
+        } else {
+          c->flags2 &= ~CONTACT_FLAG2_TRUST_TIME;
+        }
+        saveContacts();
+        Serial.printf("  > %s time-trust on '%s'\n", enable ? "set" : "cleared", c->name);
+      }
+    } else if (strcmp(cli_command, "trust list") == 0) {
+      int n = 0;
+      for (int i = 0; i < getNumContacts(); i++) {
+        ContactInfo c;
+        if (getContactByIdx(i, c) && (c.flags2 & CONTACT_FLAG2_TRUST_TIME)) {
+          char hex[2 * 8 + 1];
+          mesh::Utils::toHex(hex, c.id.pub_key, 8);
+          Serial.printf("  %s  %s\n", hex, c.name);
+          n++;
+        }
+      }
+      Serial.printf("  (%d trusted-time contact%s; threshold=%us)\n",
+                    n, n == 1 ? "" : "s", (unsigned)_prefs.clock_skew_threshold);
     } else if (strcmp(cli_command, "rebuild") == 0) {
       bool success = _store->formatFileSystem();
       if (success) {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -119,6 +119,7 @@ protected:
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
   bool isAutoAddEnabled() const override;
   bool shouldAutoAddContactType(uint8_t type) const override;
+  uint16_t getClockSkewThreshold() const override { return _prefs.clock_skew_threshold; }
   bool shouldOverwriteWhenFull() const override;
   uint8_t getAutoAddMaxHops() const override;
   void onContactsFull() override;

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -34,4 +34,5 @@ struct NodePrefs {  // persisted to file
   uint8_t autoadd_max_hops;  // 0 = no limit, 1 = direct (0 hops), N = up to N-1 hops (max 64)
   char default_scope_name[31];
   uint8_t default_scope_key[16];
+  uint16_t clock_skew_threshold;  // seconds; 0 = disabled. Trusted contacts may step our clock when |skew| exceeds this.
 };

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -122,6 +122,26 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
     }
   }
 
+  // Opportunistic clock correction from a trusted advert source. The advert's
+  // signature was already verified upstream (Mesh::onRecvPacket) and the per-sender
+  // strict-monotonic check above guards against replay, so by this point we know
+  // the timestamp came from this contact's key and is newer than anything we've
+  // previously accepted from them. If the operator has explicitly trusted this
+  // contact for time, step our local clock when |skew| exceeds the configured
+  // threshold.
+  if (from != NULL && (from->flags2 & CONTACT_FLAG2_TRUST_TIME)) {
+    uint16_t threshold = getClockSkewThreshold();
+    if (threshold > 0) {
+      uint32_t local = getRTCClock()->getCurrentTime();
+      int32_t skew = (int32_t)(timestamp - local);
+      int32_t abs_skew = skew < 0 ? -skew : skew;
+      if (abs_skew > (int32_t)threshold) {
+        MESH_DEBUG_PRINTLN("onAdvertRecv: trusted clock correction from %s skew=%ds", from->name, (int)skew);
+        getRTCClock()->setCurrentTime(timestamp);
+      }
+    }
+  }
+
   // save a copy of raw advert packet (to support "Share..." function)
   int plen;
   {

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -95,6 +95,10 @@ protected:
 
   // 'UI' concepts, for sub-classes to implement
   virtual bool isAutoAddEnabled() const { return true; }
+  // 0 disables clock correction from trusted advert sources; otherwise it is the
+  // minimum |skew| in seconds required before our clock is stepped to a trusted
+  // contact's advert timestamp. See onAdvertRecv() and CONTACT_FLAG2_TRUST_TIME.
+  virtual uint16_t getClockSkewThreshold() const { return 0; }
   virtual bool shouldAutoAddContactType(uint8_t type) const { return true; }
   virtual void onContactsFull() {};
   virtual bool shouldOverwriteWhenFull() const { return false; }

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -5,11 +5,17 @@
 
 #define OUT_PATH_UNKNOWN   0xFF
 
+// Bits for ContactInfo.flags2 (the original 'flags' byte is largely claimed by
+// favourite + telemetry-permission bits in the companion build; flags2 is the
+// fresh byte for new per-contact toggles).
+#define CONTACT_FLAG2_TRUST_TIME   0x01  // accept this contact's advert timestamp as a clock reference
+
 struct ContactInfo {
   mesh::Identity id;
   char name[32];
   uint8_t type;   // on of ADV_TYPE_*
   uint8_t flags;
+  uint8_t flags2; // bitfield, see CONTACT_FLAG2_*
   uint8_t out_path_len;
   mutable bool shared_secret_valid; // flag to indicate if shared_secret has been calculated
   uint8_t out_path[MAX_PATH_SIZE];


### PR DESCRIPTION
## Summary

A first cut at #2416. When an advert arrives from a contact the operator has explicitly marked as a time reference, and its timestamp differs from our local clock by more than a configurable threshold (default **5 min**), we step the local clock to match. The signature is already verified upstream and the existing per-sender monotonic replay check guarantees the timestamp is fresher than anything we've accepted from that key — so by the time the correction runs, both authenticity and freshness have already been established.

This is intentionally narrow and reuses what's already there. The everyday case from the issue — handhelds without RTC drifting or coming back from reset stuck in the past or future — is the one this fixes.

## Changes

- **`src/helpers/ContactInfo.h`** — new generic `uint8_t flags2` field with `CONTACT_FLAG2_TRUST_TIME` as the first bit. `flags2` repurposes the previously unused/reserved byte at offset 65 of the `/contacts3` record, so legacy files load as untrusted (the desired default) with no on-disk migration. Seven bits remain for future per-contact toggles.
- **`src/helpers/BaseChatMesh.{h,cpp}`** — new virtual `getClockSkewThreshold()` (default `0` = disabled) and the correction block in `onAdvertRecv`, placed right after the existing replay check. Steps the clock in either direction.
- **`examples/companion_radio/NodePrefs.h`** — added `uint16_t clock_skew_threshold`, default 300 s. Appended to `/new_prefs`; legacy reads short-return and the constructor's default carries through.
- **`examples/companion_radio/MyMesh.{h,cpp}`** — overrode `getClockSkewThreshold()` and added CLI Rescue verbs:
  - `trust time <name|hex-pubkey-prefix>`
  - `untrust time <name|hex-pubkey-prefix>`
  - `trust list`
  - `set clock.skew.threshold <secs>` (`0` disables)

Opt-in: no contacts are trusted by default, so behaviour is unchanged until an operator explicitly marks one.

## Out of scope (follow-up PRs)

- **Repeater receive-side trust.** `simple_repeater` extends `mesh::Mesh` directly (not `BaseChatMesh`) and uses `ClientACL` rather than a contacts list, so it would need a small parallel trust list.
- **Mobile-app exposure.** A binary frame command and companion-app UI to flip the trust bit per contact, plus surfacing "last applied correction" as suggested at the end of #2416.
- **Sender-side advert source-type metadata** (`(source_type, accuracy_class)` bits in `feat1`/`feat2`) — lets receivers prefer certain source types and is the natural next step.
- **Median-of-N and cold-boot heuristics.** Today a single trusted source steps the clock immediately; buffering multiple corrections and taking the median, plus relaxing strict monotonicity when the local clock is obviously absurd (#1332), compose cleanly with this PR.

Refs #2416. Related: #1329, #1332, #1426, #2150, #440.

## Test plan

- [ ] test on Xiao_nrf52_repeater
- [ ] test on heltec_v4_repeater
- [ ] **Functional**: on a companion handheld, `set clock.skew.threshold 60` via CLI Rescue, mark a known-good repeater with `trust time <name>`, manually skew the local clock, observe correction on next advert from that contact.
- [ ] **No-regression**: adverts from non-trusted contacts continue to be replay-checked but never alter the local clock.
- [ ] **Persistence**: trust bit and threshold survive a reboot; legacy `/contacts3` and `/new_prefs` files load without migration.