### PR TITLE
variants: USB Companion variant for LilyGo T-Echo Lite

### DIFF
--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -190,3 +190,24 @@ lib_deps =
 extends = LilyGo_T-Echo-Lite
 build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
   +<../examples/kiss_modem/>
+[env:LilyGo_T-Echo-Lite_companion_radio_usb]
+extends = LilyGo_T-Echo-Lite
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D UI_RECENT_LIST_SIZE=9
+  -D UI_SENSORS_PAGE=1
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+;  -D QSPIFLASH=1
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${LilyGo_T-Echo-Lite.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -98,6 +98,32 @@ lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:LilyGo_T-Echo-Lite_kiss_modem]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/kiss_modem/>
+[env:LilyGo_T-Echo-Lite_companion_radio_usb]
+extends = LilyGo_T-Echo-Lite
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D UI_RECENT_LIST_SIZE=9
+  -D UI_SENSORS_PAGE=1
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+;  -D QSPIFLASH=1
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${LilyGo_T-Echo-Lite.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:LilyGo_T-Echo-Lite_non_shell_companion_radio_ble]
 extends = LilyGo_T-Echo-Lite
 upload_protocol = nrfutil
@@ -182,32 +208,6 @@ build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../variants/lilygo_techo_lite>
   +<../examples/companion_radio/*.cpp>
-lib_deps =
-  ${LilyGo_T-Echo-Lite.lib_deps}
-  densaugeo/base64 @ ~1.4.0
-
-[env:LilyGo_T-Echo-Lite_kiss_modem]
-extends = LilyGo_T-Echo-Lite
-build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
-  +<../examples/kiss_modem/>
-[env:LilyGo_T-Echo-Lite_companion_radio_usb]
-extends = LilyGo_T-Echo-Lite
-board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
-board_upload.maximum_size = 712704
-build_flags =
-  ${LilyGo_T-Echo-Lite.build_flags}
-  -I src/helpers/ui
-  -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=350
-  -D MAX_GROUP_CHANNELS=40
-  -D OFFLINE_QUEUE_SIZE=256
-  -D UI_RECENT_LIST_SIZE=9
-  -D UI_SENSORS_PAGE=1
-  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
-;  -D QSPIFLASH=1
-build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
-  +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
This PR adds support for the LilyGo T-Echo Lite to be used as a USB companion.

The LilyGo T-Echo and T-Echo Lite are largely identical boards, but while the T-Echo can be used as a USB Companion, the Lite does not have this variant.

I tested the new variant on my device: LoRa, GPS, contacts, channels and DMs work as expected with the MeshCore web app.

Assuming we didn't miss anything, we (@0xC0FE and me) see no reason not to add a USB Companion variant.

Please let us know if there is anything wrong or missing - we are new to contributing to MeshCore.