### PR TITLE
fix(crypto): reject non-aligned ciphertext in Utils::decrypt

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,6 +28,11 @@ void Utils::sha256(uint8_t *hash, size_t hash_len, const uint8_t* frag1, int fra
 }
 
 int Utils::decrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len) {
+  // ciphertext must be a positive multiple of CIPHER_BLOCK_SIZE (AES-128 block size).
+  // Without this the loop below over-reads 'src' and over-writes 'dest' by up to 15 bytes
+  // when 'src_len' is attacker-controlled.
+  if (src_len <= 0 || (src_len & (CIPHER_BLOCK_SIZE - 1))) return 0;
+
   AES128 aes;
   uint8_t* dp = dest;
   const uint8_t* sp = src;
@@ -73,6 +78,10 @@ int Utils::encryptThenMAC(const uint8_t* shared_secret, uint8_t* dest, const uin
 
 int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len) {
   if (src_len <= CIPHER_MAC_SIZE) return 0;  // invalid src bytes
+  // ciphertext (the bytes after the MAC) must be aligned to the AES block size.
+  // Defensive belt-and-suspenders: decrypt() also checks this, but rejecting earlier
+  // avoids any chance of a future caller reaching decrypt() with a bad length.
+  if ((src_len - CIPHER_MAC_SIZE) & (CIPHER_BLOCK_SIZE - 1)) return 0;
 
   uint8_t hmac[CIPHER_MAC_SIZE];
   {


### PR DESCRIPTION
## Summary

`Utils::decrypt` in `src/Utils.cpp` walks AES-128 blocks with `while (sp - src < src_len)` and never checks that `src_len` is a multiple of `CIPHER_BLOCK_SIZE`. When `src_len` is attacker-controlled (it comes from packet `payload_len` via `MACThenDecrypt`), this is a remote out-of-bounds primitive: the loop over-reads `src` and over-writes `dest` by up to 15 bytes past the end of the AES-aligned boundary. This change rejects non-aligned `src_len` up front.

## Background — the primitive

The AES decryption loop sits behind every encrypted-payload receive path in `Mesh::onRecvPacket`. Concretely on the public-channel `PAYLOAD_TYPE_GRP_TXT` path:

1. An attacker who knows the public-channel PSK (preloaded in `examples/companion_radio/MyMesh.cpp` from the literal string `"izOH6cXN6mrJ5e26oRXNcg=="`) crafts a `PAYLOAD_TYPE_GRP_TXT` packet with `payload_len = 184` and a 181-byte ciphertext + a 2-byte HMAC they computed themselves.
2. The receiver's `Mesh::onRecvPacket` (the GRP_TXT branch) calls `Utils::MACThenDecrypt(..., payload_len - i = 183)`.
3. `MACThenDecrypt` strips the 2-byte MAC and calls `decrypt(..., src_len = 181)`.
4. The loop `while (sp - src < 181)` runs **12 iterations** (last check: 176 < 181), each writing 16 bytes via `aes.decryptBlock`. It writes 192 bytes total into a 184-byte stack buffer `data[MAX_PACKET_PAYLOAD]` — **8 bytes of attacker-controlled stack-OOB write**.

Receiving devices are typically ARM Cortex-M; large stack locals commonly sit adjacent to the saved frame pointer / link register, so the corrupted bytes are well-placed for control-flow consequences.

## Background — the MAC-forgery interaction

The 2-byte (16-bit) truncated HMAC at `CIPHER_MAC_SIZE = 2` (in `src/MeshCore.h`) means any random ciphertext has a ~1/65,536 chance of passing validation. At the US default radio config (910.525 MHz / BW=62.5 kHz / SF7 / CR4/5, ~590 ms time-on-air per max-length packet), an attacker can land one forged MAC in ~5.4 hours of continuous transmission — without any key material.

The right long-term fix for the weak MAC is to widen `CIPHER_MAC_SIZE` to 8 bytes, but that's a wire-format break that has to be sequenced with the protocol roadmap. **This patch is the active short-term mitigation for the MAC-forgery angle too**: after this lands, a successful MAC forgery still happens at the same probability, but it can no longer steer `decrypt()` into an out-of-bounds write. The worst remaining consequence collapses from "remote stack corruption" to "occasional content-injection into a per-type handler that still has to satisfy that handler's own validation."

## Change

`src/Utils.cpp`:

- `Utils::decrypt`: return `0` if `src_len <= 0` or `src_len & (CIPHER_BLOCK_SIZE - 1)`. The existing comment "will always be multiple of 16" is now enforced rather than trusted.
- `Utils::MACThenDecrypt`: defensively reject `(src_len - CIPHER_MAC_SIZE) & (CIPHER_BLOCK_SIZE - 1)` for the same reason, one level earlier. This is belt-and-suspenders against any future caller that might bypass `decrypt`'s check.

Both early-returns propagate naturally: every call site in `src/Mesh.cpp` (and the example firmwares) already treats a non-positive return as "decrypt failed, drop the packet."

## Why this is the minimal fix

Larger remediations — moving to AES-GCM, widening `CIPHER_MAC_SIZE`, widening the channel-hash prefix — are all wire-format breaks that belong to the next protocol revision. This patch is intentionally surgical so it can be cherry-picked back to release branches.

## Risk / compatibility

- **Wire format:** unchanged. A correctly-formed encrypted packet from a legitimate sender always has a 16-aligned ciphertext (see `Utils::encrypt`, which rounds up to a full block with zero padding). No existing peer transmits a malformed length, so no legitimate traffic is rejected.
- **Behaviour diff:** previously-undefined behaviour on malformed packets becomes a defined "drop and return 0." Already what every call site is prepared for.
- **Performance:** two integer comparisons per inbound encrypted packet. Negligible.

## References

- CWE-787 — Out-of-bounds Write.
- CWE-129 — Improper Validation of Array Index.
- NIST FIPS 197 (Advanced Encryption Standard) §5: AES operates on 128-bit blocks; partial-block ciphertext is not defined and any handling of it is an application-level invariant the implementation is required to enforce.