### PR TITLE
Add option to disable DS3231 RTC probe

### DIFF
--- a/src/helpers/AutoDiscoverRTCClock.cpp
+++ b/src/helpers/AutoDiscoverRTCClock.cpp
@@ -27,9 +27,11 @@ bool AutoDiscoverRTCClock::i2c_probe(TwoWire& wire, uint8_t addr) {
 }
 
 void AutoDiscoverRTCClock::begin(TwoWire& wire) {
+  #if !defined(DISABLE_DS3231_PROBE)
   if (i2c_probe(wire, DS3231_ADDRESS)) {
     ds3231_success = rtc_3231.begin(&wire);
   }
+  #endif
 
   if (i2c_probe(wire, RV3028_ADDRESS)) {
     rtc_rv3028.initI2C(wire);


### PR DESCRIPTION
This PR adds the option ``DISABLE_DS3231_PROBE`` to disable probing for DS3231 on boards which have a different device (like ICM20948) living at I2C address 0x68.

This was causing a broken clock on LilyGo T-Echo Card, due to the ICM20948 being detected as a DS3231 RTC.

Supercedes #2498