### PR TITLE
fix(crypto): constant-time MAC compare

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -81,7 +81,11 @@ int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uin
     sha.update(src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
     sha.finalizeHMAC(shared_secret, PUB_KEY_SIZE, hmac, CIPHER_MAC_SIZE);
   }
-  if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {
+  // Constant-time MAC compare: memcmp() returns at the first non-matching byte,
+  // leaking byte-of-first-mismatch via timing.
+  uint8_t diff = 0;
+  for (int k = 0; k < CIPHER_MAC_SIZE; k++) diff |= hmac[k] ^ src[k];
+  if (diff == 0) {
     return decrypt(shared_secret, dest, src + CIPHER_MAC_SIZE, src_len - CIPHER_MAC_SIZE);
   }
   return 0; // invalid HMAC


### PR DESCRIPTION
## Summary

`Utils::MACThenDecrypt` in `src/Utils.cpp` compares the computed HMAC to the packet's MAC bytes with `memcmp`, which is the textbook timing-oracle pattern — it returns at the first mismatched byte. This change replaces it with an XOR-OR constant-time loop.

## Background

```cpp
if (memcmp(hmac, src, CIPHER_MAC_SIZE) == 0) {  // before
```

`memcmp` is allowed to return as soon as it finds a mismatch. Across many MAC-validation attempts, an attacker can in principle observe the byte-of-first-mismatch through the (very small) timing difference and reduce a 16-bit forgery problem toward 2×8-bit problems.

The practical exploitability here is low — `CIPHER_MAC_SIZE = 2` so there are only ~2 bytes of timing signal to leak, and the LoRa receive-path noise dwarfs sub-microsecond timing differences. But:

1. The fix is six lines and adds no overhead worth measuring.
2. It removes the pattern from any future code reviewer's "is this safe?" pile.
3. As `CIPHER_MAC_SIZE` widens in any future protocol revision, having constant-time compare already in place is one less migration step.

## Change

`src/Utils.cpp` — replace the `memcmp` MAC check with an XOR-OR accumulator:

```cpp
uint8_t diff = 0;
for (int k = 0; k < CIPHER_MAC_SIZE; k++) diff |= hmac[k] ^ src[k];
if (diff == 0) { ... }
```

Every byte is always touched; loop length depends only on the public `CIPHER_MAC_SIZE`, never on the input data.

## Why this is the minimal fix

This is the standard constant-time-equality pattern (e.g. NaCl `crypto_verify`, OpenSSL `CRYPTO_memcmp`, Go `crypto/subtle.ConstantTimeCompare`). Adding a dependency on a vendor library for two bytes would be over-engineering on an embedded target.

## Risk / compatibility

- Wire format: unchanged.
- Behaviour: bit-for-bit identical accept/reject decisions; only the timing of the rejection path changes.
- Performance: ~2 byte-XORs per inbound encrypted packet. Below measurement noise.

## References

- CWE-208 — Observable Timing Discrepancy.
- D. J. Bernstein, "Cache-timing attacks on AES" (2005) — canonical motivation for constant-time crypto primitives.
- Go stdlib `crypto/subtle` documentation, "Functions in this package … all execute in constant time" — reference pattern.
