### PR TITLE
Add sanity check for DS3231 RTC probe

### DIFF
--- a/src/helpers/AutoDiscoverRTCClock.cpp
+++ b/src/helpers/AutoDiscoverRTCClock.cpp
@@ -29,6 +29,16 @@ bool AutoDiscoverRTCClock::i2c_probe(TwoWire& wire, uint8_t addr) {
 void AutoDiscoverRTCClock::begin(TwoWire& wire) {
   if (i2c_probe(wire, DS3231_ADDRESS)) {
     ds3231_success = rtc_3231.begin(&wire);
+        if (ds3231_success) {
+        DateTime now = rtc_3231.now();
+        // sanity check to avoid misidentifying other devices at 0x68 as RTC (like the IMU20948)
+        // values will be nonsensical (minutes > 59, hours > 23, etc.)
+        if (now.month() == 0 || now.month() > 12 ||
+            now.day() == 0   || now.day() > 31 ||
+            now.hour() > 23  || now.minute() > 59) {
+            ds3231_success = false;  // not a real DS3231
+            }
+        }
   }
 
   if (i2c_probe(wire, RV3028_ADDRESS)) {


### PR DESCRIPTION
This PR adds a sanity check after probing for DS3231 RTC on the I2C bus.

Some unrelated devices (such as the IMU20948) respond on the same I2C address as DS3231. This can cause AutodiscoverRTCClock to incorrectly identify a non-RTC device as a DS3231, resulting in a non-functioning clock.

The sanity check just makes sure that the data that is coming back is at least plausible.