### PR TITLE
Add support for Station G3 and its software configurable LNA/PA1

### DIFF
--- a/boards/station-g3-esp32.json
+++ b/boards/station-g3-esp32.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Station G3 ESP32",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://wiki.bqvoy.com/en/devkits/station-g3",
+  "vendor": "BQ Consulting"
+}

--- a/variants/station_g3_esp32/StationG3Board.h
+++ b/variants/station_g3_esp32/StationG3Board.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+#include <driver/rtc_io.h>
+
+#ifndef P_PRIMARY_LNA_EN_ACTIVE
+#define P_PRIMARY_LNA_EN_ACTIVE LOW
+#endif
+
+#ifndef P_PA1_EN_ACTIVE
+#define P_PA1_EN_ACTIVE HIGH
+#endif
+
+class StationG3Board : public ESP32Board {
+  void setPAModeHigh(bool enabled) {
+#ifdef P_PA1_EN
+    // Station G3 PA PL1 mode: LOW/open is PA low, HIGH/short is PA high.
+    digitalWrite(P_PA1_EN, enabled ? P_PA1_EN_ACTIVE : !P_PA1_EN_ACTIVE);
+#endif
+  }
+
+  void setPrimaryLNAControl(bool enabled) {
+#ifdef P_PRIMARY_LNA_EN
+    // Station G3 primary LNA mode is active-low: LOW/open is LNA on, HIGH/short is LNA off.
+    digitalWrite(P_PRIMARY_LNA_EN, enabled ? P_PRIMARY_LNA_EN_ACTIVE : !P_PRIMARY_LNA_EN_ACTIVE);
+#endif
+  }
+
+public:
+  void begin() {
+    ESP32Board::begin();
+
+#ifdef P_PA1_EN
+    rtc_gpio_hold_dis((gpio_num_t)P_PA1_EN);
+    pinMode(P_PA1_EN, OUTPUT);
+    setPAModeHigh(false);
+#endif
+
+#ifdef P_PRIMARY_LNA_EN
+    rtc_gpio_hold_dis((gpio_num_t)P_PRIMARY_LNA_EN);
+    pinMode(P_PRIMARY_LNA_EN, OUTPUT);
+    setPrimaryLNAControl(true);
+#endif
+
+    esp_reset_reason_t reason = esp_reset_reason();
+    if (reason == ESP_RST_DEEPSLEEP) {
+      uint64_t wakeup_source = esp_sleep_get_ext1_wakeup_status();
+      if (wakeup_source & (1ULL << P_LORA_DIO_1)) {
+        startup_reason = BD_STARTUP_RX_PACKET;
+      }
+
+      rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
+      rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
+    }
+  }
+
+  void setPrimaryLNAEnable(bool enabled) {
+    setPrimaryLNAControl(enabled);
+  }
+
+  void setPrimaryPAHighPower(bool enabled) {
+    setPAModeHigh(enabled);
+  }
+
+  void onBeforeTransmit() override {
+    ESP32Board::onBeforeTransmit();
+    setPrimaryLNAControl(false);
+  }
+
+  void onAfterTransmit() override {
+    ESP32Board::onAfterTransmit();
+    setPrimaryLNAControl(true);
+  }
+
+  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
+    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
+
+    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
+
+#ifdef P_PA1_EN
+    setPAModeHigh(false);
+    rtc_gpio_hold_en((gpio_num_t)P_PA1_EN);
+#endif
+
+#ifdef P_PRIMARY_LNA_EN
+    setPrimaryLNAControl(true);
+    rtc_gpio_hold_en((gpio_num_t)P_PRIMARY_LNA_EN);
+#endif
+
+    if (pin_wake_btn < 0) {
+      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);
+    } else {
+      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1) | (1ULL << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);
+    }
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup(secs * 1000000);
+    }
+
+    esp_deep_sleep_start();
+  }
+
+  uint16_t getBattMilliVolts() override {
+    return 0;
+  }
+
+  const char* getManufacturerName() const override {
+    return "Station G3 ESP32";
+  }
+};

--- a/variants/station_g3_esp32/platformio.ini
+++ b/variants/station_g3_esp32/platformio.ini
@@ -1,0 +1,160 @@
+[Station_G3_ESP32]
+extends = esp32_base
+board = station-g3-esp32
+build_flags =
+  ${esp32_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/station_g3_esp32
+  -I src/helpers/ui
+  -D STATION_G3_ESP32
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D P_LORA_DIO_1=48
+  -D P_LORA_NSS=11
+  -D P_LORA_RESET=21
+  -D P_LORA_BUSY=47
+  -D P_LORA_SCLK=12
+  -D P_LORA_MISO=14
+  -D P_LORA_MOSI=13
+  -D P_PA1_EN=9 ; PA PL1 Mode: LOW/open is PA low, HIGH/short is PA high.
+  -D P_PA1_EN_ACTIVE=HIGH
+  -D P_PRIMARY_LNA_EN=10 ; Primary Slot LNA Mode: LOW/open is LNA on, HIGH/short is LNA off.
+  -D P_PRIMARY_LNA_EN_ACTIVE=LOW
+  -D LORA_TX_POWER=7 ; configured as 7dbm, because the final output will be ~27dbm (~0.5w) if the PA is enabled.
+  -D MAX_LORA_TX_POWER=22
+;  -D P_LORA_TX_LED=35
+  -D PIN_BOARD_SDA=5
+  -D PIN_BOARD_SCL=6
+  -D PIN_USER_BTN=38
+  -D PIN_GPS_RX=15
+  -D PIN_GPS_TX=7
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=0
+  -D DISPLAY_CLASS=SH1106Display
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/station_g3_esp32>
+  +<helpers/sensors>
+  +<helpers/ui/SH1106Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+lib_deps =
+  ${esp32_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit SH110X @ ~2.1.13
+  adafruit/Adafruit GFX Library @ ^1.12.1
+
+[env:Station_G3_ESP32_repeater]
+extends = Station_G3_ESP32
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Station_G3_ESP32_logging_repeater]
+extends = Station_G3_ESP32
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Logging Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Station_G3_ESP32_room_server]
+extends = Station_G3_ESP32
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -D ADVERT_NAME='"Station G3 ESP32 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Station_G3_ESP32_companion_radio_usb]
+extends = Station_G3_ESP32
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Station_G3_ESP32_companion_radio_ble]
+extends = Station_G3_ESP32
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Station_G3_ESP32_companion_radio_wifi]
+extends = Station_G3_ESP32
+build_flags =
+  ${Station_G3_ESP32.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256
+; -D MESH_PACKET_LOGGING=1
+; -D MESH_DEBUG=1
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Station_G3_ESP32.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Station_G3_ESP32_kiss_modem]
+extends = Station_G3_ESP32
+build_src_filter = ${Station_G3_ESP32.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/station_g3_esp32/target.cpp
+++ b/variants/station_g3_esp32/target.cpp
@@ -1,0 +1,46 @@
+#include <Arduino.h>
+#include "target.h"
+
+StationG3Board board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi;
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/station_g3_esp32/target.h
+++ b/variants/station_g3_esp32/target.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <StationG3Board.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/SH1106Display.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+
+extern StationG3Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
Adds support for the Station G3 ESP32 module. 

The LNA is enabled via the platformio build flag `-D P_PRIMARY_LNA_EN=10`.
The PA1 is enabled via the platformio build flag `-D P_PA1_EN=9`

For the sake of transparency, I used Codex to create this variant. I personally reviewed this code and verified on real hardware.