### PR TITLE
add Waveshare ETH32-S3-ETH board

### DIFF
--- a/boards/waveshare_esp32s3eth.json
+++ b/boards/waveshare_esp32s3eth.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+      },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "waveshare_esp32s3eth"
+  },
+  "connectivity": ["wifi", "bluetooth"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Waveshare ESP32-S3-ETH (16 MB FLASH, 8 MB PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 8388608,
+    "maximum_size": 16777216,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-ETH",
+  "vendor": "Waveshare"
+}


### PR DESCRIPTION
The Waveshare ESP32-S3-ETH is a board with : 
  - an ESP32S3 chip
  - 16MB of Flash and 8MB of PSRAM
  - an Ethernet port (with an available hat for POE)
  - an adressable led (a neopixel one)