### PR TITLE
M5Stack Unit-C6L: correct hardware config and add PI4IO expander support

### DIFF
--- a/variants/m5stack_unit_c6l/UnitC6LBoard.cpp
+++ b/variants/m5stack_unit_c6l/UnitC6LBoard.cpp
@@ -1,6 +1,69 @@
 #include <Arduino.h>
 #include "target.h"
 
+// PI4IO GPIO expander: P7=LoRa reset, P6=RF switch, P5=LNA_EN, P0/P1=buttons
+#define PI4IO_ADDR         0x43
+#define PI4IO_REG_RESET    0x01
+#define PI4IO_REG_IO_DIR   0x03
+#define PI4IO_REG_OUT_SET  0x05
+#define PI4IO_REG_OUT_H_IM 0x07
+#define PI4IO_REG_IN_DEF   0x09
+#define PI4IO_REG_PULL_EN  0x0B
+#define PI4IO_REG_PULL_SEL 0x0D
+#define PI4IO_REG_INT_MASK 0x11
+#define PI4IO_REG_IRQ_STA  0x13
+
+#define PI4IO_P0  (1 << 0)
+#define PI4IO_P1  (1 << 1)
+#define PI4IO_P2  (1 << 2)
+#define PI4IO_P3  (1 << 3)
+#define PI4IO_P4  (1 << 4)
+#define PI4IO_P5  (1 << 5)
+#define PI4IO_P6  (1 << 6)
+#define PI4IO_P7  (1 << 7)
+
+static void pi4ioWrite(uint8_t reg, uint8_t val) {
+  Wire.beginTransmission(PI4IO_ADDR);
+  Wire.write(reg);
+  Wire.write(val);
+  Wire.endTransmission();
+}
+
+static uint8_t pi4ioRead(uint8_t reg) {
+  Wire.beginTransmission(PI4IO_ADDR);
+  Wire.write(reg);
+  Wire.endTransmission();
+  Wire.requestFrom((uint8_t)PI4IO_ADDR, (uint8_t)1);
+  return Wire.read();
+}
+
+static void pi4ioInit() {
+  // reset chip
+  pi4ioWrite(PI4IO_REG_RESET,    0xFF);
+  // clear reset
+  pi4ioRead(PI4IO_REG_RESET);
+  // P5=LNA_EN, P6=ANT_SW, P7=NRST as outputs
+  pi4ioWrite(PI4IO_REG_IO_DIR,   PI4IO_P5 | PI4IO_P6 | PI4IO_P7);
+  // P2-P4 unused, high-Z
+  pi4ioWrite(PI4IO_REG_OUT_H_IM, PI4IO_P2 | PI4IO_P3 | PI4IO_P4);
+  // pull-up on buttons and output pins
+  pi4ioWrite(PI4IO_REG_PULL_SEL, PI4IO_P0 | PI4IO_P1 | PI4IO_P5 | PI4IO_P6 | PI4IO_P7);
+  pi4ioWrite(PI4IO_REG_PULL_EN,  PI4IO_P0 | PI4IO_P1 | PI4IO_P5 | PI4IO_P6 | PI4IO_P7);
+  // buttons default high
+  pi4ioWrite(PI4IO_REG_IN_DEF,   PI4IO_P0 | PI4IO_P1);
+  // interrupt on P0, P1 only (mask everything else)
+  pi4ioWrite(PI4IO_REG_INT_MASK, PI4IO_P2 | PI4IO_P3 | PI4IO_P4 | PI4IO_P5 | PI4IO_P6 | PI4IO_P7);
+  // release LoRa reset, enable ANT_SW and LNA
+  pi4ioWrite(PI4IO_REG_OUT_SET,  PI4IO_P5 | PI4IO_P6 | PI4IO_P7);
+  // clear IRQ flag
+  pi4ioRead(PI4IO_REG_IRQ_STA);
+}
+
+void UnitC6LBoard::begin() {
+  ESP32Board::begin();  // initializes Wire on SDA=10, SCL=8
+  pi4ioInit();
+}
+
 UnitC6LBoard board;
 
 #if defined(P_LORA_SCLK)

--- a/variants/m5stack_unit_c6l/UnitC6LBoard.h
+++ b/variants/m5stack_unit_c6l/UnitC6LBoard.h
@@ -5,9 +5,7 @@
 
 class UnitC6LBoard : public ESP32Board {
 public:
-  void begin() {
-    ESP32Board::begin();
-  }
+  void begin();
 
   const char* getManufacturerName() const override {
     return "Unit C6L";

--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -1,12 +1,15 @@
 [M5Stack_Unit_C6L]
 extends = esp32c6_base
 board = esp32-c6-devkitm-1
-board_build.partitions = min_spiffs.csv ; get around 4mb flash limit
+board_build.flash_mode = dio
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+board_build.partitions = large_spiffs_16MB.csv
 build_flags =
   ${esp32c6_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/m5stack_unit_c6l
-  -D P_LORA_TX_LED=15
+  -D P_LORA_TX_NEOPIXEL_LED=2
   -D P_LORA_SCLK=20
   -D P_LORA_MISO=22
   -D P_LORA_MOSI=21
@@ -15,11 +18,10 @@ build_flags =
   -D P_LORA_BUSY=19
   -D P_LORA_RESET=-1
   -D PIN_BUZZER=11
-  -D PIN_BOARD_SDA=16
-  -D PIN_BOARD_SCL=17
-  -D SX126X_RXEN=5
+  -D PIN_BOARD_SDA=10
+  -D PIN_BOARD_SCL=8
   -D SX126X_DIO2_AS_RF_SWITCH=true
-  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_DIO3_TCXO_VOLTAGE=3.0
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D USE_SX1262


### PR DESCRIPTION
- 16MB flash with DIO mode and matching partition table
- NeoPixel TX LED on pin 2 (was GPIO 15)
- I2C on SDA=10/SCL=8 (was 16/17)
- TCXO voltage 3.0V (was 1.8V)
- Initialize PI4IO expander (i2c addr: 0x43): controls LoRa reset (P7), RF switch (P6), LNA enable (P5), and buttons (P0/P1) via I2C
- Remove SX126X_RXEN (now handled by PI4IO)

Tested USB companion and Repeater firmwares.