### PR TITLE
Added flash_mode=dio to avoid boot loop when flashing using merge.bin

### DIFF
--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -1,6 +1,7 @@
 [Xiao_C6]
 extends = esp32c6_base
 board = esp32-c6-devkitm-1
+board_build.flash_mode = dio
 board_build.partitions = min_spiffs.csv ; get around 4mb flash limit
 build_flags =
   ${esp32c6_base.build_flags}


### PR DESCRIPTION
This patch is for Xiao C6.
- Added flash_mode=dio to avoid boot loop when flashing using merge.bin and Web Flasher.

Without this patch, Xiao C6 will hit below boot loop when flashing using merge.bin and Web Flasher.

```
rst:0x7 (TG0_WDT_HPSYS),boot:0x1f (SPI_FAST_FLASH_BOOT)
Saved PC:0x4001a9f4
SPIWP:0xee
mode:QIO, clock div:2
load:0x40875720,len:0x1228
ets_loader.c 67
ESP-ROM:esp32c6-20220919
Build:Sep 19 2022
rst:0x7 (TG0_WDT_HPSYS),boot:0x1f (SPI_FAST_FLASH_BOOT)
Saved PC:0x4001a9f4
SPIWP:0xee
mode:QIO, clock div:2
load:0x40875720,len:0x1228
ets_loader.c 67
```

Tested working fine now with my Xiao C6. 
PowerSaving is at 5.9mA too.
<img height="512" alt="image" src="https://github.com/user-attachments/assets/08f6ed21-a874-4683-817a-61f3c9f7cb05" />
