### PR TITLE
Implement WiFi auto-reconnect functionality

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -195,6 +195,15 @@ void setup() {
 
 #ifdef WIFI_SSID
   board.setInhibitSleep(true);   // prevent sleep when WiFi is active
+  // Enable ESP-IDF auto-reconnect
+  WiFi.setAutoReconnect(true);
+  // Attach an event handler to force a reconnect specifically on disconnect events
+  WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info){
+      #ifdef WIFI_DEBUG_LOGGING
+      Serial.println("WiFi disconnected. Forcing reconnect...");
+      #endif
+      WiFi.reconnect();
+  }, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   WiFi.begin(WIFI_SSID, WIFI_PWD);
   serial_interface.begin(TCP_PORT);
 #elif defined(BLE_PIN_CODE)


### PR DESCRIPTION
Added auto-reconnect feature for WiFi and event handler for disconnection. Tested on Xiao-S3 board, it reconnects properly after router reboot.