### PR TITLE
Refactor WiFi auto-reconnect to use non-blocking polling

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -105,6 +105,12 @@ void halt() {
   while (1) ;
 }
 
+/* WIFI RECONNECT TRACKERS */
+#if defined(ESP32) && defined(WIFI_SSID)
+  bool wifi_needs_reconnect = false;
+  unsigned long last_wifi_reconnect_attempt = 0;
+#endif
+
 void setup() {
   Serial.begin(115200);
 
@@ -195,6 +201,18 @@ void setup() {
 
 #ifdef WIFI_SSID
   board.setInhibitSleep(true);   // prevent sleep when WiFi is active
+  WiFi.setAutoReconnect(true);
+
+  WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info){
+      if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED) {
+          WIFI_DEBUG_PRINTLN("WiFi disconnected. Flagging for reconnect...");
+          wifi_needs_reconnect = true;
+      } else if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
+          WIFI_DEBUG_PRINTLN("WiFi connected successfully!");
+          wifi_needs_reconnect = false;
+      }
+  });
+
   WiFi.begin(WIFI_SSID, WIFI_PWD);
   serial_interface.begin(TCP_PORT);
 #elif defined(BLE_PIN_CODE)
@@ -229,4 +247,14 @@ void loop() {
   ui_task.loop();
 #endif
   rtc_clock.tick();
+
+#if defined(ESP32) && defined(WIFI_SSID)
+  // Safely attempt to reconnect every 10 seconds if flagged
+  if (wifi_needs_reconnect && (millis() - last_wifi_reconnect_attempt > 10000)) {
+      WIFI_DEBUG_PRINTLN("Attempting manual WiFi reconnect...");
+      WiFi.disconnect();
+      WiFi.reconnect();
+      last_wifi_reconnect_attempt = millis();
+  }
+#endif
 }


### PR DESCRIPTION
Another approach to the issue:

While WiFi.setAutoReconnect(true) is the default, testing on physical hardware showed that if a router takes more than a minute to reboot, the ESP-IDF natively gives up and stays offline permanently.

I initially tried adding WiFi.reconnect() inside the onEvent handler to force it, but discovered that running blocking network commands inside the asynchronous event thread causes a recursive loop that crashes the device.

This PR implements fix for the underlying issue safely: the event handler now instantly exits after flipping a wifi_needs_reconnect flag, and the main loop() safely polls this flag, using a 10-second millis() timer to attempt reconnections without ever freezing the mesh or display tasks. Tested successfully on a physical Xiao S3, using mobile hotspot as a interrupting AP. MCU reconnected without issue after 1, 2, 5 and 15 minutes.