### PR TITLE
Improve battery monitoring algorithm for promicro

### DIFF
--- a/variants/promicro/PromicroBoard.h
+++ b/variants/promicro/PromicroBoard.h
@@ -23,7 +23,7 @@
 // - use cli to 'set adc.multiplier' (repeaters / rooms)
 
 #ifndef ADC_MULTIPLIER
-#define ADC_MULTIPLIER (1.667f) // Dependent on voltage divider resistors. Default 1MOhm & 1.5MOhm divider
+#define ADC_MULTIPLIER (2.0f) // Dependent on voltage divider resistors. Default 1MOhm resistors
 #endif
 
 class PromicroBoard : public NRF52BoardDCDC {

--- a/variants/promicro/PromicroBoard.h
+++ b/variants/promicro/PromicroBoard.h
@@ -17,8 +17,14 @@
 #define SX126X_DIO2_AS_RF_SWITCH  true
 #define SX126X_DIO3_TCXO_VOLTAGE (1.8f)
 
-#define  PIN_VBAT_READ 17
-#define  ADC_MULTIPLIER   (1.815f) // dependent on voltage divider resistors. TODO: more accurate battery tracking
+// Default values for battery monitoring voltage divider
+// To override, either:
+// - set build flags in variant's platformio.ini file
+// - use cli to 'set adc.multiplier' (repeaters / rooms)
+
+#ifndef ADC_MULTIPLIER
+#define ADC_MULTIPLIER (1.667f) // Dependent on voltage divider resistors. Default 1MOhm & 1.5MOhm divider
+#endif
 
 class PromicroBoard : public NRF52BoardDCDC {
 protected:
@@ -32,14 +38,14 @@ public:
   #define BATTERY_SAMPLES 8
 
   uint16_t getBattMilliVolts() override {
-    analogReadResolution(12);
+    analogReadResolution(ADC_RESOLUTION);
 
     uint32_t raw = 0;
     for (int i = 0; i < BATTERY_SAMPLES; i++) {
       raw += analogRead(PIN_VBAT_READ);
     }
     raw = raw / BATTERY_SAMPLES;
-    return (adc_mult * raw);
+    return (raw * (AREF_VOLTAGE * 1000) * adc_mult / (1 << (ADC_RESOLUTION)));
   }
 
   bool setAdcMultiplier(float multiplier) override {

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -23,7 +23,7 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_BMP280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
-  ; -D ADC_MULTIPLIER=1.667f
+  ; -D ADC_MULTIPLIER=2.0f
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/sensors>
   +<../variants/promicro>

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -23,6 +23,7 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_BMP280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
+  ; -D ADC_MULTIPLIER=1.667f
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/sensors>
   +<../variants/promicro>

--- a/variants/promicro/variant.h
+++ b/variants/promicro/variant.h
@@ -22,8 +22,9 @@
 #define PIN_EXT_VCC          (21)
 #define EXT_VCC              (PIN_EXT_VCC)
 
-#define BATTERY_PIN          (17)
-#define ADC_RESOLUTION       12
+#define PIN_VBAT_READ        (17)
+#define ADC_RESOLUTION       (14)
+#define AREF_VOLTAGE         (3.6f) // Using default analog reference (AR_INTERNAL), which maps ADC reading to 0 ... 3.6V
 
 ////////////////////////////////////////////////////////////////////////////////
 // Number of pins


### PR DESCRIPTION
A few tweaks to get battery monitoring working for the promicro variant:
- modify equation in `Promicroboard::getBattMilliVolts`
- correct `AREF_VOLTAGE`, lower `ADC_MULTIPLIER` accordingly
- raise `ADC_RESOLUTION`