### PR TITLE
fix(advert): bounds-check optional fields before memcpy

### DIFF
--- a/src/helpers/AdvertDataHelpers.cpp
+++ b/src/helpers/AdvertDataHelpers.cpp
@@ -32,16 +32,23 @@
     _flags = app_data[0];
     _valid = false;
     _extra1 = _extra2 = 0;
-  
+
     int i = 1;
+    // Bounds-check each optional field BEFORE memcpy: a crafted advert with all
+    // FLAG_* bits set but app_data_len=1 would otherwise over-read up to 12 bytes
+    // past the buffer (the trailing app_data_len >= i check below only catches it
+    // after the fact). Returning early leaves _valid=false.
     if (_flags & ADV_LATLON_MASK) {
+      if (i + 8 > app_data_len) return;
       memcpy(&_lat, &app_data[i], 4); i += 4;
       memcpy(&_lon, &app_data[i], 4); i += 4;
     }
     if (_flags & ADV_FEAT1_MASK) {
+      if (i + 2 > app_data_len) return;
       memcpy(&_extra1, &app_data[i], 2); i += 2;
     }
     if (_flags & ADV_FEAT2_MASK) {
+      if (i + 2 > app_data_len) return;
       memcpy(&_extra2, &app_data[i], 2); i += 2;
     }
 


### PR DESCRIPTION
## Summary

`AdvertDataParser::AdvertDataParser` (`src/helpers/AdvertDataHelpers.cpp`) optimistically `memcpy`'d `_lat` / `_lon` / `_extra1` / `_extra2` from the supplied buffer **before** validating that the buffer was long enough. A crafted advert with all optional-field flag bits set and `app_data_len = 1` over-read up to 12 bytes past the supplied slice. This change validates the length before each `memcpy`.

## Background

The buggy pattern (verbatim, before this PR):

```cpp
int i = 1;
if (_flags & ADV_LATLON_MASK) {
  memcpy(&_lat, &app_data[i], 4); i += 4;     // reads 8 bytes past app_data[1] regardless of app_data_len
  memcpy(&_lon, &app_data[i], 4); i += 4;
}
if (_flags & ADV_FEAT1_MASK) { memcpy(&_extra1, &app_data[i], 2); i += 2; }
if (_flags & ADV_FEAT2_MASK) { memcpy(&_extra2, &app_data[i], 2); i += 2; }
if (app_data_len >= i) {                       // length check happens AFTER the reads
  ...
  _valid = true;
}
```

The `app_data` argument in the live path is `&pkt->payload[i]` where `pkt->payload` is the 184-byte packet buffer (`src/Packet.h`), so OOB reads land inside the same allocation. That's the only thing keeping this from being a remote info-disclosure today. The fix prevents the OOB regardless of where the buffer happens to live, which is the right hygiene for a parser that takes a length parameter.

## Change

`src/helpers/AdvertDataHelpers.cpp` — before each `memcpy` of an optional field, check that the requested byte count is available. If not, return early; `_valid` stays `false`, which is the same outcome callers already get for a too-short payload.

## Why this is the minimal fix

The pattern matches the existing build-side `AdvertDataBuilder::encodeTo` reasoning. Rewriting the parser around a separate validator pass would add code without removing the underlying bug.

## Risk / compatibility

- Wire format: unchanged.
- Behaviour: bit-for-bit identical for any valid advert (the lengths add up by construction). Only malformed adverts now stop earlier instead of writing junk into `_lat` / `_lon` / etc. and then being rejected by the trailing length check.

## References

- CWE-125 — Out-of-bounds Read.
- CWE-1284 — Improper Validation of Specified Quantity in Input.
