### PR TITLE
[Fix] epaper set color for Heltec E213, E290 and wireless paper

### DIFF
--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -128,7 +128,9 @@ void E213Display::setTextSize(int sz) {
 
 void E213Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  // implemented in individual display methods
+  _color = c == 0 ? WHITE : BLACK; // for rectangles
+  display.setTextColor(UINT16_MAX * _color); // for text
+  // keep in mind this is inverted on e-ink
 }
 
 void E213Display::setCursor(int x, int y) {
@@ -147,7 +149,7 @@ void E213Display::fillRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-    display->fillRect(x, y, w, h, BLACK);
+    display->fillRect(x, y, w, h, _color);
 }
 
 void E213Display::drawRect(int x, int y, int w, int h) {
@@ -155,7 +157,7 @@ void E213Display::drawRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-    display->drawRect(x, y, w, h, BLACK);
+    display->drawRect(x, y, w, h, _color);
 }
 
 void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {

--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -181,7 +181,7 @@ void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 
       // If the bit is set, draw the pixel
       if (bitSet) {
-          display->drawPixel(x + bx, y + by, BLACK);
+          display->drawPixel(x + bx, y + by, _color);
       }
     }
   }

--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -128,7 +128,7 @@ void E213Display::setTextSize(int sz) {
 
 void E213Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  _color = c == 0 ? WHITE : BLACK; // for rectangles
+  _color = c == 0 ? WHITE : BLACK; // for rectangles and bitmaps
   display.setTextColor(UINT16_MAX * _color); // for text
   // keep in mind this is inverted on e-ink
 }

--- a/src/helpers/ui/E213Display.h
+++ b/src/helpers/ui/E213Display.h
@@ -13,6 +13,7 @@ class E213Display : public DisplayDriver {
   BaseDisplay* display=NULL;
   bool _init = false;
   bool _isOn = false;
+  uint8_t _color;
   RefCountedDigitalPin* _periph_power;
   CRC32 display_crc;
   uint32_t last_display_crc_value = 0;

--- a/src/helpers/ui/E290Display.cpp
+++ b/src/helpers/ui/E290Display.cpp
@@ -134,7 +134,7 @@ void E290Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 
       // If the bit is set, draw the pixel
       if (bitSet) {
-        display.drawPixel(x + bx, y + by, BLACK);
+        display.drawPixel(x + bx, y + by, _color);
       }
     }
   }

--- a/src/helpers/ui/E290Display.cpp
+++ b/src/helpers/ui/E290Display.cpp
@@ -81,7 +81,9 @@ void E290Display::setTextSize(int sz) {
 
 void E290Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  // implemented in individual display methods
+  _color = c == 0 ? WHITE : BLACK; // for rectangles
+  display.setTextColor(UINT16_MAX * _color); // for text
+  // keep in mind this is inverted on e-ink
 }
 
 void E290Display::setCursor(int x, int y) {
@@ -100,7 +102,7 @@ void E290Display::fillRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-  display.fillRect(x, y, w, h, BLACK);
+  display.fillRect(x, y, w, h, _color);
 }
 
 void E290Display::drawRect(int x, int y, int w, int h) {
@@ -108,7 +110,7 @@ void E290Display::drawRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-  display.drawRect(x, y, w, h, BLACK);
+  display.drawRect(x, y, w, h, _color);
 }
 
 void E290Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {

--- a/src/helpers/ui/E290Display.cpp
+++ b/src/helpers/ui/E290Display.cpp
@@ -81,7 +81,7 @@ void E290Display::setTextSize(int sz) {
 
 void E290Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  _color = c == 0 ? WHITE : BLACK; // for rectangles
+  _color = c == 0 ? WHITE : BLACK; // for rectangles and bitmaps
   display.setTextColor(UINT16_MAX * _color); // for text
   // keep in mind this is inverted on e-ink
 }

--- a/src/helpers/ui/E290Display.h
+++ b/src/helpers/ui/E290Display.h
@@ -13,6 +13,7 @@ class E290Display : public DisplayDriver {
   EInkDisplay_VisionMasterE290 display;
   bool _init = false;
   bool _isOn = false;
+  uint8_t _color;
   RefCountedDigitalPin* _periph_power;
   CRC32 display_crc;
   uint32_t last_display_crc_value = 0;


### PR DESCRIPTION
I noticed a massive black bar briefly appearing on the recent page when flipping through the pages on my E290 and when sending an advert. After digging through the code I realised that this is supposed to be the popup notification. It seemed like
the rectangle drawing function did not support changing the drawing. When I tried fixing that I realised that the setColor function was pretty much useless, so I essentially copied the implementation that the monochrome OLEDs and LCDs use. Later I also realised that bitmaps could also only be drawn in a single color and added color change support there too.

The popup on the recent page is a weird choice imo. It only appears when flipping through the pages forwards but not backwards. Some text saying "no recent contracts" when it's empty would probably be best. I might make a future PR for that and
better space utilisation of the big e-paper screen. It just seems like a waste of screen space to only display tiny text and only 4 recents.

The changes in this PR have been tested on a Heltec E290, the E213 and wireless paper should work the same way since they are very similar. The changes to bitmap drawing do not affect anything visually but allow for drawing white bitmaps on black background. The changes to the rectangle drawing functions allow the notification popup to be displayed correctly rather than being a solid black box.