### PR TITLE
Add missing Wire.h include to sensors

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -1,5 +1,7 @@
 #include "EnvironmentSensorManager.h"
 
+#include <Wire.h>
+
 #if ENV_PIN_SDA && ENV_PIN_SCL
 #define TELEM_WIRE &Wire1  // Use Wire1 as the I2C bus for Environment Sensors
 #else


### PR DESCRIPTION
This slipped through in PR #2327 and I noticed because the TechoBoard.h for my variant doesn't include the Wire header, so the source file in question does not coincidentally obtain a copy.