### PR TITLE
save 512 bytes of RAM

### DIFF
--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <math.h>
 
-#define MAX_HASH_SIZE        8
+#define MAX_HASH_SIZE        4
 #define PUB_KEY_SIZE        32
 #define PRV_KEY_SIZE        64
 #define SEED_SIZE           32

--- a/src/helpers/SimpleMeshTables.h
+++ b/src/helpers/SimpleMeshTables.h
@@ -12,7 +12,7 @@
 class SimpleMeshTables : public mesh::MeshTables {
   uint8_t _hashes[MAX_PACKET_HASHES*MAX_HASH_SIZE];
   int _next_idx;
-  uint32_t _acks[MAX_PACKET_ACKS];
+  uint8_t _acks[MAX_PACKET_ACKS*MAX_HASH_SIZE];
   int _next_ack_idx;
   uint32_t _direct_dups, _flood_dups;
 
@@ -42,8 +42,8 @@ public:
 
   bool hasSeen(const mesh::Packet* packet) override {
     if (packet->getPayloadType() == PAYLOAD_TYPE_ACK) {
-      uint32_t ack;
-      memcpy(&ack, packet->payload, 4);
+      uint8_t ack;
+      memcpy(&ack, packet->payload, MAX_HASH_SIZE);
       for (int i = 0; i < MAX_PACKET_ACKS; i++) {
         if (ack == _acks[i]) { 
           if (packet->isRouteDirect()) {
@@ -82,8 +82,8 @@ public:
 
   void clear(const mesh::Packet* packet) override {
     if (packet->getPayloadType() == PAYLOAD_TYPE_ACK) {
-      uint32_t ack;
-      memcpy(&ack, packet->payload, 4);
+      uint8_t ack;
+      memcpy(&ack, packet->payload, MAX_HASH_SIZE);
       for (int i = 0; i < MAX_PACKET_ACKS; i++) {
         if (ack == _acks[i]) { 
           _acks[i] = 0;


### PR DESCRIPTION
Instead of 64 bit fingerprints use 32 bit fingerprints for de-dupping. This saves us 512 bytes of RAM.

The probability of false positive was at 128 / 2^64, this would bring it to 128 / 2^32 (1 in 33M)

If we reduced it to 3 bytes (24 bits), we would have 1 in 131k at which point it may not longer be negligible at scale (but may still be acceptable);

On discord I was talking about probabilistic data structures (bloom/cuckoo filters); maybe we don't need the complexity, especially if there is no need to track more than 128 packets.