### PR TITLE
feat(techo-lite): add USB companion radio target for non-shell variant

### DIFF
--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -141,6 +141,49 @@ lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:LilyGo_T-Echo-Lite_non_shell_companion_radio_usb]
+extends = LilyGo_T-Echo-Lite
+upload_protocol = nrfutil
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${nrf52_base.build_flags}
+  -I variants/lilygo_techo_lite
+  -I src/helpers/nrf52
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D LILYGO_TECHO
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_POWER_EN=30
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D P_LORA_TX_LED=LED_GREEN
+  -D DISABLE_DIAGNOSTIC_OUTPUT
+  -D ENV_INCLUDE_GPS=1
+  -D GPS_BAUD_RATE=9600
+  -D PIN_GPS_EN=GPS_EN
+  -D AUTO_OFF_MILLIS=0
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D UI_RECENT_LIST_SIZE=9
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<helpers/*.cpp>
+  +<TechoBoard.cpp>
+  +<helpers/sensors/EnvironmentSensorManager.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../variants/lilygo_techo_lite>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_T-Echo-Lite.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:LilyGo_T-Echo-Lite_kiss_modem]
 extends = LilyGo_T-Echo-Lite
 build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}


### PR DESCRIPTION
Adds \`LilyGo_T-Echo-Lite_non_shell_companion_radio_usb\` to
\`variants/lilygo_techo_lite/platformio.ini\`.

The T-Echo Lite non-shell variant had a BLE companion radio target
but no USB equivalent. This adds the missing USB target, mirroring
the BLE/USB symmetry seen in other nRF52840 devices (RAK4631, Xiao,
T114).

The USB target is identical to the BLE target except:
- \`SerialBLEInterface.cpp\` removed
- \`BLE_PIN_CODE=123456\` removed  
- \`OFFLINE_QUEUE_SIZE=256\` removed

Build verified: RAM 40.3% / Flash 51.8%
Hardware tested: T-Echo Lite Non-Shell (nRF52840 + SX1262)
Tested with: Android MeshCore app via USB

Note: This PR adds the non-shell (no display) variant, complementing
PR #2472 which adds the standard T-Echo Lite USB target.