### PR TITLE
feat: add WiFi companion radio env for LilyGo T3-S3 V1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,6 +225,7 @@ build_companion_firmwares() {
   # build all companion firmwares
   build_all_firmwares_by_suffix "_companion_radio_usb"
   build_all_firmwares_by_suffix "_companion_radio_ble"
+  build_all_firmwares_by_suffix "_companion_radio_wifi"
 
 }
 

--- a/variants/lilygo_t3s3/platformio.ini
+++ b/variants/lilygo_t3s3/platformio.ini
@@ -178,3 +178,27 @@ lib_deps =
 extends = LilyGo_T3S3_sx1262
 build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:LilyGo_T3S3_sx1262_companion_radio_wifi]
+extends = LilyGo_T3S3_sx1262
+build_flags =
+  ${LilyGo_T3S3_sx1262.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${LilyGo_T3S3_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
## Summary

Adds `LilyGo_T3S3_sx1262_companion_radio_wifi` — a WiFi companion radio variant for the LilyGo T3-S3 V1 board. The env block is a 1:1 mirror of `Heltec_v3_companion_radio_wifi`, just swapping the `extends =` reference. No source code changes.

Also enables the `_companion_radio_wifi` suffix in `build.sh`'s companion release loop, which has the side effect of starting to ship WiFi binaries for every board that already has a `_companion_radio_wifi` env upstream but isn't currently included in the `companion-vX.Y.Z` release tag (see "Side effect" below).

Refs:
- Fills the gap explicitly noted in #387: *"Could potentially have a wifi companion mode as well but didn't add it."*
- Addresses the use case described in open issue #1134 (T3-S3 BLE companion serial-no-response → user explicitly asks for a WiFi alternative).

## Motivation

The T3-S3 V1 (ESP32-S3 + SX1262 + SSD1306 OLED) is structurally identical to the Heltec V3 from the WiFi companion stack's perspective — same MCU family, same radio, same display. The WiFi runtime path (`#ifdef WIFI_SSID` in `examples/companion_radio/main.cpp` and `examples/companion_radio/ui-new/UITask.cpp`) already ships and is exercised by `Heltec_v3_companion_radio_wifi`, `RAK_3112_companion_radio_wifi`, `T_Beam_S3_Supreme_SX1262_companion_radio_wifi`, and others. T3-S3 owners are the largest LilyGo group without a WiFi build today.

## Changes

| File | Lines | What |
|---|---|---|
| `variants/lilygo_t3s3/platformio.ini` | +24 | New `[env:LilyGo_T3S3_sx1262_companion_radio_wifi]` block. No source code changes, no custom partition CSV, no `upload_flags` override, no display/board hardware definitions to add — all inherited from the existing `[LilyGo_T3S3_sx1262]` base block. |
| `build.sh` | +1 | `build_all_firmwares_by_suffix "_companion_radio_wifi"` inside `build_companion_firmwares()`. Mirrors the existing `_usb` and `_ble` lines. |

Total: 2 files, 25 lines, 0 source code changes.

Build sizes (default board partition, no override needed):

```
RAM:   51.1% (167,476 / 327,680 B)
Flash: 77.1% (1,010,497 / 1,310,720 B)   ← fits in default.csv's 1.25 MB app slot
```

## Test plan

- [x] Compiles cleanly with stock `default.csv` partition (no override needed).
- [x] Flashed to LilyGo T3-S3 V1 hardware (433 MHz SX1262 variant).
- [x] Device boots, joins WiFi (DHCP), OLED shows IP on the home page.
- [x] TCP server reachable on port 5000 from the LAN.
- [x] MeshCore companion protocol works end-to-end over TCP — verified by sending `APP_START` (0x01) and `DEVICE_QUERY` (0x16 0x03), receiving valid `PACKET_SELF_INFO` and `PACKET_DEVICE_INFO`.
- [x] LoRa stack unaffected — position prefs survived, RF chip still functional.

## Side effect — `build.sh` blast radius

The added `build_all_firmwares_by_suffix "_companion_radio_wifi"` line is upstream of any `_wifi` env. After this lands, the next `companion-vX.Y.Z` tag will start producing release binaries for the following WiFi envs that are already in the tree but currently silently skipped by the release loop:

```
Heltec_v2_companion_radio_wifi
Heltec_v3_companion_radio_wifi
Heltec_v4_companion_radio_wifi
Heltec_v4_tft_companion_radio_wifi
Heltec_WSL3_companion_radio_wifi
heltec_tracker_v2_companion_radio_wifi
LilyGo_TBeam_1W_companion_radio_wifi
LilyGo_TLora_V2_1_1_6_companion_radio_wifi
LilyGo_T3S3_sx1262_companion_radio_wifi     ← new in this PR
nibble_screen_connect_companion_radio_wifi
RAK_3112_companion_radio_wifi
Station_G2_companion_radio_wifi
T_Beam_S3_Supreme_SX1262_companion_radio_wifi
ThinkNode_M2_companion_radio_wifi
ThinkNode_M5_companion_radio_wifi
Xiao_C3_companion_radio_wifi
Xiao_S3_WIO_companion_radio_wifi
```

If maintainers prefer to land the `build.sh` line separately so the blast radius can be sanity-checked independently of this T3-S3 env, happy to split into two PRs.

## Out of scope (acknowledged)

I'm aware of in-flight work that may eventually replace or supersede the compile-time `WIFI_SSID` / `WIFI_PWD` pattern:

- #2217 (CLI WiFi config persisted in NodePrefs)
- #1648 (WiFiManager-based provisioning)
- #1888 (CLI provisioning + reconnect)
- #1968 (runtime BLE↔WiFi/TCP transport switching)
- #2527 (security gating for WiFi builds)

If/when one of those lands, this env benefits uniformly along with all other `_companion_radio_wifi` envs. Not landing this env now means T3-S3 users have no upstream WiFi path today. Happy to drop the env later if maintainers decide to deprecate the compile-time approach repo-wide.

## Listing in the web flasher

This PR only touches the firmware repo. To make the new variant appear in `https://flasher.meshcore.io/`, a companion PR to `meshcore-dev/flasher.meshcore.io` is required (adding a `companionWifi` role + per-board firmware entry to `config.json`). I'll open that as a follow-up once this lands and the first `companion-vX.Y.Z` release contains the new binaries — same approach would benefit the other 16 WiFi envs listed above.
