### PR TITLE
Enhance KissModem frame processing and timeout handling

### DIFF
--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -129,6 +129,9 @@ void KissModem::processFrame() {
         memcpy(_pending_tx, data, data_len);
         _pending_tx_len = data_len;
         _has_pending_tx = true;
+      } else if (_has_pending_tx) {
+        uint8_t result = 0x00;
+        writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
       }
       break;
 
@@ -257,6 +260,7 @@ void KissModem::processTx() {
           _tx_timer = millis();
           _tx_state = TX_DELAY;
         } else {
+          _tx_timer = millis();
           _tx_state = TX_WAIT_CLEAR;
         }
       }
@@ -273,19 +277,28 @@ void KissModem::processTx() {
           _tx_timer = millis();
           _tx_state = TX_SLOT_WAIT;
         }
+      } else if (millis() - _tx_timer >= _radio.getEstAirtimeFor(KISS_MAX_PACKET_SIZE) * KISS_TX_TIMEOUT_FACTOR) {
+        _tx_timer = millis();
+        _tx_state = TX_DELAY;
       }
       break;
 
     case TX_SLOT_WAIT:
       if (millis() - _tx_timer >= (uint32_t)_slottime * 10) {
+        _tx_timer = millis();
         _tx_state = TX_WAIT_CLEAR;
       }
       break;
 
     case TX_DELAY:
       if (millis() - _tx_timer >= (uint32_t)_txdelay * 10) {
-        _radio.startSendRaw(_pending_tx, _pending_tx_len);
-        _tx_state = TX_SENDING;
+        if (_radio.startSendRaw(_pending_tx, _pending_tx_len)) {
+          _tx_timer = millis();
+          _tx_state = TX_SENDING;
+        } else {
+          _has_pending_tx = false;
+          _tx_state = TX_IDLE;
+        }
       }
       break;
 
@@ -293,6 +306,12 @@ void KissModem::processTx() {
       if (_radio.isSendComplete()) {
         _radio.onSendFinished();
         uint8_t result = 0x01;
+        writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
+        _has_pending_tx = false;
+        _tx_state = TX_IDLE;
+      } else if (millis() - _tx_timer >= _radio.getEstAirtimeFor(_pending_tx_len) * KISS_TX_TIMEOUT_FACTOR) {
+        _radio.onSendFinished();
+        uint8_t result = 0x00;
         writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
         _has_pending_tx = false;
         _tx_state = TX_IDLE;

--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -130,8 +130,7 @@ void KissModem::processFrame() {
         _pending_tx_len = data_len;
         _has_pending_tx = true;
       } else if (_has_pending_tx) {
-        uint8_t result = 0x00;
-        writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
+        writeHardwareError(HW_ERR_TX_BUSY);
       }
       break;
 
@@ -296,6 +295,8 @@ void KissModem::processTx() {
           _tx_timer = millis();
           _tx_state = TX_SENDING;
         } else {
+          uint8_t result = 0x00;
+          writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
           _has_pending_tx = false;
           _tx_state = TX_IDLE;
         }

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -26,6 +26,7 @@
 #define KISS_DEFAULT_TXDELAY     50
 #define KISS_DEFAULT_PERSISTENCE 63
 #define KISS_DEFAULT_SLOTTIME    10
+#define KISS_TX_TIMEOUT_FACTOR   3/2   // 1.5x estimated airtime
 
 #define HW_CMD_GET_IDENTITY      0x01
 #define HW_CMD_GET_RANDOM        0x02

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -72,6 +72,7 @@
 #define HW_ERR_MAC_FAILED        0x04
 #define HW_ERR_UNKNOWN_CMD       0x05
 #define HW_ERR_ENCRYPT_FAILED    0x06
+#define HW_ERR_TX_BUSY           0x07
 
 #define KISS_FIRMWARE_VERSION 1
 


### PR DESCRIPTION
Fixes several bugs in the KISS modem TX state machine that could cause the modem to permanently stop sending packets over serial.
## Problem
The KISS modem TX state machine had multiple paths that could lock up permanently, requiring a device reboot:
1. **`TX_SENDING` stuck forever** — If `isSendComplete()` never returns true (missed radio interrupt, SPI glitch), the state machine stays in `TX_SENDING` indefinitely. No more packets can be sent or queued.
2. **`startSendRaw()` return value ignored** — If the radio fails to start transmitting, the modem enters `TX_SENDING` waiting for a completion that never started.
3. **`TX_WAIT_CLEAR` stuck forever** — If the radio gets stuck detecting a phantom carrier, `isReceiving()` returns true indefinitely and the state machine never progresses.
4. **Silent packet drops** — When a DATA frame arrives while a TX is already pending, it's silently discarded with no feedback to the host application, which may hang waiting for a TX completion that will never come.
## Changes
- **Dynamic TX timeout** — Added a timeout to `TX_SENDING` using `getEstAirtimeFor() * 1.5`, matching the approach used by the Dispatcher in companion/repeater firmware. Adapts automatically to radio configuration instead of using a fixed 10s constant.
- **`startSendRaw()` error handling** — Check return value; on failure, drop the packet and return to `TX_IDLE` instead of entering a dead state.
- **`TX_WAIT_CLEAR` timeout** — If the channel stays busy longer than the worst-case max packet airtime × 1.5, force-proceed to `TX_DELAY`.
- **`TX_SLOT_WAIT` timer reset** — Reset `_tx_timer` when cycling back to `TX_WAIT_CLEAR` so the channel-busy timeout measures time in that state, not cumulative time since the TX was queued.
- **TX-busy rejection** — When a DATA frame is received while a TX is already pending, respond with `HW_RESP_TX_DONE` (result=0x00) so the host knows the packet was rejected.
- **TX failure notification** — On TX timeout, notify the host with `HW_RESP_TX_DONE` (result=0x00) instead of silently dropping.
## Testing
These are all state machine edge cases triggered by radio hardware faults (missed interrupts, stuck carrier detect). Verified by code review against the Dispatcher's equivalent timeout handling in `src/Dispatcher.cpp`.