### PR TITLE
Clock towers + pio testing support

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,32 @@
+name: Host Tests
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'test/**'
+      - 'platformio.ini'
+      - '.github/workflows/host-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'test/**'
+      - 'platformio.ini'
+      - '.github/workflows/host-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Build Environment
+        uses: ./.github/actions/setup-build-environment
+
+      - name: Run host tests
+        run: pio test -e native

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+# Convenience targets. Firmware builds use PlatformIO directly: `pio run -e <env>`.
+
+.PHONY: test
+test:
+	pio test -e native

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -60,6 +60,129 @@
 
 #define LAZY_CONTACTS_WRITE_DELAY    5000
 
+// On-disk format owned by TrustedClockTable (serialize/deserialize). MyMesh just maps
+// the file open/read/write idioms required for each platform.
+void MyMesh::loadTrustedClocks() {
+  clock_trust.reset();
+  if (!_fs->exists(TRUSTED_CLOCKS_FILE)) return;
+#if defined(RP2040_PLATFORM)
+  File f = _fs->open(TRUSTED_CLOCKS_FILE, "r");
+#else
+  File f = _fs->open(TRUSTED_CLOCKS_FILE);
+#endif
+  if (!f) return;
+  uint8_t buf[TrustedClockTable::HEADER_SIZE
+              + (size_t)MAX_TRUSTED_CLOCK_KEYS * TrustedClockTable::RECORD_SIZE];
+  int n = f.read(buf, sizeof(buf));
+  f.close();
+  if (n > 0) clock_trust.deserialize(buf, (size_t)n);
+}
+
+void MyMesh::saveTrustedClocks() {
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  _fs->remove(TRUSTED_CLOCKS_FILE);
+  File f = _fs->open(TRUSTED_CLOCKS_FILE, FILE_O_WRITE);
+#elif defined(RP2040_PLATFORM)
+  File f = _fs->open(TRUSTED_CLOCKS_FILE, "w");
+#else
+  File f = _fs->open(TRUSTED_CLOCKS_FILE, "w", true);
+#endif
+  if (!f) return;
+  uint8_t buf[TrustedClockTable::HEADER_SIZE
+              + (size_t)MAX_TRUSTED_CLOCK_KEYS * TrustedClockTable::RECORD_SIZE];
+  size_t n = clock_trust.serialize(buf, sizeof(buf));
+  if (n > 0) f.write(buf, n);
+  f.close();
+}
+
+void MyMesh::formatSyncEventsReply(char* reply, size_t reply_size) {
+  if (reply_size == 0) return;
+  uint8_t n = clock_trust.syncEventCount();
+  if (n == 0) {
+    StrHelper::strncpy(reply, "(none)", reply_size);
+    return;
+  }
+  // Walk newest-first. Per line: <hex16> <name> <±delta>s.
+  reply[0] = 0;
+  size_t used = 0;
+  for (uint8_t k = 0; k < n; k++) {
+    const ClockSyncEvent& ev = clock_trust.syncEventNewestFirst(k);
+    char hex[17];
+    mesh::Utils::toHex(hex, ev.pub_key_prefix, sizeof(ev.pub_key_prefix));
+    hex[16] = 0;
+    int32_t delta = (int32_t)(ev.advert_timestamp - ev.local_before);
+    const char* nm = ev.name[0] ? ev.name : "(no name)";
+    int written = snprintf(reply + used, reply_size - used,
+                           "%s%s %s %+lds", used == 0 ? "" : "\n", hex, nm, (long)delta);
+    if (written < 0 || (size_t)written >= reply_size - used) {
+      reply[reply_size - 1] = 0;
+      break;
+    }
+    used += (size_t)written;
+  }
+}
+
+void MyMesh::formatTrustedClocksReply(char* reply, size_t reply_size) {
+  if (reply_size == 0) return;
+  if (clock_trust.count() == 0) {
+    StrHelper::strncpy(reply, "(none)", reply_size);
+    return;
+  }
+  // Compact listing: <16-hex-prefix> <name> per line. Truncates safely when out of room.
+  reply[0] = 0;
+  size_t used = 0;
+  for (uint8_t i = 0; i < clock_trust.count(); i++) {
+    const TrustedClockSource& s = clock_trust.at(i);
+    char hex[17];
+    mesh::Utils::toHex(hex, s.pub_key, 8);
+    hex[16] = 0;
+    const char* nm = s.name[0] ? s.name : "(no name)";
+    int written = snprintf(reply + used, reply_size - used,
+                           "%s%s %s", used == 0 ? "" : "\n", hex, nm);
+    if (written < 0 || (size_t)written >= reply_size - used) {
+      reply[reply_size - 1] = 0;
+      break;
+    }
+    used += (size_t)written;
+  }
+}
+
+void MyMesh::maybeStepClockFromTrustedAdvert(const mesh::Identity& id, uint32_t advert_timestamp) {
+  TrustedClockSource* src = clock_trust.find(id.pub_key);
+  if (src == NULL) return;
+
+  const char* src_name = src->name[0] ? src->name : "(no name)";
+  char src_hex[17];
+  mesh::Utils::toHex(src_hex, src->pub_key, 8);
+  src_hex[16] = 0;
+
+  // Replay guard: must be strictly newer than what we last accepted from this key.
+  // last_timestamp is RAM-only (resets to 0 on reboot, then re-converges on the next legit advert).
+  if (!TrustedClockTable::passesReplay(advert_timestamp, src->last_timestamp)) {
+    MESH_DEBUG_PRINTLN("trusted-clock: replay/stale advert from %s [%s] (ts=%u <= last=%u), ignoring",
+                       src_name, src_hex, (unsigned)advert_timestamp, (unsigned)src->last_timestamp);
+    return;
+  }
+  src->last_timestamp = advert_timestamp;
+
+  uint32_t now = getRTCClock()->getCurrentTime();
+  uint16_t threshold = _prefs.clock_trust_thresh;
+  if (!TrustedClockTable::shouldStep(now, advert_timestamp, threshold)) {
+    if (threshold != 0) {
+      MESH_DEBUG_PRINTLN("trusted-clock: advert from %s [%s] within threshold (diff=%u < %u), no step",
+                         src_name, src_hex,
+                         (unsigned)TrustedClockTable::absDiff(now, advert_timestamp),
+                         (unsigned)threshold);
+    }
+    return;
+  }
+  uint32_t diff = TrustedClockTable::absDiff(now, advert_timestamp);
+  MESH_DEBUG_PRINTLN("trusted-clock: stepping local clock by %s%u secs from %s [%s]",
+                     advert_timestamp > now ? "+" : "-", (unsigned)diff, src_name, src_hex);
+  clock_trust.recordSyncEvent(src->pub_key, src->name, now, advert_timestamp);
+  getRTCClock()->setCurrentTime(advert_timestamp);
+}
+
 void MyMesh::putNeighbour(const mesh::Identity &id, uint32_t timestamp, float snr) {
 #if MAX_NEIGHBOURS // check if neighbours enabled
   // find existing neighbour, else use least recently updated
@@ -634,6 +757,10 @@ void MyMesh::onAdvertRecv(mesh::Packet *packet, const mesh::Identity &id, uint32
                           const uint8_t *app_data, size_t app_data_len) {
   mesh::Mesh::onAdvertRecv(packet, id, timestamp, app_data, app_data_len); // chain to super impl
 
+  // signature was already verified by caller, so this advert authentically came from id.pub_key.
+  // If this pubkey is on our trusted-clock list, use the timestamp to (maybe) step our local clock.
+  maybeStepClockFromTrustedAdvert(id, timestamp);
+
   // if this a zero hop advert (and not via 'Share'), add it to neighbours
   if (packet->path_len == 0 && !isShare(packet)) {
     AdvertDataParser parser(app_data, app_data_len);
@@ -868,6 +995,8 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   memset(neighbours, 0, sizeof(neighbours));
 #endif
 
+  clock_trust.reset();
+
   // defaults
   memset(&_prefs, 0, sizeof(_prefs));
   _prefs.airtime_factor = 1.0;
@@ -903,6 +1032,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.advert_loc_policy = ADVERT_LOC_PREFS;
 
   _prefs.adc_multiplier = 0.0f; // 0.0f means use default board multiplier
+  _prefs.clock_trust_thresh = 60; // step the clock when |advert_ts - local_ts| >= 60s from a trusted source
 
 #if defined(USE_SX1262) || defined(USE_SX1268)
 #ifdef SX126X_RX_BOOSTED_GAIN
@@ -926,6 +1056,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
   acl.load(_fs, self_id);
   // TODO: key_store.begin();
   region_map.load(_fs);
+  loadTrustedClocks();
 
   // establish default-scope
   {
@@ -1242,6 +1373,57 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
       Serial.printf("\n");
     }
     reply[0] = 0;
+  } else if (memcmp(command, "clock.trust ", 12) == 0) {
+    char* sub = command + 12;
+    while (*sub == ' ') sub++;
+    if (memcmp(sub, "list", 4) == 0) {
+      formatTrustedClocksReply(reply, MIN_CLI_REPLY_LEN);
+    } else if (memcmp(sub, "events", 6) == 0) {
+      formatSyncEventsReply(reply, MIN_CLI_REPLY_LEN);
+    } else if (memcmp(sub, "add ", 4) == 0) {
+      char* hex = sub + 4;
+      while (*hex == ' ') hex++;
+      // optional name follows the hex pubkey, separated by a space
+      char* name = strchr(hex, ' ');
+      if (name) {
+        *name++ = 0;
+        while (*name == ' ') name++;
+      }
+      uint8_t pubkey[PUB_KEY_SIZE];
+      if (strlen(hex) == PUB_KEY_SIZE * 2 && mesh::Utils::fromHex(pubkey, PUB_KEY_SIZE, hex)) {
+        if (memcmp(pubkey, self_id.pub_key, PUB_KEY_SIZE) == 0) {
+          strcpy(reply, "Err - cannot trust self");
+        } else if (clock_trust.add(pubkey, name)) {
+          saveTrustedClocks();
+          strcpy(reply, "OK");
+        } else {
+          sprintf(reply, "Err - trusted-clock list full (max %d)", MAX_TRUSTED_CLOCK_KEYS);
+        }
+      } else {
+        strcpy(reply, "Err - bad pubkey (need 64 hex chars)");
+      }
+    } else if (memcmp(sub, "remove ", 7) == 0) {
+      const char* arg = sub + 7;
+      while (*arg == ' ') arg++;
+      uint8_t pubkey[PUB_KEY_SIZE];
+      // accept either a full hex pubkey or a name match
+      bool removed = false;
+      if (strlen(arg) == PUB_KEY_SIZE * 2 && mesh::Utils::fromHex(pubkey, PUB_KEY_SIZE, arg)) {
+        removed = clock_trust.remove(pubkey);
+        strcpy(reply, removed ? "OK" : "Err - not found");
+      } else {
+        TrustedClockSource* by_name = clock_trust.findByName(arg);
+        if (by_name) {
+          removed = clock_trust.remove(by_name->pub_key);
+          strcpy(reply, removed ? "OK" : "Err - not found");
+        } else {
+          strcpy(reply, "Err - not found (use full hex pubkey or name)");
+        }
+      }
+      if (removed) saveTrustedClocks();
+    } else {
+      strcpy(reply, "Err - usage: clock.trust [list|events|add <pubkey> [name]|remove <pubkey-or-name>]");
+    }
   } else if (memcmp(command, "discover.neighbors", 18) == 0) {
     const char* sub = command + 18;
     while (*sub == ' ') sub++;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -34,6 +34,7 @@
 #include <helpers/TxtDataHelpers.h>
 #include <helpers/RegionMap.h>
 #include "RateLimiter.h"
+#include "TrustedClockTable.h"
 
 #ifdef WITH_BRIDGE
 extern AbstractBridge* bridge;
@@ -60,6 +61,12 @@ struct RepeaterStats {
 #ifndef MAX_CLIENTS
   #define MAX_CLIENTS           32
 #endif
+
+#define TRUSTED_CLOCKS_FILE     "/trusted_clocks"
+
+// Minimum CLI reply buffer size that all callers of MyMesh::handleCommand must allocate.
+// Used by format helpers as a conservative bound for snprintf-style writes.
+#define MIN_CLI_REPLY_LEN       160
 
 struct NeighbourInfo {
   mesh::Identity id;
@@ -106,6 +113,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #if MAX_NEIGHBOURS
   NeighbourInfo neighbours[MAX_NEIGHBOURS];
 #endif
+  TrustedClockTable clock_trust;
   CayenneLPP telemetry;
   unsigned long set_radio_at, revert_radio_at;
   float pending_freq;
@@ -120,6 +128,13 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
 #endif
 
   void putNeighbour(const mesh::Identity& id, uint32_t timestamp, float snr);
+
+  void loadTrustedClocks();
+  void saveTrustedClocks();
+  void formatTrustedClocksReply(char* reply, size_t reply_size);
+  void formatSyncEventsReply(char* reply, size_t reply_size);
+  void maybeStepClockFromTrustedAdvert(const mesh::Identity& id, uint32_t advert_timestamp);
+
   uint8_t handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood);
   uint8_t handleAnonRegionsReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);
   uint8_t handleAnonOwnerReq(const mesh::Identity& sender, uint32_t sender_timestamp, const uint8_t* data);

--- a/examples/simple_repeater/TrustedClockTable.cpp
+++ b/examples/simple_repeater/TrustedClockTable.cpp
@@ -1,0 +1,102 @@
+#include "TrustedClockTable.h"
+
+static void copy_name(char* dest, const char* src, size_t cap) {
+  if (cap == 0) return;
+  if (src == NULL) { dest[0] = 0; return; }
+  size_t i = 0;
+  for (; i + 1 < cap && src[i] != 0; i++) dest[i] = src[i];
+  dest[i] = 0;
+}
+
+TrustedClockSource* TrustedClockTable::find(const uint8_t* pub_key) {
+  for (uint8_t i = 0; i < _count; i++) {
+    if (memcmp(_sources[i].pub_key, pub_key, PUB_KEY_SIZE) == 0) return &_sources[i];
+  }
+  return NULL;
+}
+
+TrustedClockSource* TrustedClockTable::findByName(const char* name) {
+  if (name == NULL || name[0] == 0) return NULL;
+  for (uint8_t i = 0; i < _count; i++) {
+    if (strcmp(_sources[i].name, name) == 0) return &_sources[i];
+  }
+  return NULL;
+}
+
+bool TrustedClockTable::add(const uint8_t* pub_key, const char* name) {
+  TrustedClockSource* existing = find(pub_key);
+  if (existing != NULL) {
+    if (name != NULL) copy_name(existing->name, name, sizeof(existing->name));
+    return true;
+  }
+  if (_count >= MAX_TRUSTED_CLOCK_KEYS) return false;
+  TrustedClockSource* slot = &_sources[_count++];
+  memcpy(slot->pub_key, pub_key, PUB_KEY_SIZE);
+  slot->last_timestamp = 0;
+  copy_name(slot->name, name, sizeof(slot->name));
+  return true;
+}
+
+bool TrustedClockTable::remove(const uint8_t* pub_key) {
+  for (uint8_t i = 0; i < _count; i++) {
+    if (memcmp(_sources[i].pub_key, pub_key, PUB_KEY_SIZE) == 0) {
+      for (uint8_t j = i + 1; j < _count; j++) _sources[j - 1] = _sources[j];
+      _count--;
+      memset(&_sources[_count], 0, sizeof(_sources[_count]));
+      return true;
+    }
+  }
+  return false;
+}
+
+const ClockSyncEvent& TrustedClockTable::syncEventNewestFirst(uint8_t idx_from_newest) const {
+  // Caller must ensure idx_from_newest < _num_events
+  int idx = ((int)_next_event_idx - 1 - (int)idx_from_newest + MAX_SYNC_EVENTS) % MAX_SYNC_EVENTS;
+  return _events[idx];
+}
+
+void TrustedClockTable::recordSyncEvent(const uint8_t* pub_key, const char* name,
+                                        uint32_t local_before, uint32_t advert_timestamp) {
+  ClockSyncEvent& slot = _events[_next_event_idx];
+  memcpy(slot.pub_key_prefix, pub_key, sizeof(slot.pub_key_prefix));
+  copy_name(slot.name, name, sizeof(slot.name));
+  slot.local_before = local_before;
+  slot.advert_timestamp = advert_timestamp;
+  _next_event_idx = (_next_event_idx + 1) % MAX_SYNC_EVENTS;
+  if (_num_events < MAX_SYNC_EVENTS) _num_events++;
+}
+
+size_t TrustedClockTable::serialize(uint8_t* buf, size_t cap) const {
+  size_t need = serializedSize();
+  if (cap < need) return 0;
+  buf[0] = FORMAT_VERSION;
+  buf[1] = _count;
+  size_t off = HEADER_SIZE;
+  for (uint8_t i = 0; i < _count; i++) {
+    memcpy(buf + off, _sources[i].pub_key, PUB_KEY_SIZE);
+    off += PUB_KEY_SIZE;
+    memcpy(buf + off, _sources[i].name, TRUSTED_CLOCK_NAME_LEN);
+    off += TRUSTED_CLOCK_NAME_LEN;
+  }
+  return off;
+}
+
+bool TrustedClockTable::deserialize(const uint8_t* buf, size_t len) {
+  _count = 0;
+  if (len < HEADER_SIZE) return false;
+  if (buf[0] != FORMAT_VERSION) return false;
+  uint8_t want = buf[1];
+  if (want > MAX_TRUSTED_CLOCK_KEYS) want = MAX_TRUSTED_CLOCK_KEYS;
+  size_t off = HEADER_SIZE;
+  for (uint8_t i = 0; i < want; i++) {
+    if (off + RECORD_SIZE > len) break;   // truncated; stop
+    memcpy(_sources[i].pub_key, buf + off, PUB_KEY_SIZE);
+    off += PUB_KEY_SIZE;
+    memcpy(_sources[i].name, buf + off, TRUSTED_CLOCK_NAME_LEN);
+    off += TRUSTED_CLOCK_NAME_LEN;
+    _sources[i].name[TRUSTED_CLOCK_NAME_LEN - 1] = 0;
+    _sources[i].last_timestamp = 0;
+    _count++;
+  }
+  return true;
+}

--- a/examples/simple_repeater/TrustedClockTable.h
+++ b/examples/simple_repeater/TrustedClockTable.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifndef PUB_KEY_SIZE
+#define PUB_KEY_SIZE            32
+#endif
+
+#ifndef MAX_TRUSTED_CLOCK_KEYS
+#define MAX_TRUSTED_CLOCK_KEYS  4
+#endif
+
+#define TRUSTED_CLOCK_NAME_LEN  16
+#define MAX_SYNC_EVENTS         2
+
+struct TrustedClockSource {
+  uint8_t  pub_key[PUB_KEY_SIZE];
+  uint32_t last_timestamp;                   // RAM-only replay cursor; resets on reboot
+  char     name[TRUSTED_CLOCK_NAME_LEN];     // "" if unset
+};
+
+struct ClockSyncEvent {
+  uint8_t  pub_key_prefix[8];
+  char     name[TRUSTED_CLOCK_NAME_LEN];
+  uint32_t local_before;
+  uint32_t advert_timestamp;
+};
+
+class TrustedClockTable {
+public:
+  static const uint8_t FORMAT_VERSION = 0x02;
+  static const size_t  RECORD_SIZE    = PUB_KEY_SIZE + TRUSTED_CLOCK_NAME_LEN;
+  static const size_t  HEADER_SIZE    = 2;   // version + count
+
+  TrustedClockTable() { reset(); }
+
+  void reset() {
+    _count = 0;
+    _num_events = 0;
+    _next_event_idx = 0;
+    memset(_sources, 0, sizeof(_sources));
+    memset(_events, 0, sizeof(_events));
+  }
+
+  uint8_t count() const                              { return _count; }
+  bool    isFull() const                             { return _count >= MAX_TRUSTED_CLOCK_KEYS; }
+  const TrustedClockSource& at(uint8_t i) const      { return _sources[i]; }
+  TrustedClockSource&       at(uint8_t i)            { return _sources[i]; }
+
+  TrustedClockSource* find(const uint8_t* pub_key);
+  TrustedClockSource* findByName(const char* name);
+  // Returns true if added or already present (name updated when non-NULL); false if full and key not present.
+  bool add(const uint8_t* pub_key, const char* name);
+  bool remove(const uint8_t* pub_key);
+
+  // Pure predicates (also exposed for unit tests)
+  static bool     passesReplay(uint32_t advert_ts, uint32_t last_ts) { return advert_ts > last_ts; }
+  static uint32_t absDiff(uint32_t a, uint32_t b)                    { return a > b ? a - b : b - a; }
+  static bool     shouldStep(uint32_t now, uint32_t advert_ts, uint16_t threshold) {
+    if (threshold == 0) return false;
+    return absDiff(now, advert_ts) >= threshold;
+  }
+
+  // Sync-event ring (newest-first iteration helper)
+  uint8_t syncEventCount() const { return _num_events; }
+  const ClockSyncEvent& syncEventNewestFirst(uint8_t idx_from_newest) const;
+  void recordSyncEvent(const uint8_t* pub_key, const char* name,
+                       uint32_t local_before, uint32_t advert_timestamp);
+
+  // Pure serialization for the on-disk format. No filesystem dependency.
+  // Format: u8 version, u8 count, then count × {pub_key[32], name[16]}.
+  // serialize() returns bytes written; deserialize() returns true on a valid header.
+  // last_timestamp is intentionally NOT persisted (RAM-only).
+  size_t serializedSize() const { return HEADER_SIZE + (size_t)_count * RECORD_SIZE; }
+  size_t serialize(uint8_t* buf, size_t cap) const;
+  bool   deserialize(const uint8_t* buf, size_t len);
+
+private:
+  TrustedClockSource _sources[MAX_TRUSTED_CLOCK_KEYS];
+  uint8_t            _count;
+  ClockSyncEvent     _events[MAX_SYNC_EVENTS];
+  uint8_t            _num_events;
+  uint8_t            _next_event_idx;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -151,3 +151,18 @@ lib_deps =
   stevemarple/MicroNMEA @ ^2.0.6
   adafruit/Adafruit BME680 Library @ ^2.0.4
   adafruit/Adafruit BMP085 Library @ ^1.2.4
+
+;
+; Host-side unit tests. Run with: pio test -e native (or `make test`).
+; Tests live under test/ following PIO conventions.
+;
+[env:native]
+platform = native
+test_framework = unity
+test_build_src = yes
+build_flags =
+  -std=c++14
+  -Wall
+  -Wextra
+  -I examples/simple_repeater
+build_src_filter = -<*> +<../examples/simple_repeater/TrustedClockTable.cpp>

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -88,7 +88,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.read((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.read((uint8_t *)&_prefs->clock_trust_thresh, sizeof(_prefs->clock_trust_thresh));        // 291
+    // next: 293
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -118,6 +119,7 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
 
     // sanitise settings
     _prefs->rx_boosted_gain = constrain(_prefs->rx_boosted_gain, 0, 1); // boolean
+    _prefs->clock_trust_thresh = constrain(_prefs->clock_trust_thresh, 0, 3600);
 
     file.close();
   }
@@ -179,7 +181,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.write((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.write((uint8_t *)&_prefs->clock_trust_thresh, sizeof(_prefs->clock_trust_thresh));        // 291
+    // next: 293
 
     file.close();
   }
@@ -712,6 +715,15 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     savePrefs();
     strcpy(reply, "OK");
 #endif
+  } else if (memcmp(config, "clock.trust.thresh ", 19) == 0) {
+    int secs = (int)_atoi(&config[19]);
+    if (secs < 0 || secs > 3600) {
+      strcpy(reply, "Error: must be 0-3600 seconds (0 disables)");
+    } else {
+      _prefs->clock_trust_thresh = (uint16_t)secs;
+      savePrefs();
+      strcpy(reply, "OK");
+    }
   } else if (memcmp(config, "adc.multiplier ", 15) == 0) {
     _prefs->adc_multiplier = atof(&config[15]);
     if (_board->setAdcMultiplier(_prefs->adc_multiplier)) {
@@ -852,6 +864,8 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   #else
       strcpy(reply, "ERROR: unsupported");
   #endif
+  } else if (memcmp(config, "clock.trust.thresh", 18) == 0) {
+    sprintf(reply, "> %d", (uint32_t)_prefs->clock_trust_thresh);
   } else if (memcmp(config, "adc.multiplier", 14) == 0) {
     float adc_mult = _board->getAdcMultiplier();
     if (adc_mult == 0.0f) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -61,6 +61,7 @@ struct NodePrefs { // persisted to file
   uint8_t rx_boosted_gain; // power settings
   uint8_t path_hash_mode;   // which path mode to use when sending
   uint8_t loop_detect;
+  uint16_t clock_trust_thresh; // seconds; min |advert_ts - local_ts| diff that triggers a step from a trusted clock source (0 disables)
 };
 
 class CommonCLICallbacks {

--- a/test/test_trusted_clock_table/test_main.cpp
+++ b/test/test_trusted_clock_table/test_main.cpp
@@ -1,0 +1,250 @@
+// Host-side unit tests for TrustedClockTable.
+// Runs under PlatformIO's native env: `pio test -e native` (or `make test`).
+
+#include <unity.h>
+#include <cstdio>
+#include <cstring>
+
+#include "TrustedClockTable.h"
+
+void setUp(void)    {}
+void tearDown(void) {}
+
+static void fill_key(uint8_t* k, uint8_t seed) {
+  for (int i = 0; i < PUB_KEY_SIZE; i++) k[i] = (uint8_t)(seed + i);
+}
+
+static void test_find_add_remove(void) {
+  TrustedClockTable t;
+  uint8_t k1[PUB_KEY_SIZE]; fill_key(k1, 1);
+  uint8_t k2[PUB_KEY_SIZE]; fill_key(k2, 2);
+
+  TEST_ASSERT_EQUAL_UINT8(0, t.count());
+  TEST_ASSERT_NULL(t.find(k1));
+  TEST_ASSERT_NULL(t.findByName("alice"));
+  TEST_ASSERT_NULL(t.findByName(NULL));
+  TEST_ASSERT_NULL(t.findByName(""));
+
+  TEST_ASSERT_TRUE(t.add(k1, "alice"));
+  TEST_ASSERT_EQUAL_UINT8(1, t.count());
+  TrustedClockSource* s1 = t.find(k1);
+  TEST_ASSERT_NOT_NULL(s1);
+  TEST_ASSERT_EQUAL_STRING("alice", s1->name);
+  TEST_ASSERT_EQUAL_UINT32(0, s1->last_timestamp);
+  TEST_ASSERT_EQUAL_PTR(s1, t.findByName("alice"));
+
+  // Re-add same key with new name updates name; count unchanged.
+  TEST_ASSERT_TRUE(t.add(k1, "alice2"));
+  TEST_ASSERT_EQUAL_UINT8(1, t.count());
+  TEST_ASSERT_EQUAL_STRING("alice2", t.find(k1)->name);
+
+  // Re-add same key with NULL name leaves existing name.
+  TEST_ASSERT_TRUE(t.add(k1, NULL));
+  TEST_ASSERT_EQUAL_STRING("alice2", t.find(k1)->name);
+
+  // Add a second key with no name.
+  TEST_ASSERT_TRUE(t.add(k2, NULL));
+  TEST_ASSERT_EQUAL_UINT8(2, t.count());
+  TEST_ASSERT_EQUAL_INT(0, t.find(k2)->name[0]);
+
+  // Remove first.
+  TEST_ASSERT_TRUE(t.remove(k1));
+  TEST_ASSERT_EQUAL_UINT8(1, t.count());
+  TEST_ASSERT_NULL(t.find(k1));
+  TEST_ASSERT_NOT_NULL(t.find(k2));
+
+  // Remove again returns false.
+  TEST_ASSERT_FALSE(t.remove(k1));
+}
+
+static void test_capacity(void) {
+  TrustedClockTable t;
+  uint8_t k[PUB_KEY_SIZE];
+  for (int i = 0; i < MAX_TRUSTED_CLOCK_KEYS; i++) {
+    fill_key(k, (uint8_t)(10 + i));
+    char name[8]; snprintf(name, sizeof(name), "n%d", i);
+    TEST_ASSERT_TRUE(t.add(k, name));
+  }
+  TEST_ASSERT_EQUAL_UINT8(MAX_TRUSTED_CLOCK_KEYS, t.count());
+  TEST_ASSERT_TRUE(t.isFull());
+
+  // One more new key — must fail.
+  fill_key(k, 99);
+  TEST_ASSERT_FALSE(t.add(k, "overflow"));
+  TEST_ASSERT_EQUAL_UINT8(MAX_TRUSTED_CLOCK_KEYS, t.count());
+
+  // Re-adding an existing key is still fine when full.
+  uint8_t existing[PUB_KEY_SIZE]; fill_key(existing, 10);
+  TEST_ASSERT_TRUE(t.add(existing, "renamed"));
+  TEST_ASSERT_EQUAL_STRING("renamed", t.find(existing)->name);
+}
+
+static void test_remove_shifts(void) {
+  TrustedClockTable t;
+  uint8_t k0[PUB_KEY_SIZE]; fill_key(k0, 1);
+  uint8_t k1[PUB_KEY_SIZE]; fill_key(k1, 2);
+  uint8_t k2[PUB_KEY_SIZE]; fill_key(k2, 3);
+  t.add(k0, "a"); t.add(k1, "b"); t.add(k2, "c");
+
+  // Remove middle; remaining order should be a, c.
+  TEST_ASSERT_TRUE(t.remove(k1));
+  TEST_ASSERT_EQUAL_UINT8(2, t.count());
+  TEST_ASSERT_EQUAL_STRING("a", t.at(0).name);
+  TEST_ASSERT_EQUAL_STRING("c", t.at(1).name);
+}
+
+static void test_predicates(void) {
+  // passesReplay: strictly newer.
+  TEST_ASSERT_TRUE (TrustedClockTable::passesReplay(100, 99));
+  TEST_ASSERT_FALSE(TrustedClockTable::passesReplay(100, 100));
+  TEST_ASSERT_FALSE(TrustedClockTable::passesReplay(100, 101));
+  TEST_ASSERT_TRUE (TrustedClockTable::passesReplay(1, 0));
+
+  // absDiff: order-independent.
+  TEST_ASSERT_EQUAL_UINT32(10, TrustedClockTable::absDiff(100, 90));
+  TEST_ASSERT_EQUAL_UINT32(10, TrustedClockTable::absDiff(90, 100));
+  TEST_ASSERT_EQUAL_UINT32(0,  TrustedClockTable::absDiff(7, 7));
+
+  // shouldStep.
+  TEST_ASSERT_FALSE(TrustedClockTable::shouldStep(1000, 1100, 0));    // disabled
+  TEST_ASSERT_FALSE(TrustedClockTable::shouldStep(1000, 1059, 60));   // diff < threshold
+  TEST_ASSERT_TRUE (TrustedClockTable::shouldStep(1000, 1060, 60));   // boundary: >=
+  TEST_ASSERT_TRUE (TrustedClockTable::shouldStep(1000, 940,  60));   // past, boundary
+  TEST_ASSERT_FALSE(TrustedClockTable::shouldStep(1000, 941,  60));   // past, just under
+  TEST_ASSERT_FALSE(TrustedClockTable::shouldStep(1000, 1000, 1));    // exactly equal
+}
+
+static void test_sync_event_ring(void) {
+  TrustedClockTable t;
+  uint8_t k[PUB_KEY_SIZE]; fill_key(k, 5);
+
+  TEST_ASSERT_EQUAL_UINT8(0, t.syncEventCount());
+
+  t.recordSyncEvent(k, "src1", 1000, 1100);
+  TEST_ASSERT_EQUAL_UINT8(1, t.syncEventCount());
+  TEST_ASSERT_EQUAL_UINT32(1100, t.syncEventNewestFirst(0).advert_timestamp);
+  TEST_ASSERT_EQUAL_UINT32(1000, t.syncEventNewestFirst(0).local_before);
+  TEST_ASSERT_EQUAL_STRING("src1", t.syncEventNewestFirst(0).name);
+
+  t.recordSyncEvent(k, "src2", 2000, 2050);
+  TEST_ASSERT_EQUAL_UINT8(2, t.syncEventCount());                       // ring full at MAX_SYNC_EVENTS
+  TEST_ASSERT_EQUAL_UINT32(2050, t.syncEventNewestFirst(0).advert_timestamp);
+  TEST_ASSERT_EQUAL_UINT32(1100, t.syncEventNewestFirst(1).advert_timestamp);
+
+  // Third write evicts the oldest, preserves newest-first order.
+  t.recordSyncEvent(k, "src3", 3000, 3030);
+  TEST_ASSERT_EQUAL_UINT8(MAX_SYNC_EVENTS, t.syncEventCount());
+  TEST_ASSERT_EQUAL_UINT32(3030, t.syncEventNewestFirst(0).advert_timestamp);
+  TEST_ASSERT_EQUAL_UINT32(2050, t.syncEventNewestFirst(1).advert_timestamp);
+}
+
+static void test_serialize_roundtrip(void) {
+  TrustedClockTable a;
+  uint8_t k1[PUB_KEY_SIZE]; fill_key(k1, 1);
+  uint8_t k2[PUB_KEY_SIZE]; fill_key(k2, 2);
+  a.add(k1, "first");
+  a.add(k2, "second");
+
+  uint8_t buf[256];
+  size_t n = a.serialize(buf, sizeof(buf));
+  TEST_ASSERT_EQUAL_size_t(TrustedClockTable::HEADER_SIZE + 2 * TrustedClockTable::RECORD_SIZE, n);
+  TEST_ASSERT_EQUAL_UINT8(TrustedClockTable::FORMAT_VERSION, buf[0]);
+  TEST_ASSERT_EQUAL_UINT8(2, buf[1]);
+
+  TrustedClockTable b;
+  TEST_ASSERT_TRUE(b.deserialize(buf, n));
+  TEST_ASSERT_EQUAL_UINT8(2, b.count());
+  TEST_ASSERT_EQUAL_MEMORY(k1, b.at(0).pub_key, PUB_KEY_SIZE);
+  TEST_ASSERT_EQUAL_MEMORY(k2, b.at(1).pub_key, PUB_KEY_SIZE);
+  TEST_ASSERT_EQUAL_STRING("first",  b.at(0).name);
+  TEST_ASSERT_EQUAL_STRING("second", b.at(1).name);
+  // last_timestamp is intentionally not persisted; both should be 0 after load.
+  TEST_ASSERT_EQUAL_UINT32(0, b.at(0).last_timestamp);
+  TEST_ASSERT_EQUAL_UINT32(0, b.at(1).last_timestamp);
+}
+
+static void test_serialize_too_small_buffer(void) {
+  TrustedClockTable a;
+  uint8_t k[PUB_KEY_SIZE]; fill_key(k, 7);
+  a.add(k, "x");
+  uint8_t tiny[1];
+  TEST_ASSERT_EQUAL_size_t(0, a.serialize(tiny, sizeof(tiny)));   // refuses partial write
+}
+
+static void test_deserialize_bad_version(void) {
+  TrustedClockTable t;
+  uint8_t k[PUB_KEY_SIZE]; fill_key(k, 8);
+  t.add(k, "preexisting");
+
+  uint8_t bad[2] = { 0xFF, 0 };
+  TEST_ASSERT_FALSE(t.deserialize(bad, sizeof(bad)));
+  // deserialize() resets the table even on failure (matches load semantics).
+  TEST_ASSERT_EQUAL_UINT8(0, t.count());
+}
+
+static void test_deserialize_clamps_count(void) {
+  // Buffer claims more entries than MAX_TRUSTED_CLOCK_KEYS; loader must clamp.
+  size_t cap = TrustedClockTable::HEADER_SIZE
+               + (size_t)(MAX_TRUSTED_CLOCK_KEYS + 2) * TrustedClockTable::RECORD_SIZE;
+  uint8_t buf[512];
+  TEST_ASSERT_TRUE(cap <= sizeof(buf));
+  buf[0] = TrustedClockTable::FORMAT_VERSION;
+  buf[1] = MAX_TRUSTED_CLOCK_KEYS + 2;
+  size_t off = TrustedClockTable::HEADER_SIZE;
+  for (int i = 0; i < MAX_TRUSTED_CLOCK_KEYS + 2; i++) {
+    for (int j = 0; j < PUB_KEY_SIZE; j++) buf[off + j] = (uint8_t)(i * 10 + j);
+    off += PUB_KEY_SIZE;
+    char name[TRUSTED_CLOCK_NAME_LEN] = {0};
+    snprintf(name, sizeof(name), "n%d", i);
+    memcpy(buf + off, name, TRUSTED_CLOCK_NAME_LEN);
+    off += TRUSTED_CLOCK_NAME_LEN;
+  }
+
+  TrustedClockTable t;
+  TEST_ASSERT_TRUE(t.deserialize(buf, off));
+  TEST_ASSERT_EQUAL_UINT8(MAX_TRUSTED_CLOCK_KEYS, t.count());
+}
+
+static void test_deserialize_truncated_records(void) {
+  // Header says 3 records but the buffer only holds 1 full record.
+  uint8_t k[PUB_KEY_SIZE]; fill_key(k, 9);
+  uint8_t buf[256];
+  buf[0] = TrustedClockTable::FORMAT_VERSION;
+  buf[1] = 3;
+  memcpy(buf + 2, k, PUB_KEY_SIZE);
+  memset(buf + 2 + PUB_KEY_SIZE, 0, TRUSTED_CLOCK_NAME_LEN);
+  memcpy(buf + 2 + PUB_KEY_SIZE, "trunc", 5);
+  size_t len = TrustedClockTable::HEADER_SIZE + TrustedClockTable::RECORD_SIZE;
+
+  TrustedClockTable t;
+  TEST_ASSERT_TRUE(t.deserialize(buf, len));
+  TEST_ASSERT_EQUAL_UINT8(1, t.count());
+  TEST_ASSERT_EQUAL_STRING("trunc", t.at(0).name);
+}
+
+static void test_name_length_clamping(void) {
+  TrustedClockTable t;
+  uint8_t k[PUB_KEY_SIZE]; fill_key(k, 11);
+  const char* longname = "0123456789ABCDEFG_overflow_extra";
+  TEST_ASSERT_TRUE(t.add(k, longname));
+  const TrustedClockSource& s = t.at(0);
+  TEST_ASSERT_EQUAL_INT(0, s.name[TRUSTED_CLOCK_NAME_LEN - 1]);
+  TEST_ASSERT_TRUE(strlen(s.name) < TRUSTED_CLOCK_NAME_LEN);
+  TEST_ASSERT_EQUAL_MEMORY(longname, s.name, strlen(s.name));
+}
+
+int main(int /*argc*/, char** /*argv*/) {
+  UNITY_BEGIN();
+  RUN_TEST(test_find_add_remove);
+  RUN_TEST(test_capacity);
+  RUN_TEST(test_remove_shifts);
+  RUN_TEST(test_predicates);
+  RUN_TEST(test_sync_event_ring);
+  RUN_TEST(test_serialize_roundtrip);
+  RUN_TEST(test_serialize_too_small_buffer);
+  RUN_TEST(test_deserialize_bad_version);
+  RUN_TEST(test_deserialize_clamps_count);
+  RUN_TEST(test_deserialize_truncated_records);
+  RUN_TEST(test_name_length_clamping);
+  return UNITY_END();
+}


### PR DESCRIPTION
Implement repeater clock trust update (see #2416 "Clock towers").

Adds an opt-in "trusted clock" list of advert pubkeys whose timestamps
may step the local RTC. Replay-guarded (advert_ts must be strictly newer
 than the last accepted from the same key.

Last few sync events are kept in a small RAM ring queryable via the CLI.

Logic lives in TrustedClockTable (no Arduino deps): table ops, replay
predicate, threshold predicate, sync-event ring, and pure
serialize/deserialize. MyMesh holds it as a member and wraps file I/O
around the helper.

CLI under clock.trust:
```
      clock.trust list
      clock.trust events
      clock.trust add <pubkey> [name]
      clock.trust remove <pubkey-or-name>

```
Also adds a new setting `clock.trust.thresh`.


To make reviewing easy I have structured the PR in two parts:

1) The functionality itself
2) Unit tests for the feature + make test + pio test support, which may help adding tests for other parts of the code as we go.



This is an example of the firmware running on a local T114 repeater I have at home:

```
10:54:32 - 15/5/2024 U RAW: 0A41ED97D250BFB5D6C748C653EA62BE1074E131DD97CA7E
10:54:32 - 15/5/2024 U: RX, len=24 (type=2, route=D, payload_len=20) SNR=13 RSSI=-53 score=1000 time=259 hash=C50C189C44122D59 [50 -> D2]
10:54:32 - 15/5/2024 U: TX, len=22 (type=2, route=D, payload_len=20) [50 -> D2]
DEBUG: RadioLibWrapper: noise_floor = -115
10:54:33 - 15/5/2024 U RAW: 0A4050D29F18FB6E5FCAA4B6333CF3E9ABE1982A4731FCA9AF308C06FD298B2EF8415B6077CB
10:54:33 - 15/5/2024 U: RX, len=38 (type=2, route=D, payload_len=36) SNR=10 RSSI=-94 score=1000 time=320 hash=76C4462508AC411C [D2 -> 50]
```

advert from a trusted clock key received (it's another repeater with GPS clock sync):
```
10:54:35 - 15/5/2024 U RAW: 1140D2590AED87376D577891BDC956026E38412BD4E8E7A972D21A2EF47478F26ECB569FFD69FA8D3475A0C2F8CFA2E9B456E1DC1E329F66F122DDF401E4692C259707750057E9EF5E972B99D770A4EF3078967DE781A43041475FAD3BA901B7520F765DDF0D9261946802AA1AC7FF5075657274612064656C20C3816E67656C20F09FA59D
10:54:35 - 15/5/2024 U: RX, len=133 (type=4, route=F, payload_len=131) SNR=11 RSSI=-93 score=1000 time=812 hash=BF74AF4E5683B06D
DEBUG: 10:54:35 - 15/5/2024 U Dispatcher::checkRecv(), score delay below threshold (0)
DEBUG: 10:54:35 - 15/5/2024 U Mesh::onRecvPacket(): valid advertisement received!
```

clock gets updated: 10:54:35 - 15/5/2024 --> 08:31:18 - 8/5/2026
```
DEBUG: trusted-clock: stepping local clock by +62458603 secs from kiwi [D2590AED87376D57]
DEBUG: RadioLibWrapper: noise_floor = -110
08:31:18 - 8/5/2026 U RAW: 1141CEBAD2590AED87376D577891BDC956026E38412BD4E8E7A972D21A2EF47478F26ECB569FFD69FA8D3475A0C2F8CFA2E9B456E1DC1E329F66F122DDF401E4692C259707750057E9EF5E972B99D770A4EF3078967DE781A43041475FAD3BA901B7520F765DDF0D9261946802AA1AC7FF5075657274612064656C20C3816E67656C20F09FA59D
08:31:18 - 8/5/2026 U: RX, len=135 (type=4, route=F, payload_len=131) SNR=-4 RSSI=-114 score=271 time=832 hash=BF74AF4E5683B06D
DEBUG: 08:31:18 - 8/5/2026 U Dispatcher::checkRecv(), score delay below threshold (0)
08:31:19 - 8/5/2026 U: TX, len=135 (type=4, route=F, payload_len=131)
DEBUG: RadioLibWrapper: noise_floor = -115
DEBUG: RadioLibWrapper: noise_floor = -110
DEBUG: RadioLibWrapper: noise_floor = -110
```


<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/6e9d6a1a-66df-4ff0-9d3d-13eb2e459ded" />
