### PR TITLE
Add support for LilyGo T-Impulse-Plus

### DIFF
--- a/boards/lilygo_t_impulse_plus_nrf52840.json
+++ b/boards/lilygo_t_impulse_plus_nrf52840.json
@@ -1,0 +1,64 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_T_IMPULSE_PLUS -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8029"
+      ]
+    ],
+    "usb_product": "T-Impulse-Plus-nRF52840",
+    "mcu": "nrf52840",
+    "variant": "t_impulse_plus_nrf52840",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "onboard_tools": [
+      "jlink"
+    ],
+    "svd_path": "nrf52840.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Lilygo T-Impulse-Plus-nRF52840",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "require_upload_port": true,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "stlink",
+      "cmsis-dap",
+      "blackmagic"
+    ],
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.lilygo.cc/",
+  "vendor": "Lilygo"
+}

--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.cpp
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.cpp
@@ -1,0 +1,39 @@
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "TImpulsePlusBoard.h"
+
+void TImpulsePlusBoard::begin() {
+  NRF52BoardDCDC::begin();
+
+  // turn on 3.3v
+  pinMode(RT9080_EN, OUTPUT);
+  digitalWrite(RT9080_EN, HIGH);
+  delay(100);
+
+  // init gps pins
+  pinMode(GPS_EN, OUTPUT);
+  digitalWrite(GPS_EN, HIGH); // gps off by default
+
+  // configure battery measurement
+  pinMode(BATTERY_ADC_DATA, INPUT);
+  pinMode(BATTERY_MEASUREMENT_CONTROL, OUTPUT);
+  digitalWrite(BATTERY_MEASUREMENT_CONTROL, LOW); // turn off battery voltage measurement
+
+  // set the analog reference to 3.0V (default = 3.6V)
+  analogReference(AR_INTERNAL_3_0);
+  
+  // set the resolution to 12-bit (0..4095)
+  analogReadResolution(12); // Can be 8, 10, 12 or 14
+
+  // configure user button
+  pinMode(TTP223_KEY, INPUT_PULLDOWN);
+
+  #if defined(PIN_WIRE_SDA) && defined(PIN_WIRE_SCL)
+    Wire.setPins(PIN_WIRE_SDA, PIN_WIRE_SCL);
+  #endif
+
+  Wire.begin();
+
+  delay(10); // give sx1262 some time to power up
+}

--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <Arduino.h>
+#include <helpers/NRF52Board.h>
+
+class TImpulsePlusBoard : public NRF52BoardDCDC {
+protected:
+  uint8_t btn_prev_state;
+
+public:
+  TImpulsePlusBoard() : NRF52Board("T-Impulse-Plus OTA") {}
+  void begin();
+
+#if defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+  }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+    // enable battery voltage measurement
+    digitalWrite(BATTERY_MEASUREMENT_CONTROL, HIGH);
+    delay(100);
+
+    analogReadResolution(12);
+    analogReference(AR_INTERNAL);
+    delay(10);
+
+    // read battery voltage
+    int adcvalue = 0;
+    analogReadResolution(12);
+    analogReference(AR_INTERNAL);
+    delay(10);
+    adcvalue = analogRead(BATTERY_ADC_DATA);
+
+    // disable battery voltage measurement
+    digitalWrite(BATTERY_MEASUREMENT_CONTROL, LOW);
+
+    return ((adcvalue * ((3000.0 / 4096.0)))) * 2.0;
+  }
+
+  const char* getManufacturerName() const override {
+    return "LilyGo T-Impulse-Plus";
+  }
+
+  void powerOff() override {
+    sd_power_system_off();
+  }
+};

--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
@@ -48,6 +48,12 @@ public:
   }
 
   void powerOff() override {
+
+    // turn off 3.3v
+    digitalWrite(RT9080_EN, LOW);
+
+    // power off system
     sd_power_system_off();
+
   }
 };

--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
@@ -33,7 +33,7 @@ public:
     // read battery voltage
     int adcvalue = 0;
     analogReadResolution(12);
-    analogReference(AR_INTERNAL);
+    analogReference(AR_INTERNAL_3_0);
     delay(10);
     adcvalue = analogRead(BATTERY_ADC_DATA);
 

--- a/variants/lilygo_t_impulse_plus/platformio.ini
+++ b/variants/lilygo_t_impulse_plus/platformio.ini
@@ -1,0 +1,73 @@
+[LilyGo_T_Impulse_Plus]
+extends = nrf52_base
+board = lilygo_t_impulse_plus_nrf52840
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+build_flags = ${nrf52_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/lilygo_t_impulse_plus
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_USER_BTN=-1
+  ; -D PIN_USER_BTN=TTP223_KEY ; leave button disabled until screen implemented
+  ; -D USER_BTN_PRESSED=HIGH
+  -D PIN_WIRE_SDA=SCREEN_SDA
+  -D PIN_WIRE_SCL=SCREEN_SCL
+  -D ENV_PIN_SDA=IIC_SDA_2 ; firmware hangs without this
+  -D ENV_PIN_SCL=IIC_SCL_2 ; firmware hangs without this
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<TImpulsePlusBoard.cpp>
+  +<../variants/lilygo_t_impulse_plus>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/sensors>
+lib_deps= ${nrf52_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit SSD1306 @ ^2.5.13
+  adafruit/Adafruit GFX Library @ ^1.12.1
+
+[env:LilyGo_T_Impulse_Plus_repeater]
+extends = LilyGo_T_Impulse_Plus
+build_src_filter = ${LilyGo_T_Impulse_Plus.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${LilyGo_T_Impulse_Plus.build_flags}
+  -D ADVERT_NAME='"T-Impulse-Plus Repeater"'
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps = ${LilyGo_T_Impulse_Plus.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+
+[env:LilyGo_T_Impulse_Plus_companion_radio_ble]
+extends = LilyGo_T_Impulse_Plus
+; board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+; board_upload.maximum_size = 712704
+build_flags =
+  ${LilyGo_T_Impulse_Plus.build_flags}
+  -I src/helpers/ui
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D QSPIFLASH=1
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_T_Impulse_Plus.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${LilyGo_T_Impulse_Plus.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:LilyGo_T_Impulse_Plus_kiss_modem]
+extends = LilyGo_T_Impulse_Plus
+build_src_filter = ${LilyGo_T_Impulse_Plus.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/lilygo_t_impulse_plus/target.cpp
+++ b/variants/lilygo_t_impulse_plus/target.cpp
@@ -1,0 +1,37 @@
+#include <Arduino.h>
+#include "target.h"
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/sensors/MicroNMEALocationProvider.h>
+
+TImpulsePlusBoard board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#ifdef ENV_INCLUDE_GPS
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+EnvironmentSensorManager sensors = EnvironmentSensorManager();
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&SPI);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}
+

--- a/variants/lilygo_t_impulse_plus/target.h
+++ b/variants/lilygo_t_impulse_plus/target.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <TImpulsePlusBoard.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/SSD1306Display.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+
+extern TImpulsePlusBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();
+

--- a/variants/lilygo_t_impulse_plus/variant.cpp
+++ b/variants/lilygo_t_impulse_plus/variant.cpp
@@ -1,0 +1,43 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+const uint32_t g_ADigitalPinMap[] =
+{
+  // P0
+  0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 ,
+  8 , 9 , 10, 11, 12, 13, 14, 15,
+  16, 17, 18, 19, 20, 21, 22, 23,
+  24, 25, 26, 27, 28, 29, 30, 31,
+
+  // P1
+  32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47
+};
+
+
+void initVariant()
+{
+  
+}

--- a/variants/lilygo_t_impulse_plus/variant.h
+++ b/variants/lilygo_t_impulse_plus/variant.h
@@ -1,0 +1,224 @@
+ /*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_T_IMPULSE_PLUS_NRF52840_
+#define _VARIANT_T_IMPULSE_PLUS_NRF52840_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+#define USE_LFXO      // Board uses 32khz crystal for LF
+// define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+#define _PINNUM(port, pin) ((port) * 32 + (pin))
+
+// IIC
+#define IIC_SDA_1 _PINNUM(1, 8)
+#define IIC_SCL_1 _PINNUM(0, 11)
+#define IIC_SDA_2 _PINNUM(0, 20)
+#define IIC_SCL_2 _PINNUM(0, 15)
+
+// TTP223
+#define TTP223_KEY _PINNUM(1, 4)
+
+// SSD1315
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+#define SCREEN_ADDRESS 0x3C
+#define SCREEN_RST -1
+#define SCREEN_SDA IIC_SDA_2
+#define SCREEN_SCL IIC_SCL_2
+
+// Lora S62F(SX1262)
+#define SX1262_CS _PINNUM(1, 14)
+#define SX1262_RST _PINNUM(0, 2)
+#define SX1262_SCLK _PINNUM(0, 3)
+#define SX1262_MOSI _PINNUM(0, 28)
+#define SX1262_MISO _PINNUM(0, 30)
+#define SX1262_BUSY _PINNUM(0, 31)
+#define SX1262_INT _PINNUM(0, 29)
+#define SX1262_DIO1 _PINNUM(0, 29)
+#define SX1262_DIO2 _PINNUM(1, 15)
+#define SX1262_RF_VC1 _PINNUM(1, 13)
+#define SX1262_RF_VC2 _PINNUM(1, 7)
+
+#define SX126X_TXEN SX1262_RF_VC1
+#define SX126X_RXEN SX1262_RF_VC2
+
+#define P_LORA_NSS SX1262_CS
+#define P_LORA_DIO_1 SX1262_DIO1
+#define P_LORA_RESET SX1262_RST
+#define P_LORA_BUSY SX1262_BUSY
+#define P_LORA_DIO_0 RADIOLIB_NC
+#define P_LORA_DIO_2 SX1262_DIO2
+#define P_LORA_SCLK SX1262_SCLK
+#define P_LORA_MISO SX1262_MISO
+#define P_LORA_MOSI SX1262_MOSI
+
+// RT9080
+#define RT9080_EN _PINNUM(0, 14)
+
+// GPS
+#define GPS_EN _PINNUM(1, 10)
+#define GPS_UART_RX _PINNUM(1, 11)
+#define GPS_UART_TX _PINNUM(1, 12)
+#define PIN_GPS_RX GPS_UART_TX
+#define PIN_GPS_TX GPS_UART_RX
+#define PIN_GPS_EN GPS_EN
+#define GPS_BAUD_RATE 38400
+#define PIN_GPS_EN_ACTIVE LOW
+
+// Battery
+#define BATTERY_MEASUREMENT_CONTROL _PINNUM(0, 25)
+#define BATTERY_ADC_DATA _PINNUM(0, 5)
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (48)
+#define NUM_DIGITAL_PINS     (48)
+#define NUM_ANALOG_INPUTS    (6)
+#define NUM_ANALOG_OUTPUTS   (0)
+
+// LEDs
+#define PIN_LED1             (_PINNUM(0, 17))
+// #define PIN_LED2             (_PINNUM(1, 5))
+// #define PIN_LED3             (15)
+// #define PIN_LED4             (16)
+
+#define LED_BUILTIN          PIN_LED1
+// #define LED_CONN             PIN_LED2
+
+// #define LED_RED              PIN_LED1
+#define LED_BLUE             PIN_LED1
+
+#define LED_STATE_ON         0         // State when LED is litted
+
+/*
+ * Buttons
+ */
+#define PIN_BUTTON1          _PINNUM(0, 24)
+// #define PIN_BUTTON2          12
+// #define PIN_BUTTON3          24
+// #define PIN_BUTTON4          25
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (3)
+#define PIN_A1               (4)
+#define PIN_A2               (28)
+#define PIN_A3               (29)
+#define PIN_A4               (30)
+#define PIN_A5               (31)
+#define PIN_A6               (0xff)
+#define PIN_A7               (0xff)
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+static const uint8_t A6  = PIN_A6 ;
+static const uint8_t A7  = PIN_A7 ;
+#define ADC_RESOLUTION    14
+
+// Other pins
+#define PIN_AREF           (2)
+#define PIN_NFC1           (9)
+#define PIN_NFC2           (10)
+
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+
+// Arduino Header D0, D1
+#define PIN_SERIAL1_RX      (33) // P1.01
+#define PIN_SERIAL1_TX      (34) // P1.02
+
+// Connected to Jlink CDC
+#define PIN_SERIAL2_RX      (8)
+#define PIN_SERIAL2_TX      (6)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (46)
+#define PIN_SPI_MOSI         (45)
+#define PIN_SPI_SCK          (47)
+
+static const uint8_t SS   = 44 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 2
+
+#define PIN_WIRE_SDA         (26)
+#define PIN_WIRE_SCL         (27)
+
+#define PIN_WIRE1_SDA         (26)
+#define PIN_WIRE1_SCL         (27)
+
+// ZD25WQ32CEIGR SPI
+#define ZD25WQ32C_CS _PINNUM(0, 12)
+#define ZD25WQ32C_SCLK _PINNUM(0, 4)
+#define ZD25WQ32C_MOSI _PINNUM(0, 6)
+#define ZD25WQ32C_MISO _PINNUM(1, 9)
+#define ZD25WQ32C_IO0 _PINNUM(0, 6)
+#define ZD25WQ32C_IO1 _PINNUM(1, 9)
+#define ZD25WQ32C_IO2 _PINNUM(0, 8)
+#define ZD25WQ32C_IO3 _PINNUM(0, 26)
+
+#define PIN_QSPI_SCK         ZD25WQ32C_SCLK
+#define PIN_QSPI_CS          ZD25WQ32C_CS
+#define PIN_QSPI_IO0         ZD25WQ32C_IO0
+#define PIN_QSPI_IO1         ZD25WQ32C_IO1
+#define PIN_QSPI_IO2         ZD25WQ32C_IO2
+#define PIN_QSPI_IO3         ZD25WQ32C_IO3
+
+// On-board QSPI Flash
+#define EXTERNAL_FLASH_DEVICES   MX25R6435F
+#define EXTERNAL_FLASH_USE_QSPI
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
This PR adds initial support for the [LilyGo T-Impulse-Plus](https://github.com/Xinyuan-LilyGO/T-Impulse-Plus) device.

- Schematic: https://github.com/Xinyuan-LilyGO/T-Impulse-Plus/blob/main/project/T-Impulse-Plus_V1.0.pdf
- Pin Out: https://github.com/Xinyuan-LilyGO/T-Impulse-Plus/blob/main/libraries/private_library/pin_config.h

It's very small and could be useful as a pendant/necklace tracker node, or an ultra light portable companion node.

- It has a GPS module
- It has a 200mAh battery
- It has a vibrator module (not implemented at this time)
- The TX/RX signal strength is decent with the built in spring antenna
- It has capacitive touch support on the top face, however currently disabled while screen not implemented
- It has 4MB of external QSPI flash, much improved over other devices with 1MB internal or 2MB external

I've not implemented display support, the screen is very small, and the default SSD1306 library would not init.
This can be done sometime in the future, as a UI redesign would be required anyway. Possibly based on @oltaco's PR https://github.com/meshcore-dev/MeshCore/pull/2517 for the LilyGo T-Echo Card. 

I've tested Companion BLE firmware with the MeshCore App as well as the Repeater firmware.

<img width="200" alt="20260511_142633" src="https://github.com/user-attachments/assets/cdea1422-fec7-4250-93aa-7b8f2f460a1d" />

<img width="200" alt="20260511_192619" src="https://github.com/user-attachments/assets/1db45581-705a-4c61-90e8-d2b8c6345c69" />
