### PR TITLE
Add build flag to configure allowed repeat frequency range

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -982,9 +982,13 @@ struct FreqRange {
 };
 
 static FreqRange repeat_freq_ranges[] = {
+  #ifdef ALLOWED_REPEAT_FREQ_RANGE
+  ALLOWED_REPEAT_FREQ_RANGE
+  #else
   { 433000, 433000 },
   { 869000, 869000 },
   { 918000, 918000 }
+  #endif
 };
 
 bool MyMesh::isValidClientRepeatFreq(uint32_t f) const {


### PR DESCRIPTION
This PR adds a new `ALLOWED_REPEAT_FREQ_RANGE` build flag.

It allows custom firmware to easily configure their own allowed frequency ranges for companion repeat mode without needing to modify any project files.

Example usage:

```
-D ALLOWED_REPEAT_FREQ_RANGE='{ 433000, 434000 }'
```