### PR TITLE
Do not perform redundant reset on ST7789 displays

### DIFF
--- a/src/helpers/ui/ST7789LCDDisplay.cpp
+++ b/src/helpers/ui/ST7789LCDDisplay.cpp
@@ -27,12 +27,6 @@ bool ST7789LCDDisplay::begin() {
       pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
       digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
     }
-    if (PIN_TFT_RST != -1) {
-      pinMode(PIN_TFT_RST, OUTPUT);
-      digitalWrite(PIN_TFT_RST, LOW); 
-      delay(10);
-      digitalWrite(PIN_TFT_RST, HIGH);
-    }
 
     // Im not sure if this is just a t-deck problem or not, if your display is slow try this.
     #if defined(LILYGO_TDECK) || defined(HELTEC_LORA_V4_TFT)


### PR DESCRIPTION
The `::init` method in the Adafruit ST7789 library is responsible to initialize the device. This includes performing a reset, which can be found in the Adafruit source for `Adafruit_SPITFT`.

Before this change, MeshCore performed its own ST7789 display reset sequence, which consisted of three steps.

* Pull reset low
* Wait 10ms
* Pull reset high

Importantly, there was no fixed delay after pulling reset high. The ST7789 driver requires a delay (T<sub>RT</sub>) of 5ms in Sleep In Mode and 120ms in Sleep Out Mode before it will properly receive commands. When `Adafruit_SPITFT` resets the device after MeshCore has already reset it, the mandatory time may not have elapsed, leading to strange behavior. In the author's case, this issue caused the initial `fillScreen` to fail, such that the display showed an uninitialized framebuffer.

This removes the MeshCore delay, leaving the responsibility of reset to `Adafruit_SPITFT`, where they have the correct delays in place with extra safety margin. The change was briefly tested by Josiah VanderZee and Ben Zignego on a custom hardware build using an nRF52840 Dongle and an Adafruit 4311 TFT display. The user button seemed to behave strangely, but the display looked correct.