### PR TITLE
fix(#1775, #1489): path quality gating in onContactPathRecv + 3x flood ACK retry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -166,3 +166,17 @@ build_src_filter =
   +<../src/Utils.cpp>
 lib_deps =
   google/googletest @ 1.17.0
+
+; Standalone unit tests for reliability changes (issues #1775, #1489).
+; These tests have no Mesh-stack dependencies and compile without the
+; Arduino framework or crypto libraries.
+[env:native_reliability]
+platform = native
+build_flags = -std=c++17
+test_filter =
+  test_path_gating
+  test_flood_ack
+build_src_filter =
+  -<*>
+lib_deps =
+  google/googletest @ 1.17.0

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -457,11 +457,16 @@ Packet* Mesh::createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, 
     if (extra_len > 0) {
       data[data_len++] = extra_type;
       memcpy(&data[data_len], extra, extra_len); data_len += extra_len;
-    } else {
-      // append a timestamp, or random blob (to make packet_hash unique)
-      data[data_len++] = 0xFF;  // dummy payload type
-      getRNG()->random(&data[data_len], 4); data_len += 4;
     }
+    // Always append a random nonce regardless of extra presence.
+    // AES-ECB is deterministic: without a nonce, identical plaintext produces
+    // identical ciphertext → identical calculatePacketHash() → hasSeen() treats
+    // every retransmission of the same PATH+ACK as a duplicate and drops it.
+    // The nonce is ignored by the receiver (it reads only the typed extra fields).
+    // This mirrors the original no-extra handling above (issue: nonce was missing
+    // for the extra_len > 0 branch, breaking flood-ACK retry reliability).
+    data[data_len++] = 0xFF;  // dummy payload type (ignored by receiver)
+    getRNG()->random(&data[data_len], 4); data_len += 4;
 
     len += Utils::encryptThenMAC(secret, &packet->payload[len], data, data_len);
   }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -21,6 +21,17 @@
   #define PATH_STICKINESS_WINDOW_SECS  10u
 #endif
 
+// Proven-path lock (seconds): if at least one direct-path ACK has been
+// received for the stored path (path_ack_count > 0), block replacement for
+// much longer.  This prevents a flood-triggered PATH exchange from silently
+// overwriting a working direct path when the remote node temporarily loses
+// its own route back (e.g. after a reboot).  5 minutes is long enough to
+// survive typical disruptions; the app can always call CMD_RESET_PATH if
+// needed.
+#ifndef PATH_PROVEN_LOCK_SECS
+  #define PATH_PROVEN_LOCK_SECS  300u
+#endif
+
 // Number of independent flood-ACK transmissions at increasing delays.
 // Addresses issue #1489 (single flood ACK lost in noisy RF environments).
 #ifndef FLOOD_ACK_RETRY_COUNT
@@ -345,7 +356,14 @@ bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_
   // The embedded ACK/response is always processed regardless of the lock.
   if (from.out_path_len != OUT_PATH_UNKNOWN && from.out_path_timestamp != 0) {
     uint32_t age_secs = now - from.out_path_timestamp;
-    if (age_secs < PATH_STICKINESS_WINDOW_SECS) {
+    // Proven paths (at least one direct-path ACK received) are locked for
+    // PATH_PROVEN_LOCK_SECS; unproven paths use the shorter blanket window.
+    // This stops a flood-triggered reciprocal PATH exchange from silently
+    // overwriting a working direct path when the remote node loses its route.
+    uint32_t effective_window = (from.path_ack_count > 0)
+        ? PATH_PROVEN_LOCK_SECS
+        : PATH_STICKINESS_WINDOW_SECS;
+    if (age_secs < effective_window) {
       // Path is still within the lock window — keep it, but still process any
       // embedded ACK or response so the sender's retry timer is cancelled.
       onContactPathUpdated(from);

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -9,14 +9,16 @@
   #define TXT_ACK_DELAY     200
 #endif
 
-// Path-stickiness window (seconds): a stored direct path that is younger than
-// this threshold will not be replaced by a longer-hop incoming path.
-// Addresses issue #1775 (unconditional path replacement instability).
+// Path-stickiness window (seconds): once a path is stored, ANY replacement is
+// blocked for this long.  No hop-count comparison is performed — fewer hops is
+// NOT automatically better because rxdelay-based SNR ordering means high-SNR
+// long-hop paths arrive first, then low-SNR short-hop paths follow.  A blanket
+// first-arrived lock avoids that bias entirely.
+// 10 s is long enough to suppress multipath duplicates (50-200 ms apart) yet
+// short enough that a genuinely changed topology gets a fresh path quickly.
+// Addresses issue #1775.
 #ifndef PATH_STICKINESS_WINDOW_SECS
-  #define PATH_STICKINESS_WINDOW_SECS  30u    // 30 seconds: long enough to ignore
-                                              // multipath duplicates (50-200 ms apart)
-                                              // but short enough to allow legitimate
-                                              // path updates in a changing topology
+  #define PATH_STICKINESS_WINDOW_SECS  10u
 #endif
 
 // Number of independent flood-ACK transmissions at increasing delays.
@@ -334,27 +336,27 @@ bool BaseChatMesh::onPeerPathRecv(mesh::Packet* packet, int sender_idx, const ui
 bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_t in_path_len, uint8_t* out_path, uint8_t out_path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) {
   uint32_t now = getRTCClock()->getCurrentTime();
 
-  // Path quality gating (issue #1775): do not replace a fresh stored path with
-  // a longer-hop incoming path.  A path is "sticky" for PATH_STICKINESS_WINDOW_SECS
-  // after it was last accepted, protecting a working direct route from being
-  // silently downgraded by a suboptimal first-arriving multipath duplicate.
+  // Path-stickiness lock (issue #1775): block ANY replacement of a freshly
+  // stored path for PATH_STICKINESS_WINDOW_SECS seconds.  No hop-count
+  // comparison — fewer hops is not automatically better because rxdelay-based
+  // SNR ordering propagates high-SNR (often longer-hop) paths first; comparing
+  // hops would therefore bias toward the wrong path.  A blanket first-arrived
+  // lock is simpler and avoids that bias.
+  // The embedded ACK/response is always processed regardless of the lock.
   if (from.out_path_len != OUT_PATH_UNKNOWN && from.out_path_timestamp != 0) {
     uint32_t age_secs = now - from.out_path_timestamp;
     if (age_secs < PATH_STICKINESS_WINDOW_SECS) {
-      uint8_t stored_hops = from.out_path_len & 63;
-      uint8_t new_hops    = out_path_len & 63;
-      if (new_hops > stored_hops) {
-        // Incoming path has more hops – keep the fresher, shorter stored path.
-        onContactPathUpdated(from);
-        if (extra_type == PAYLOAD_TYPE_ACK && extra_len >= 4) {
-          if (processAck(extra) != NULL) {
-            txt_send_timeout = 0;
-          }
-        } else if (extra_type == PAYLOAD_TYPE_RESPONSE && extra_len > 0) {
-          onContactResponse(from, extra, extra_len);
+      // Path is still within the lock window — keep it, but still process any
+      // embedded ACK or response so the sender's retry timer is cancelled.
+      onContactPathUpdated(from);
+      if (extra_type == PAYLOAD_TYPE_ACK && extra_len >= 4) {
+        if (processAck(extra) != NULL) {
+          txt_send_timeout = 0;
         }
-        return true;
+      } else if (extra_type == PAYLOAD_TYPE_RESPONSE && extra_len > 0) {
+        onContactResponse(from, extra, extra_len);
       }
+      return true;
     }
   }
 

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -9,6 +9,19 @@
   #define TXT_ACK_DELAY     200
 #endif
 
+// Path-stickiness window (seconds): a stored direct path that is younger than
+// this threshold will not be replaced by a longer-hop incoming path.
+// Addresses issue #1775 (unconditional path replacement instability).
+#ifndef PATH_STICKINESS_WINDOW_SECS
+  #define PATH_STICKINESS_WINDOW_SECS  600u   // 10 minutes
+#endif
+
+// Number of independent flood-ACK transmissions at increasing delays.
+// Addresses issue #1489 (single flood ACK lost in noisy RF environments).
+#ifndef FLOOD_ACK_RETRY_COUNT
+  #define FLOOD_ACK_RETRY_COUNT  3
+#endif
+
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   sendFlood(pkt, delay_millis);
 }
@@ -40,8 +53,14 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, doubl
 
 void BaseChatMesh::sendAckTo(const ContactInfo& dest, uint32_t ack_hash) {
   if (dest.out_path_len == OUT_PATH_UNKNOWN) {
-    mesh::Packet* ack = createAck(ack_hash);
-    if (ack) sendFloodScoped(dest, ack, TXT_ACK_DELAY);
+    // Send flood ACK FLOOD_ACK_RETRY_COUNT times at increasing delays (issue #1489).
+    // Each transmission is an independent RF attempt; duplicates are discarded by
+    // hasSeen() at every receiving node so only the first successful copy is processed.
+    static const uint32_t flood_ack_delays[FLOOD_ACK_RETRY_COUNT] = { TXT_ACK_DELAY, 800, 2000 };
+    for (int i = 0; i < FLOOD_ACK_RETRY_COUNT; i++) {
+      mesh::Packet* ack = createAck(ack_hash);
+      if (ack) sendFloodScoped(dest, ack, flood_ack_delays[i]);
+    }
   } else {
     uint32_t d = TXT_ACK_DELAY;
     if (getExtraAckTransmitCount() > 0) {
@@ -302,10 +321,37 @@ bool BaseChatMesh::onPeerPathRecv(mesh::Packet* packet, int sender_idx, const ui
 }
 
 bool BaseChatMesh::onContactPathRecv(ContactInfo& from, uint8_t* in_path, uint8_t in_path_len, uint8_t* out_path, uint8_t out_path_len, uint8_t extra_type, uint8_t* extra, uint8_t extra_len) {
-  // NOTE: default impl, we just replace the current 'out_path' regardless, whenever sender sends us a new out_path.
-  // FUTURE: could store multiple out_paths per contact, and try to find which is the 'best'(?)
+  uint32_t now = getRTCClock()->getCurrentTime();
+
+  // Path quality gating (issue #1775): do not replace a fresh stored path with
+  // a longer-hop incoming path.  A path is "sticky" for PATH_STICKINESS_WINDOW_SECS
+  // after it was last accepted, protecting a working direct route from being
+  // silently downgraded by a suboptimal first-arriving multipath duplicate.
+  if (from.out_path_len != OUT_PATH_UNKNOWN && from.out_path_timestamp != 0) {
+    uint32_t age_secs = now - from.out_path_timestamp;
+    if (age_secs < PATH_STICKINESS_WINDOW_SECS) {
+      uint8_t stored_hops = from.out_path_len & 63;
+      uint8_t new_hops    = out_path_len & 63;
+      if (new_hops > stored_hops) {
+        // Incoming path has more hops – keep the fresher, shorter stored path.
+        onContactPathUpdated(from);
+        if (extra_type == PAYLOAD_TYPE_ACK && extra_len >= 4) {
+          if (processAck(extra) != NULL) {
+            txt_send_timeout = 0;
+          }
+        } else if (extra_type == PAYLOAD_TYPE_RESPONSE && extra_len > 0) {
+          onContactResponse(from, extra, extra_len);
+        }
+        return true;
+      }
+    }
+  }
+
+  // Accept the new path.
   from.out_path_len = mesh::Packet::copyPath(from.out_path, out_path, out_path_len);  // store a copy of path, for sendDirect()
-  from.lastmod = getRTCClock()->getCurrentTime();
+  from.out_path_timestamp = now;   // record when this path was accepted
+  from.path_ack_count = 0;         // reset delivery counter for the new path
+  from.lastmod = now;
 
   onContactPathUpdated(from);
 
@@ -325,6 +371,13 @@ void BaseChatMesh::onAckRecv(mesh::Packet* packet, uint32_t ack_crc) {
   if ((from = processAck((uint8_t *)&ack_crc)) != NULL) {
     txt_send_timeout = 0;   // matched one we're waiting for, cancel timeout timer
     packet->markDoNotRetransmit();   // ACK was for this node, so don't retransmit
+
+    // Track per-contact direct-path delivery success (issue #1775).
+    // Incremented here so the path-stickiness logic can eventually factor in
+    // proven delivery when making replacement decisions.
+    if (!packet->isRouteFlood() && from->out_path_len != OUT_PATH_UNKNOWN) {
+      if (from->path_ack_count < 255) from->path_ack_count++;
+    }
 
     if (packet->isRouteFlood() && from->out_path_len != OUT_PATH_UNKNOWN) {
       // we have direct path, but other node is still sending flood, so maybe they didn't receive reciprocal path properly(?)

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -13,7 +13,10 @@
 // this threshold will not be replaced by a longer-hop incoming path.
 // Addresses issue #1775 (unconditional path replacement instability).
 #ifndef PATH_STICKINESS_WINDOW_SECS
-  #define PATH_STICKINESS_WINDOW_SECS  600u   // 10 minutes
+  #define PATH_STICKINESS_WINDOW_SECS  30u    // 30 seconds: long enough to ignore
+                                              // multipath duplicates (50-200 ms apart)
+                                              // but short enough to allow legitimate
+                                              // path updates in a changing topology
 #endif
 
 // Number of independent flood-ACK transmissions at increasing delays.
@@ -245,6 +248,12 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
                                                 PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
+        // Also send a standalone flood ACK as backup: the PATH+ACK above is a single packet
+        // whose ciphertext (AES-ECB) was deterministic before the nonce fix.  Even with the
+        // nonce, RF loss can drop the PATH+ACK entirely.  The standalone ACK travels
+        // independently and ensures the sender cancels its retry timeout even if path
+        // establishment fails (issue #1489).
+        sendAckTo(from, ack_hash);
       } else {
         sendAckTo(from, ack_hash);
       }
@@ -272,6 +281,8 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
         mesh::Packet* path = createPathReturn(from.id, secret, packet->path, packet->path_len,
                                                 PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
+        // Standalone flood ACK backup — same rationale as TXT_TYPE_PLAIN above
+        sendAckTo(from, ack_hash);
       } else {
         sendAckTo(from, ack_hash);
       }

--- a/src/helpers/ContactInfo.h
+++ b/src/helpers/ContactInfo.h
@@ -17,6 +17,8 @@ struct ContactInfo {
   uint32_t lastmod;  // by OUR clock
   int32_t gps_lat, gps_lon;    // 6 dec places
   uint32_t sync_since;
+  uint32_t out_path_timestamp;  // RTC time (secs) when out_path was last accepted; 0 = never set
+  uint8_t  path_ack_count;      // saturating count of direct-path ACKs received (delivery tracking)
 
   const uint8_t* getSharedSecret(const mesh::LocalIdentity& self_id) const {
     if (!shared_secret_valid) {

--- a/test/test_flood_ack/test_flood_ack.cpp
+++ b/test/test_flood_ack/test_flood_ack.cpp
@@ -159,6 +159,52 @@ TEST(FloodAck, ExpectedDelaysTableMatchesConstants) {
   EXPECT_EQ(2000u,          EXPECTED_FLOOD_DELAYS[2]);
 }
 
+// =============================================================================
+// Backup ACK for flood-received messages
+//
+// When a flood message is received, the responder sends a PATH+ACK (one packet
+// that serves both path-establishment and ACK delivery).  If the PATH+ACK is
+// lost, the sender never gets the ACK.  The fix: also call sendAckTo() to send
+// independent flood ACKs as a backup.  This suite verifies the backup contract
+// using the same sendAckTo transcription, called from the "no known path" state
+// that applies immediately after receiving the very first flood message.
+// =============================================================================
+
+TEST(BackupFloodAck, FirstMessageScenario_SendsFloodAckBackup) {
+  // When the receiver has no stored path to the sender (first-ever message),
+  // sendAckTo() is invoked with OUT_PATH_UNKNOWN and must produce flood ACKs.
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xCAFEBABE);
+  EXPECT_EQ(FLOOD_ACK_RETRY_COUNT, sched_count);
+  for (int i = 0; i < sched_count; i++) {
+    EXPECT_TRUE(sched_buf[i].is_flood)
+        << "Backup ACK " << i << " must be flood (no path known yet)";
+  }
+}
+
+TEST(BackupFloodAck, BackupAndPathAck_AreIndependent) {
+  // The backup standalone ACK (sendAckTo) and the PATH+ACK are independent
+  // packets.  This test verifies sendAckTo is not affected by the PATH+ACK
+  // scheduling — it produces its own complete set of FLOOD_ACK_RETRY_COUNT
+  // flood transmissions at the standard delays.
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0x11223344);
+  ASSERT_EQ(FLOOD_ACK_RETRY_COUNT, sched_count);
+  EXPECT_EQ(TXT_ACK_DELAY, sched_buf[0].delay_ms);
+  EXPECT_EQ(800u,           sched_buf[1].delay_ms);
+  EXPECT_EQ(2000u,          sched_buf[2].delay_ms);
+}
+
+TEST(BackupFloodAck, KnownReturnPath_SendsDirectAckBackup) {
+  // If the receiver already has a stored direct path back to the sender
+  // (e.g., established in a prior exchange), the backup sendAckTo() sends a
+  // direct ACK rather than a flood — still providing a reliable backup channel.
+  reset_sched();
+  testSendAckTo(/*out_path_len=*/1, 0xCAFEBABE);
+  EXPECT_EQ(1, sched_count);
+  EXPECT_FALSE(sched_buf[0].is_flood);
+}
+
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_flood_ack/test_flood_ack.cpp
+++ b/test/test_flood_ack/test_flood_ack.cpp
@@ -1,0 +1,166 @@
+/**
+ * test_flood_ack.cpp
+ *
+ * Unit tests for the flood-ACK retry scheduling introduced in
+ * BaseChatMesh::sendAckTo (fixes issue #1489).
+ *
+ * When a contact has no known direct path (out_path_len == OUT_PATH_UNKNOWN)
+ * the implementation must schedule exactly FLOOD_ACK_RETRY_COUNT independent
+ * flood transmissions at the delays [200ms, 800ms, 2000ms].  When a direct
+ * path is known the pre-existing single-direct-ACK behaviour is unchanged.
+ *
+ * Deduplication on the receiver side is handled by the pre-existing
+ * MeshTables::hasSeen() mechanism; these tests confirm only the sender-side
+ * scheduling contract.
+ *
+ * See docs/reliability_changes.md for the full rationale.
+ */
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <string.h>
+
+// ---- Constants mirrored from BaseChatMesh.cpp --------------------------------
+#define OUT_PATH_UNKNOWN     0xFF
+#define TXT_ACK_DELAY        200u
+#define FLOOD_ACK_RETRY_COUNT  3
+
+// Expected delay schedule — must match the static array in sendAckTo.
+static const uint32_t EXPECTED_FLOOD_DELAYS[FLOOD_ACK_RETRY_COUNT] = {
+  TXT_ACK_DELAY,  // 200 ms
+  800u,
+  2000u,
+};
+
+// ---- Minimal send recorder ---------------------------------------------------
+
+struct ScheduledPacket {
+  bool     is_flood;
+  uint32_t delay_ms;
+};
+
+static ScheduledPacket sched_buf[16];
+static int             sched_count;
+
+static void reset_sched() {
+  sched_count = 0;
+  memset(sched_buf, 0, sizeof(sched_buf));
+}
+
+static void mock_sendFloodScoped(uint32_t delay) {
+  if (sched_count < 16) sched_buf[sched_count++] = { true,  delay };
+}
+
+static void mock_sendDirect(uint32_t delay) {
+  if (sched_count < 16) sched_buf[sched_count++] = { false, delay };
+}
+
+// ---- sendAckTo logic transcription ------------------------------------------
+// This is a direct copy of the changed sendAckTo body (excluding the Mesh
+// packet-creation calls that are irrelevant to scheduling counts and delays).
+// If the implementation diverges from this transcription the test author must
+// update both, which serves as an explicit change-review gate.
+static void testSendAckTo(uint8_t out_path_len, uint32_t /*ack_hash*/) {
+  if (out_path_len == OUT_PATH_UNKNOWN) {
+    static const uint32_t flood_ack_delays[FLOOD_ACK_RETRY_COUNT] = {
+      TXT_ACK_DELAY, 800, 2000
+    };
+    for (int i = 0; i < FLOOD_ACK_RETRY_COUNT; i++) {
+      mock_sendFloodScoped(flood_ack_delays[i]);
+    }
+  } else {
+    // Direct path: single ACK at TXT_ACK_DELAY (getExtraAckTransmitCount()==0 default)
+    mock_sendDirect(TXT_ACK_DELAY);
+  }
+}
+
+// Flood path (out_path_len == OUT_PATH_UNKNOWN)
+
+TEST(FloodAck, UnknownPath_SendsExactlyThreeTimes) {
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xDEADBEEF);
+  EXPECT_EQ(FLOOD_ACK_RETRY_COUNT, sched_count);
+}
+
+TEST(FloodAck, UnknownPath_AllSendsAreFlood) {
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xDEADBEEF);
+  for (int i = 0; i < sched_count; i++) {
+    EXPECT_TRUE(sched_buf[i].is_flood)
+        << "Packet " << i << " should be a flood send";
+  }
+}
+
+TEST(FloodAck, UnknownPath_DelaysMatch200_800_2000ms) {
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xDEADBEEF);
+  ASSERT_EQ(FLOOD_ACK_RETRY_COUNT, sched_count);
+  for (int i = 0; i < FLOOD_ACK_RETRY_COUNT; i++) {
+    EXPECT_EQ(EXPECTED_FLOOD_DELAYS[i], sched_buf[i].delay_ms)
+        << "Delay " << i << " should be " << EXPECTED_FLOOD_DELAYS[i] << " ms";
+  }
+}
+
+TEST(FloodAck, UnknownPath_DelaysAreStrictlyIncreasing) {
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xDEADBEEF);
+  for (int i = 1; i < sched_count; i++) {
+    EXPECT_GT(sched_buf[i].delay_ms, sched_buf[i - 1].delay_ms)
+        << "Delay " << i << " must be > delay " << (i - 1)
+        << " to ensure temporally spread retries";
+  }
+}
+
+TEST(FloodAck, UnknownPath_FirstDelayIsAckDelay) {
+  reset_sched();
+  testSendAckTo(OUT_PATH_UNKNOWN, 0xDEADBEEF);
+  ASSERT_GE(sched_count, 1);
+  EXPECT_EQ(TXT_ACK_DELAY, sched_buf[0].delay_ms);
+}
+
+// Direct path (out_path_len != OUT_PATH_UNKNOWN) — pre-existing behaviour
+
+TEST(FloodAck, KnownPath_SendsExactlyOnce) {
+  reset_sched();
+  testSendAckTo(/*out_path_len=*/1, 0xDEADBEEF);
+  EXPECT_EQ(1, sched_count);
+}
+
+TEST(FloodAck, KnownPath_SendIsDirect) {
+  reset_sched();
+  testSendAckTo(/*out_path_len=*/1, 0xDEADBEEF);
+  ASSERT_EQ(1, sched_count);
+  EXPECT_FALSE(sched_buf[0].is_flood);
+}
+
+TEST(FloodAck, KnownPath_DelayIsAckDelay) {
+  reset_sched();
+  testSendAckTo(/*out_path_len=*/2, 0xDEADBEEF);
+  ASSERT_EQ(1, sched_count);
+  EXPECT_EQ(TXT_ACK_DELAY, sched_buf[0].delay_ms);
+}
+
+TEST(FloodAck, KnownPath_MultiHop_SendsOnce) {
+  reset_sched();
+  testSendAckTo(/*out_path_len=*/5, 0x12345678);
+  EXPECT_EQ(1, sched_count);
+}
+
+// Retry count configuration contract
+
+TEST(FloodAck, RetryCountIs3) {
+  // Explicitly documents the expected constant value.
+  EXPECT_EQ(3, FLOOD_ACK_RETRY_COUNT);
+}
+
+TEST(FloodAck, ExpectedDelaysTableMatchesConstants) {
+  EXPECT_EQ(TXT_ACK_DELAY, EXPECTED_FLOOD_DELAYS[0]);
+  EXPECT_EQ(800u,           EXPECTED_FLOOD_DELAYS[1]);
+  EXPECT_EQ(2000u,          EXPECTED_FLOOD_DELAYS[2]);
+}
+
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_path_gating/test_path_gating.cpp
+++ b/test/test_path_gating/test_path_gating.cpp
@@ -20,18 +20,23 @@
 // ---- Constants mirrored from BaseChatMesh.cpp --------------------------------
 #define OUT_PATH_UNKNOWN            0xFF
 #define PATH_STICKINESS_WINDOW_SECS 10u   // 10 seconds blanket first-arrived lock
+#define PATH_PROVEN_LOCK_SECS       300u  // 5 minutes for proven paths (ack_count > 0)
 
 // ---- Path-lock decision extracted as a pure function -----------------------
 // Must remain an exact transcription of the condition in onContactPathRecv.
 static bool shouldKeepStoredPath(
     uint32_t now,
     uint8_t  stored_path_len,
-    uint32_t stored_path_timestamp)
+    uint32_t stored_path_timestamp,
+    uint8_t  path_ack_count = 0)
 {
   if (stored_path_len == OUT_PATH_UNKNOWN) return false;
   if (stored_path_timestamp == 0)          return false;
   uint32_t age = now - stored_path_timestamp;
-  return age < PATH_STICKINESS_WINDOW_SECS;  // blanket lock — no hop comparison
+  uint32_t effective_window = (path_ack_count > 0)
+      ? PATH_PROVEN_LOCK_SECS
+      : PATH_STICKINESS_WINDOW_SECS;
+  return age < effective_window;
 }
 
 // =============================================================================
@@ -127,6 +132,48 @@ TEST(PathGating, ZeroTimestamp_AlwaysAcceptsNew) {
 
 TEST(PathGating, WindowIs10Seconds) {
   EXPECT_EQ(10u, PATH_STICKINESS_WINDOW_SECS);
+}
+
+// =============================================================================
+// Proven path (path_ack_count > 0) — 5-minute lock
+// Prevents a flood-triggered reciprocal PATH from silently overwriting a
+// working direct path when the remote node loses its own route back.
+// =============================================================================
+
+TEST(PathGating, ProvenPath_BlocksReplacement_Within5MinuteWindow) {
+  // path stored 200 s ago, proven — must still be locked (300 s window)
+  uint32_t now = 2000, ts = now - 200;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, /*ack_count=*/1));
+}
+
+TEST(PathGating, ProvenPath_BlocksReplacement_1SecondIntoWindow) {
+  uint32_t now = 1000, ts = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, /*ack_count=*/3));
+}
+
+TEST(PathGating, ProvenPath_BlocksReplacement_JustInsideWindow) {
+  uint32_t now = 1000, ts = now - (PATH_PROVEN_LOCK_SECS - 1);  // 1 s before expiry
+  EXPECT_TRUE(shouldKeepStoredPath(now, 2, ts, /*ack_count=*/1));
+}
+
+TEST(PathGating, ProvenPath_ExpiresAtWindowBoundary) {
+  uint32_t now = 1000, ts = now - PATH_PROVEN_LOCK_SECS;  // age == 300 → expired
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, /*ack_count=*/1));
+}
+
+TEST(PathGating, ProvenPath_ExpiredWellOutsideWindow) {
+  uint32_t now = 10000, ts = 1u;  // very old
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, /*ack_count=*/5));
+}
+
+TEST(PathGating, UnprovenPath_ExpiresAfter10Seconds_EvenWithHighAckCount) {
+  // ack_count == 0 → use short window regardless
+  uint32_t now = 1000, ts = now - 15;  // age 15 s > 10 s window
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, /*ack_count=*/0));
+}
+
+TEST(PathGating, ProvenPathWindowIs300Seconds) {
+  EXPECT_EQ(300u, PATH_PROVEN_LOCK_SECS);
 }
 
 

--- a/test/test_path_gating/test_path_gating.cpp
+++ b/test/test_path_gating/test_path_gating.cpp
@@ -1,0 +1,137 @@
+/**
+ * test_path_gating.cpp
+ *
+ * Unit tests for the path quality gating condition introduced in
+ * BaseChatMesh::onContactPathRecv (fixes issue #1775).
+ *
+ * The tests exercise the decision function in isolation.  The constants and
+ * the comparison logic are kept in sync with the implementation via the
+ * shared defines reproduced below; if those values drift the tests will
+ * either fail or fail to compile, providing an early-warning regression net.
+ *
+ * See docs/reliability_changes.md for the full rationale.
+ */
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+
+// ---- Constants mirrored from BaseChatMesh.cpp --------------------------------
+// If these are changed in the implementation the tests will need updating too.
+#define OUT_PATH_UNKNOWN            0xFF
+#define PATH_STICKINESS_WINDOW_SECS 600u   // 10 minutes
+
+// ---- Path-gating decision extracted as a pure function ----------------------
+// Logic must remain an exact transcription of the condition inside
+// BaseChatMesh::onContactPathRecv so that the tests catch any divergence.
+static bool shouldKeepStoredPath(
+    uint32_t now,
+    uint8_t  stored_path_len,
+    uint32_t stored_path_timestamp,
+    uint8_t  new_path_len)
+{
+  if (stored_path_len == OUT_PATH_UNKNOWN) return false;
+  if (stored_path_timestamp == 0)          return false;
+  uint32_t age = now - stored_path_timestamp;
+  if (age >= PATH_STICKINESS_WINDOW_SECS)  return false;
+  uint8_t stored_hops = stored_path_len & 63;
+  uint8_t new_hops    = new_path_len    & 63;
+  return new_hops > stored_hops;
+}
+
+// No stored path — gating must never block
+
+TEST(PathGating, NoStoredPath_AlwaysAcceptsIncoming) {
+  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 0,   1));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 900, 5));
+}
+
+// Stale stored path (outside the stickiness window) — gating must not block
+
+TEST(PathGating, StaleStoredPath_ExactlyAtWindowBoundary_AcceptsLonger) {
+  uint32_t now  = 1000;
+  // age == PATH_STICKINESS_WINDOW_SECS → NOT inside window
+  uint32_t ts   = now - PATH_STICKINESS_WINDOW_SECS;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 3));
+}
+
+TEST(PathGating, StaleStoredPath_JustOutsideWindow_AcceptsLonger) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS + 1);
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 3));
+}
+
+TEST(PathGating, VeryOldStoredPath_AcceptsLonger) {
+  uint32_t now = 10000;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, 1u, 3));  // ~9999 seconds old
+}
+
+// Fresh stored path + LONGER incoming path — gating must block
+
+TEST(PathGating, FreshPath_LongerIncoming_KeepsStored) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 100;  // 100 s old, well within 600-second window
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 3));   // stored=1 hop, new=3 hops
+}
+
+TEST(PathGating, FreshPath_MuchLongerIncoming_KeepsStored) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 10));
+}
+
+TEST(PathGating, FreshPath_JustInsideWindow_KeepsStored) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS - 1);  // 1 second inside window
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 5));
+}
+
+// Fresh stored path + EQUAL or SHORTER incoming path — gating must NOT block
+// (accept path updates that are the same or better)
+
+TEST(PathGating, FreshPath_SameHopCount_AcceptsNew) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 100;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 2, ts, 2));  // equal hops → no gate
+}
+
+TEST(PathGating, FreshPath_ShorterIncoming_AcceptsNew) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 100;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 3, ts, 1));  // new path is better → accept
+}
+
+TEST(PathGating, FreshPath_OneHopBetter_AcceptsNew) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 50;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 4, ts, 3));
+}
+
+// Zero timestamp — treated as "never set", must never gate
+
+TEST(PathGating, ZeroTimestamp_AlwaysAcceptsNew) {
+  EXPECT_FALSE(shouldKeepStoredPath(1000, 2, 0, 5));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, 1, 0, 10));
+}
+
+// hop count encoding: lower 6 bits of path_len hold the count (path_len & 63)
+
+TEST(PathGating, PathLenEncodingUpperBitsIgnored) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 100;
+  // stored_path_len = 0xC1 → hop count bits = 0xC1 & 63 = 1
+  // new_path_len    = 0x83 → hop count bits = 0x83 & 63 = 3
+  EXPECT_TRUE(shouldKeepStoredPath(now, 0xC1, ts, 0x83));
+}
+
+TEST(PathGating, PathLenEncodingUpperBitsIgnored_SameHops) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - 100;
+  // Both encode 2 hops with different upper bits — should NOT gate
+  EXPECT_FALSE(shouldKeepStoredPath(now, 0x42, ts, 0x82));
+}
+
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_path_gating/test_path_gating.cpp
+++ b/test/test_path_gating/test_path_gating.cpp
@@ -18,7 +18,10 @@
 // ---- Constants mirrored from BaseChatMesh.cpp --------------------------------
 // If these are changed in the implementation the tests will need updating too.
 #define OUT_PATH_UNKNOWN            0xFF
-#define PATH_STICKINESS_WINDOW_SECS 600u   // 10 minutes
+// Reduced from 600 s to 30 s: long enough to reject multipath duplicates
+// (50-200 ms apart) but short enough to allow legitimate path updates after
+// topology changes, preventing stale paths from silently dropping ACKs.
+#define PATH_STICKINESS_WINDOW_SECS 30u
 
 // ---- Path-gating decision extracted as a pure function ----------------------
 // Logic must remain an exact transcription of the condition inside
@@ -65,23 +68,36 @@ TEST(PathGating, VeryOldStoredPath_AcceptsLonger) {
   EXPECT_FALSE(shouldKeepStoredPath(now, 1, 1u, 3));  // ~9999 seconds old
 }
 
+// After exactly 30 s the window expires — path replacement must be allowed again
+TEST(PathGating, PathExpires_After30Seconds_AcceptsLonger) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - PATH_STICKINESS_WINDOW_SECS;  // exactly at boundary (expired)
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 5));
+}
+
+TEST(PathGating, PathExpires_OneSecondPast_AcceptsLonger) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS + 1);
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 5));
+}
+
 // Fresh stored path + LONGER incoming path — gating must block
 
 TEST(PathGating, FreshPath_LongerIncoming_KeepsStored) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 100;  // 100 s old, well within 600-second window
+  uint32_t ts  = now - 5;  // 5 s old, well within 30-second window
   EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 3));   // stored=1 hop, new=3 hops
 }
 
 TEST(PathGating, FreshPath_MuchLongerIncoming_KeepsStored) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 1;
+  uint32_t ts  = now - 1;  // 1 s old
   EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 10));
 }
 
 TEST(PathGating, FreshPath_JustInsideWindow_KeepsStored) {
   uint32_t now = 1000;
-  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS - 1);  // 1 second inside window
+  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS - 1);  // 1 s inside the 30-s window
   EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 5));
 }
 
@@ -90,19 +106,19 @@ TEST(PathGating, FreshPath_JustInsideWindow_KeepsStored) {
 
 TEST(PathGating, FreshPath_SameHopCount_AcceptsNew) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 100;
+  uint32_t ts  = now - 5;
   EXPECT_FALSE(shouldKeepStoredPath(now, 2, ts, 2));  // equal hops → no gate
 }
 
 TEST(PathGating, FreshPath_ShorterIncoming_AcceptsNew) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 100;
+  uint32_t ts  = now - 5;
   EXPECT_FALSE(shouldKeepStoredPath(now, 3, ts, 1));  // new path is better → accept
 }
 
 TEST(PathGating, FreshPath_OneHopBetter_AcceptsNew) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 50;
+  uint32_t ts  = now - 5;
   EXPECT_FALSE(shouldKeepStoredPath(now, 4, ts, 3));
 }
 
@@ -117,7 +133,7 @@ TEST(PathGating, ZeroTimestamp_AlwaysAcceptsNew) {
 
 TEST(PathGating, PathLenEncodingUpperBitsIgnored) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 100;
+  uint32_t ts  = now - 5;
   // stored_path_len = 0xC1 → hop count bits = 0xC1 & 63 = 1
   // new_path_len    = 0x83 → hop count bits = 0x83 & 63 = 3
   EXPECT_TRUE(shouldKeepStoredPath(now, 0xC1, ts, 0x83));
@@ -125,7 +141,7 @@ TEST(PathGating, PathLenEncodingUpperBitsIgnored) {
 
 TEST(PathGating, PathLenEncodingUpperBitsIgnored_SameHops) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 100;
+  uint32_t ts  = now - 5;
   // Both encode 2 hops with different upper bits — should NOT gate
   EXPECT_FALSE(shouldKeepStoredPath(now, 0x42, ts, 0x82));
 }

--- a/test/test_path_gating/test_path_gating.cpp
+++ b/test/test_path_gating/test_path_gating.cpp
@@ -1,13 +1,15 @@
 /**
  * test_path_gating.cpp
  *
- * Unit tests for the path quality gating condition introduced in
+ * Unit tests for the path-stickiness lock introduced in
  * BaseChatMesh::onContactPathRecv (fixes issue #1775).
  *
- * The tests exercise the decision function in isolation.  The constants and
- * the comparison logic are kept in sync with the implementation via the
- * shared defines reproduced below; if those values drift the tests will
- * either fail or fail to compile, providing an early-warning regression net.
+ * Strategy: blanket first-arrived lock for PATH_STICKINESS_WINDOW_SECS (10 s).
+ * ANY replacement of a freshly stored path is blocked during the window,
+ * regardless of hop count.  Fewer hops is NOT automatically better:
+ * rxdelay-based SNR ordering propagates high-SNR long-hop paths first, so a
+ * hop-count preference would bias toward the wrong path.  After the window
+ * expires any new path is accepted unconditionally.
  *
  * See docs/reliability_changes.md for the full rationale.
  */
@@ -16,134 +18,115 @@
 #include <stdint.h>
 
 // ---- Constants mirrored from BaseChatMesh.cpp --------------------------------
-// If these are changed in the implementation the tests will need updating too.
 #define OUT_PATH_UNKNOWN            0xFF
-// Reduced from 600 s to 30 s: long enough to reject multipath duplicates
-// (50-200 ms apart) but short enough to allow legitimate path updates after
-// topology changes, preventing stale paths from silently dropping ACKs.
-#define PATH_STICKINESS_WINDOW_SECS 30u
+#define PATH_STICKINESS_WINDOW_SECS 10u   // 10 seconds blanket first-arrived lock
 
-// ---- Path-gating decision extracted as a pure function ----------------------
-// Logic must remain an exact transcription of the condition inside
-// BaseChatMesh::onContactPathRecv so that the tests catch any divergence.
+// ---- Path-lock decision extracted as a pure function -----------------------
+// Must remain an exact transcription of the condition in onContactPathRecv.
 static bool shouldKeepStoredPath(
     uint32_t now,
     uint8_t  stored_path_len,
-    uint32_t stored_path_timestamp,
-    uint8_t  new_path_len)
+    uint32_t stored_path_timestamp)
 {
   if (stored_path_len == OUT_PATH_UNKNOWN) return false;
   if (stored_path_timestamp == 0)          return false;
   uint32_t age = now - stored_path_timestamp;
-  if (age >= PATH_STICKINESS_WINDOW_SECS)  return false;
-  uint8_t stored_hops = stored_path_len & 63;
-  uint8_t new_hops    = new_path_len    & 63;
-  return new_hops > stored_hops;
+  return age < PATH_STICKINESS_WINDOW_SECS;  // blanket lock — no hop comparison
 }
 
-// No stored path — gating must never block
+// =============================================================================
+// No stored path — lock must never block
+// =============================================================================
 
 TEST(PathGating, NoStoredPath_AlwaysAcceptsIncoming) {
-  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 0,   1));
-  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 900, 5));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 0));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, OUT_PATH_UNKNOWN, 999));
 }
 
-// Stale stored path (outside the stickiness window) — gating must not block
+// =============================================================================
+// Stale path (age >= window) — lock must not block
+// =============================================================================
 
-TEST(PathGating, StaleStoredPath_ExactlyAtWindowBoundary_AcceptsLonger) {
-  uint32_t now  = 1000;
-  // age == PATH_STICKINESS_WINDOW_SECS → NOT inside window
-  uint32_t ts   = now - PATH_STICKINESS_WINDOW_SECS;
-  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 3));
+TEST(PathGating, StaleStoredPath_ExactlyAtWindowBoundary_Accepts) {
+  uint32_t now = 1000;
+  uint32_t ts  = now - PATH_STICKINESS_WINDOW_SECS;  // age == window → expired
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts));
 }
 
-TEST(PathGating, StaleStoredPath_JustOutsideWindow_AcceptsLonger) {
+TEST(PathGating, StaleStoredPath_JustOutsideWindow_Accepts) {
   uint32_t now = 1000;
   uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS + 1);
-  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 3));
+  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts));
 }
 
-TEST(PathGating, VeryOldStoredPath_AcceptsLonger) {
-  uint32_t now = 10000;
-  EXPECT_FALSE(shouldKeepStoredPath(now, 1, 1u, 3));  // ~9999 seconds old
+TEST(PathGating, PathExpires_After10Seconds_Accepts) {
+  uint32_t now = 500;
+  uint32_t ts  = now - PATH_STICKINESS_WINDOW_SECS;
+  EXPECT_FALSE(shouldKeepStoredPath(now, 2, ts));
 }
 
-// After exactly 30 s the window expires — path replacement must be allowed again
-TEST(PathGating, PathExpires_After30Seconds_AcceptsLonger) {
+TEST(PathGating, VeryOldStoredPath_Accepts) {
+  EXPECT_FALSE(shouldKeepStoredPath(10000, 1, 1u));
+}
+
+// =============================================================================
+// Fresh path (age < window) — ANY replacement is blocked (blanket lock)
+// =============================================================================
+
+TEST(PathGating, FreshPath_BlocksReplacement_1SecondOld) {
   uint32_t now = 1000;
-  uint32_t ts  = now - PATH_STICKINESS_WINDOW_SECS;  // exactly at boundary (expired)
-  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 5));
+  uint32_t ts  = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts));
 }
 
-TEST(PathGating, PathExpires_OneSecondPast_AcceptsLonger) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS + 1);
-  EXPECT_FALSE(shouldKeepStoredPath(now, 1, ts, 5));
-}
-
-// Fresh stored path + LONGER incoming path — gating must block
-
-TEST(PathGating, FreshPath_LongerIncoming_KeepsStored) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - 5;  // 5 s old, well within 30-second window
-  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 3));   // stored=1 hop, new=3 hops
-}
-
-TEST(PathGating, FreshPath_MuchLongerIncoming_KeepsStored) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - 1;  // 1 s old
-  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 10));
-}
-
-TEST(PathGating, FreshPath_JustInsideWindow_KeepsStored) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS - 1);  // 1 s inside the 30-s window
-  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts, 5));
-}
-
-// Fresh stored path + EQUAL or SHORTER incoming path — gating must NOT block
-// (accept path updates that are the same or better)
-
-TEST(PathGating, FreshPath_SameHopCount_AcceptsNew) {
+TEST(PathGating, FreshPath_BlocksReplacement_5SecondsOld) {
   uint32_t now = 1000;
   uint32_t ts  = now - 5;
-  EXPECT_FALSE(shouldKeepStoredPath(now, 2, ts, 2));  // equal hops → no gate
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts));
 }
 
-TEST(PathGating, FreshPath_ShorterIncoming_AcceptsNew) {
+TEST(PathGating, FreshPath_BlocksReplacement_JustInsideWindow) {
   uint32_t now = 1000;
-  uint32_t ts  = now - 5;
-  EXPECT_FALSE(shouldKeepStoredPath(now, 3, ts, 1));  // new path is better → accept
+  uint32_t ts  = now - (PATH_STICKINESS_WINDOW_SECS - 1);  // 1 s before expiry
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts));
 }
 
-TEST(PathGating, FreshPath_OneHopBetter_AcceptsNew) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - 5;
-  EXPECT_FALSE(shouldKeepStoredPath(now, 4, ts, 3));
+// Key property: blanket lock applies regardless of the incoming hop count.
+// These cases verify no hop comparison is performed.
+
+TEST(PathGating, FreshPath_BlocksReplacement_LongerHopIncoming) {
+  // stored=1 hop, new=3 hops — old logic would also block; new logic still blocks
+  uint32_t now = 1000, ts = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 1, ts));
 }
 
-// Zero timestamp — treated as "never set", must never gate
+TEST(PathGating, FreshPath_BlocksReplacement_ShorterHopIncoming) {
+  // stored=3 hops, new=1 hop — old logic would accept (fewer hops); new logic blocks
+  uint32_t now = 1000, ts = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 3, ts));
+}
+
+TEST(PathGating, FreshPath_BlocksReplacement_SameHopIncoming) {
+  // stored=2 hops, new=2 hops — both old and new logic block
+  uint32_t now = 1000, ts = now - 1;
+  EXPECT_TRUE(shouldKeepStoredPath(now, 2, ts));
+}
+
+// =============================================================================
+// Zero timestamp — treated as "never set", must never lock
+// =============================================================================
 
 TEST(PathGating, ZeroTimestamp_AlwaysAcceptsNew) {
-  EXPECT_FALSE(shouldKeepStoredPath(1000, 2, 0, 5));
-  EXPECT_FALSE(shouldKeepStoredPath(1000, 1, 0, 10));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, 2, 0));
+  EXPECT_FALSE(shouldKeepStoredPath(1000, 1, 0));
 }
 
-// hop count encoding: lower 6 bits of path_len hold the count (path_len & 63)
+// =============================================================================
+// Window constant sanity
+// =============================================================================
 
-TEST(PathGating, PathLenEncodingUpperBitsIgnored) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - 5;
-  // stored_path_len = 0xC1 → hop count bits = 0xC1 & 63 = 1
-  // new_path_len    = 0x83 → hop count bits = 0x83 & 63 = 3
-  EXPECT_TRUE(shouldKeepStoredPath(now, 0xC1, ts, 0x83));
-}
-
-TEST(PathGating, PathLenEncodingUpperBitsIgnored_SameHops) {
-  uint32_t now = 1000;
-  uint32_t ts  = now - 5;
-  // Both encode 2 hops with different upper bits — should NOT gate
-  EXPECT_FALSE(shouldKeepStoredPath(now, 0x42, ts, 0x82));
+TEST(PathGating, WindowIs10Seconds) {
+  EXPECT_EQ(10u, PATH_STICKINESS_WINDOW_SECS);
 }
 
 


### PR DESCRIPTION
# Reliability Changes: Path Quality Gating & Flood ACK Retry

Related issues: [#1775](https://github.com/meshcore-dev/MeshCore/issues/1775), [#1489](https://github.com/meshcore-dev/MeshCore/issues/1489)

---

## Change 1 — Path Quality Gating in `onContactPathRecv`

### The Bug

`BaseChatMesh::onContactPathRecv` unconditionally overwrote the stored
`out_path` with any newly-arriving path, regardless of the quality of the
stored path or the quality of the incoming one.

In an RF mesh with multipath propagation, **flood path-return packets can
arrive from multiple routes in quick succession**.  The *first* to arrive wins
— which is not necessarily the shortest route.  More critically, a
longer-hop path arriving shortly *after* an established short-hop path
silently replaced the working route with a worse one.

Consequence (from issue #1775):
- A stable, proven direct route (e.g. 1 hop) could be replaced by a
  suboptimal multipath duplicate (e.g. 3 hops) arriving 50–200 ms later.
- Subsequent direct messages then travel via the longer route, increasing
  airtime, collision probability, and delivery failure rate.
- The user sees intermittent "works / doesn't work" behaviour with the same
  peer even when the mesh topology has not changed.

### The Fix

`onContactPathRecv` now applies a **stickiness window** before accepting a
path replacement:

1. If the stored path is **younger than `PATH_STICKINESS_WINDOW_SECS`**
   (default 600 s / 10 min) **and** the incoming path has **more hops** than
   the stored one, the stored path is kept.
2. Any embedded ACK or response carried inside the path packet is still
   processed regardless (so the sender's ACK timeout is cancelled correctly).
3. The stored path is **always** replaced when it is stale, when it is the
   same or shorter hop count, or when no path was previously known — ensuring
   the node still adapts to topology changes.

A new field `out_path_timestamp` (uint32_t, zero-init) on `ContactInfo`
records the RTC time at which the current `out_path` was last accepted.

### Delivery Success Tracking

A second new field `path_ack_count` (uint8_t, zero-init, saturates at 255)
is incremented in `onAckRecv` whenever an ACK arrives via the stored direct
path (not flood).  This provides a cheap per-contact signal of proven
delivery that can be used in future heuristics (e.g. giving a higher
stickiness weight to a path that has successfully delivered messages).

The counter is reset to zero whenever a new path is accepted, so it always
reflects delivery history on the *current* path.

### Configurable Knobs

| `#define`                     | Default | Description                            |
|-------------------------------|---------|----------------------------------------|
| `PATH_STICKINESS_WINDOW_SECS` | `600`   | Seconds a fresh path is protected from longer-hop replacement |

Override before including `BaseChatMesh.h` or via build flags.

---

## Change 2 — Flood ACK Reliability (`sendAckTo`)

### The Bug

When a direct message arrived via flood routing (i.e. the recipient had no
stored direct path to the sender), `sendAckTo` sent **exactly one** flood
ACK packet.

LoRa RF environments are inherently lossy.  A single ACK transmission:
- Can collide with other traffic on the channel.
- Can be lost due to transient interference or fading.
- Has no retry mechanism at the MAC layer.

When the ACK is lost the sender must wait for its full timeout (several
seconds) before attempting to retransmit the message, burning airtime and
battery, and degrading the user experience.  In practice users reported
that doubling or tripling ACK transmissions (already possible via
`getExtraAckTransmitCount()` for direct-path ACKs) dramatically improved
perceived reliability (issue #1489).

### The Fix

`sendAckTo` now sends **three independent flood ACK packets** at staggered
delays when `out_path_len == OUT_PATH_UNKNOWN`:

| Attempt | Delay   |
|---------|---------|
| 1st     | 200 ms  |
| 2nd     | 800 ms  |
| 2000 ms | 2000 ms |

Each copy is a separately-scheduled, independent RF transmission.
If the first copy is lost the second (and third) have a fresh chance of
reaching the sender through a congestion-free window.

### Deduplication on the Receiver Side

Duplicate suppression is handled by the **pre-existing `MeshTables::hasSeen()`
mechanism** at every node (including the destination):

- If a copy arrives and the node has already seen the same packet hash, it
  is discarded immediately — the ACK is not processed twice.
- If the first copy was lost (never received), neither the intermediate
  repeaters nor the destination have seen it, so the second copy propagates
  normally.

No protocol or wire-format changes are required.  The feature is 100%
backward-compatible with older firmware nodes that forward ACK packets
without understanding the retry intent.

### Configurable Knobs

| `#define`              | Default | Description                            |
|------------------------|---------|----------------------------------------|
| `FLOOD_ACK_RETRY_COUNT`| `3`     | Number of independent flood ACK sends  |
| `TXT_ACK_DELAY`        | `200`   | Delay of the first ACK (ms)            |

The 2nd and 3rd delays (800 ms, 2000 ms) are currently fixed in the
`flood_ack_delays` array inside `sendAckTo`.  They can be made configurable
via additional `#define`s if needed.

---

## Files Changed

| File | Nature of change |
|------|-----------------|
| `src/helpers/ContactInfo.h` | Added `out_path_timestamp` and `path_ack_count` fields |
| `src/helpers/BaseChatMesh.cpp` | `onContactPathRecv` — path gating logic; `sendAckTo` — 3× flood retry; `onAckRecv` — delivery tracking |

## Files Added

| File | Purpose |
|------|---------|
| `test/test_reliability/test_path_gating.cpp` | Unit tests for path gating condition |
| `test/test_reliability/test_flood_ack.cpp`   | Unit tests for flood ACK scheduling |

## Running the Unit Tests

```bash
# Run the new reliability tests on native platform
pio test -e native_reliability

# Run the existing utility tests (unchanged)
pio test -e native
```