### PR TITLE
fix(mesh): widen TRACE offset to uint16 to avoid narrowing

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -50,7 +50,9 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       uint8_t path_sz = flags & 0x03;  // NEW v1.11+: lower 2 bits is path hash size
 
       uint8_t len = pkt->payload_len - i;
-      uint8_t offset = pkt->path_len << path_sz;
+      // path_len*entry_size can exceed 255 (path_len up to 63, entry_size up to 8);
+      // a uint8_t offset would wrap and steer the isHashMatch() read to the wrong place.
+      uint16_t offset = (uint16_t)pkt->path_len << path_sz;
       if (offset >= len) {   // TRACE has reached end of given path
         onTraceRecv(pkt, trace_tag, auth_code, flags, pkt->path, &pkt->payload[i], len);
       } else if (self_id.isHashMatch(&pkt->payload[i + offset], 1 << path_sz) && allowPacketForward(pkt) && !_tables->hasSeen(pkt)) {


### PR DESCRIPTION
## Summary

In the TRACE-packet forwarding branch of `Mesh::onRecvPacket` (`src/Mesh.cpp`), the byte-offset computed as `pkt->path_len << path_sz` was being narrowed to `uint8_t`. With `path_sz = 3` (an 8-byte path hash entry) and `pkt->path_len ≥ 32`, the shift overflowed the destination type and wrapped, steering the subsequent `isHashMatch()` read to the wrong byte in `pkt->payload`. This is a logic / mis-routing bug, not a memory-safety bug — the read still lands inside the 184-byte payload buffer. Fix is a one-line type widening.

## Background

```cpp
uint8_t path_sz = flags & 0x03;       // 0..3
uint8_t len    = pkt->payload_len - i;
uint8_t offset = pkt->path_len << path_sz;   // <-- narrowing
if (offset >= len) { ... }
else if (self_id.isHashMatch(&pkt->payload[i + offset], 1 << path_sz) && ...) { ... }
```

`pkt->path_len` is `uint16_t` (`src/Packet.h`). `pkt->path_len << path_sz` is performed in `int`, then assigned to `uint8_t`, taking the low 8 bits. For `path_len = 32, path_sz = 3` the true byte offset is `256` (wraps to `0`); for `path_len = 33`, true offset is `264` (wraps to `8`); etc. The receiver then reads `path_sz`-sized entries from the wrong position, producing either spurious "I am the next hop" matches or silent drops.

## Change

`src/Mesh.cpp` — widen `offset` to `uint16_t` and explicitly cast the shifted operand to `uint16_t` to avoid any future surprise from integer promotion rules.

## Why this is the minimal fix

A one-line type widening. No callers need to change — `isHashMatch` and `pkt->payload[]` indexing both already accept the wider value cleanly.

## Risk / compatibility

- Wire format: unchanged.
- Behaviour: correct for the `path_len*entry_size > 255` case (previously mis-routed); identical for the common case where it stays in `uint8_t` range.

## References

- CWE-197 — Numeric Truncation Error.
- ISO/IEC 9899 §6.3.1.3 ("Signed and unsigned integers"): conversion of a value that doesn't fit in the destination type yields an implementation-defined / wrap-around result; the C++ rule for unsigned narrowing is modular.
