### PR TITLE
pin CustomLFS to version 0.2.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -92,7 +92,7 @@ build_flags = ${arduino_base.build_flags}
   -D EXTRAFS=1
 lib_deps =
   ${arduino_base.lib_deps}
-  https://github.com/oltaco/CustomLFS#0.2.1
+  https://github.com/oltaco/CustomLFS#0.2.2
 ; ----------------- RP2040 ---------------------
 
 [rp2040_base]


### PR DESCRIPTION
Pin to new version of CustomLFS to support the ZD25WQ32CEIGR flash chip in some LilyGo devices.