### PR TITLE
revert: "feat: Enable GPS on RAK 1W kit" (#2401)

### DIFF
--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,7 +6,6 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
-  -D RAK_BOARD
   -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
@@ -65,7 +64,6 @@ build_flags =
   ${rak3401.build_flags}
   -I examples/companion_radio/ui-new
   -D PIN_USER_BTN_ANA=31
-  -D PIN_GPS_EN=-1
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
@@ -86,7 +84,6 @@ build_flags =
   ${rak3401.build_flags}
   -I examples/companion_radio/ui-new
   -D PIN_USER_BTN_ANA=31
-  -D PIN_GPS_EN=-1
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40


### PR DESCRIPTION
reverted changes to RAK_BOARD and PIN_GPS_EN. setting `RAK_BOARD` would cause radio to stop working and end with RadioLib error -707