### PR TITLE
fix(acl): refuse admin login while password is at build default

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -99,6 +99,12 @@ uint8_t MyMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secr
   }
   if (client == NULL) {
     uint8_t perms;
+    // Refuse any password-based login while admin password is at the build default.
+    // Operator must change it via serial CLI before LoRa logins are accepted.
+    if (_prefs.password[0] == 0 || strcmp(_prefs.password, "password") == 0) {
+      MESH_DEBUG_PRINTLN("Login refused: admin password is at default");
+      return 0;
+    }
     if (strcmp((char *)data, _prefs.password) == 0) { // check for valid admin password
       perms = PERM_ACL_ADMIN;
     } else if (strcmp((char *)data, _prefs.guest_password) == 0) { // check guest password

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -324,6 +324,12 @@ void MyMesh::onAnonDataRecv(mesh::Packet *packet, const uint8_t *secret, const m
     }
     if (client == NULL) {
       uint8_t perm;
+      // Refuse any password-based login while admin password is at the build default.
+      // Operator must change it via serial CLI before LoRa logins are accepted.
+      if (_prefs.password[0] == 0 || strcmp(_prefs.password, "password") == 0) {
+        MESH_DEBUG_PRINTLN("Login refused: admin password is at default");
+        return; // no response
+      }
       if (strcmp((char *)&data[8], _prefs.password) == 0) { // check for valid admin password
         perm = PERM_ACL_ADMIN;
       } else {

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -338,6 +338,12 @@ uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* 
       return 0;
     }
   } else {
+    // Refuse any password-based login while admin password is at the build default.
+    // Operator must change it via serial CLI before LoRa logins are accepted.
+    if (_prefs.password[0] == 0 || strcmp(_prefs.password, "password") == 0) {
+      MESH_DEBUG_PRINTLN("Login refused: admin password is at default");
+      return 0;
+    }
     if (strcmp((char *) data, _prefs.password) != 0) {  // check for valid admin password
     #if MESH_DEBUG
       MESH_DEBUG_PRINTLN("Invalid password: %s", &data[4]);


### PR DESCRIPTION
## Summary

The `simple_repeater`, `simple_room_server`, and `simple_sensor` example firmwares all set `_prefs.password = ADMIN_PASSWORD` where `ADMIN_PASSWORD` defaults to the literal string `"password"`. Any radio peer that learns the target's advert pubkey can submit an ANON_REQ login with `data = "password"` and become `PERM_ACL_ADMIN` — full takeover of a freshly-flashed device. This change refuses the password-based login path at runtime while `_prefs.password` is empty or equal to `"password"`. The operator must change it via serial CLI before LoRa admin logins work.

## Background

Three sites accept the default password unchanged:

- `examples/simple_repeater/MyMesh.cpp` — `if (strcmp((char *)data, _prefs.password) == 0) perms = PERM_ACL_ADMIN;`
- `examples/simple_room_server/MyMesh.cpp` — same shape with `&data[8]`.
- `examples/simple_sensor/SensorMesh.cpp` — same shape.

`ADMIN_PASSWORD` is defined as `"password"` in each example's `MyMesh.cpp` / `SensorMesh.cpp` if the build doesn't override it (`-D ADMIN_PASSWORD=...`). `_prefs.password` is seeded from this in the constructor and stays there until the operator runs the `password <new>` CLI command over serial.

The attack: an attacker only needs to receive any advert from the target (passive), then craft an ANON_REQ login wrapped in ECDH against the target's advert pubkey, payload bytes `"password\0"`. The receiving firmware grants `PERM_ACL_ADMIN`. From there, `setperm`, `set password`, `set prv.key`, region edits, etc. are all reachable.

## Change

Add an early refusal at the top of the password-comparison block in each example:

```cpp
if (_prefs.password[0] == 0 || strcmp(_prefs.password, "password") == 0) {
  MESH_DEBUG_PRINTLN("Login refused: admin password is at default");
  return 0;
}
```

`return 0` (or `return;` in room_server's `void` handler) yields no response — the client times out, matching the existing "incorrect password" treatment.

Three files touched, same idiom in each:

- `examples/simple_repeater/MyMesh.cpp`
- `examples/simple_room_server/MyMesh.cpp`
- `examples/simple_sensor/SensorMesh.cpp`

## Why this is the minimal fix

A complete fix is "require setup before going on-air" — provisioned by a setup wizard, factory-randomised per-board, etc. That's a larger UX change with hardware implications. This patch is a pure-firmware refusal that closes the LoRa attack vector immediately, without changing the wire protocol or the host-app flow. The guest_password path is intentionally left alone — many sensor deployments rely on a known guest password for basic telemetry from unprovisioned clients, and that doesn't grant any admin authority.

## Risk / compatibility

- Wire format: unchanged.
- Behaviour: factory-fresh devices that have not had `password` changed will now reject all LoRa admin logins. This is the intent: operator must connect over USB-serial and run `password <new>` first. Devices already provisioned with a non-default password are unaffected.
- Empty-password protection (`_prefs.password[0] == 0`) is included because some build profiles override `ADMIN_PASSWORD` to the empty string, and an empty admin password is even worse than `"password"`.

## References

- CWE-798 — Use of Hard-coded Credentials.
- CWE-1392 — Use of Default Credentials.
- NIST SP 800-63B §5.1.1.2 ("Memorized Secret Verifiers") — memorised secrets that are dictionary words or known-compromised SHALL be rejected.
