### PR TITLE
xiao_nrf52: move Wire to NFC pins to unblock BLE pairing

### DIFF
--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -26,8 +26,11 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-  -D PIN_WIRE_SCL=D6
-  -D PIN_WIRE_SDA=D7
+  ; D6/D7 are also defined as PIN_SERIAL1_TX/RX in variant.h. Muxing Wire
+  ; there causes BLE/USB instability after init on the Wio-SX1262 for XIAO
+  ; baseboard. Use the NFC pads (P0.30 NFC1, P0.31 NFC2) instead.
+  -D PIN_WIRE_SDA=30
+  -D PIN_WIRE_SCL=31
   -D PIN_USER_BTN=PIN_BUTTON1
   -D DISPLAY_CLASS=NullDisplayDriver
 build_src_filter = ${nrf52_base.build_src_filter}


### PR DESCRIPTION
## Problem

On `Xiao_nrf52*` envs, `PIN_WIRE_SDA=D7` / `PIN_WIRE_SCL=D6` collide with `PIN_SERIAL1_RX/TX` defined in [variants/xiao_nrf52/variant.h](variants/xiao_nrf52/variant.h):

```c
#define PIN_SERIAL1_RX  (7)
#define PIN_SERIAL1_TX  (6)
```

With `Wire` muxed onto the same pads, the BLE companion advertises briefly after boot and then stops. The MeshCore Android app intermittently fails to pair, and Serial output is unreliable.

## Fix

Move Wire to the NFC pads (P0.30 NFC1, P0.31 NFC2). The Adafruit BSP exposes them as Arduino pins 30/31 and they aren't claimed by another peripheral on this board. Same approach Meshtastic uses for the same baseboard (their `seeed_xiao_nrf52840_kit/variant.h`).

## Diff

+5/-2 in `variants/xiao_nrf52/platformio.ini`. No code changes.

## Tested

- Hardware: XIAO nRF52840 Sense + Wio-SX1262 for XIAO Kit
- Confirmed: BLE advertises stably, MeshCore Android app pairs and stays connected
- Tested on `dev` (current `meshcore-dev/Adafruit_nRF52_Arduino` fork) and on `main` with the stock `framework-arduinoadafruitnrf52@1.10700.0` — both work
