### PR TITLE
Add Heltec T096 sensor environment

### DIFF
--- a/variants/heltec_t096/platformio.ini
+++ b/variants/heltec_t096/platformio.ini
@@ -103,6 +103,23 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 
+[env:Heltec_t096_sensor]
+extends = Heltec_t096
+build_flags =
+  ${Heltec_t096.build_flags}
+  -D ADVERT_NAME='"Heltec_t096 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ENV_PIN_SDA=PIN_WIRE1_SDA
+  -D ENV_PIN_SCL=PIN_WIRE1_SCL
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_t096.build_src_filter}
+  +<../examples/simple_sensor>
+lib_deps =
+  ${Heltec_t096.lib_deps}
+
 [env:Heltec_t096_companion_radio_ble]
 extends = Heltec_t096
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld


### PR DESCRIPTION
## Summary
- Add a Heltec T096 sensor environment using the simple sensor example.
- Configure T096 sensor I2C on Wire1 via PIN_WIRE1_SDA/PIN_WIRE1_SCL.