### PR TITLE
Display Fix for new models of LilyGo T-Beam Supreme

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: meshcore-dev

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MeshCore provides the ability to create wireless mesh networks, similar to Mesht
 
 ## 🚀 How to Get Started
 
-- Watch the [MeshCore Intro Video](https://www.youtube.com/watch?v=t1qne8uJBAc) by Andy Kirby.
+- Watch the [MeshCore QuickStart Playlist](https://www.youtube.com/watch?v=iaFltojJrAc&list=PLshzThxhw4O4WU_iZo3NmNZOv6KMrUuF9) by The Comms Channel
 - Watch the [MeshCore Technical Presentation](https://www.youtube.com/watch?v=OwmkVkZQTf4) by Liam Cottle.
 - Read through our [Frequently Asked Questions](./docs/faq.md) and [Documentation](https://docs.meshcore.io).
 - Flash the MeshCore firmware on a supported device.

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -405,6 +405,11 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+#### View this node's firmware version
+**Usage:** `ver`
+
+---
+
 #### View this node's configured role
 **Usage:** `get role`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,7 +111,6 @@ Anyone is able to build anything they like on top of MeshCore without paying any
 - MeshCore Firmware on GitHub: [https://github.com/meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore)
 - MeshCore Companion Web App: [https://app.meshcore.nz](https://app.meshcore.nz)
 - MeshCore Map: [https://map.meshcore.io](https://map.meshcore.io)
-- Andy Kirby's [MeshCore Intro Video](https://www.youtube.com/watch?v=t1qne8uJBAc)
 - Liam Cottle's [MeshCore Technical Presentation](https://www.youtube.com/watch?v=OwmkVkZQTf4)
 
 You need LoRa hardware devices to run MeshCore firmware as clients or server (repeater and room server).
@@ -404,9 +403,6 @@ Another way to download map tiles is to use this Python script to get the tiles 
 There is also a modified script that adds additional error handling and parallel downloads:
 <https://discord.com/channels/826570251612323860/1330643963501351004/1338775811548905572>
 
-UK map tiles are available separately from Andy Kirby on his discord server:
-<https://discord.com/channels/826570251612323860/1330643963501351004/1331346597367386224>
-
 ### 4.8. Q: Where do the map tiles go?
 Once you have the tiles downloaded, copy the `\tiles` folder to the root of your T-Deck's SD card.
 
@@ -562,10 +558,6 @@ save, then run:
 pio run -e RAK_4631_Repeater
 ```
 then you'll find `firmware.zip` in `.pio/build/RAK_4631_Repeater`
-
-Andy also has a video on how to build using VS Code:
-*How to build and flash Meshcore repeater firmware | Heltec V3*
-<https://www.youtube.com/watch?v=WJvg6dt13hk> *(Link referenced in the Discord post)*
 
 ### 5.10. Q: Are there other MeshCore related open source projects?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -402,7 +402,7 @@ Another way to download map tiles is to use this Python script to get the tiles 
 <https://github.com/fistulareffigy/MTD-Script>
 
 There is also a modified script that adds additional error handling and parallel downloads:
-<https://discord.com/channels/826570251612323860/1330643963501351004/1338775811548905572>
+<https://github.com/TheBestJohn/MTD-Script>
 
 UK map tiles are available separately from Andy Kirby on his discord server:
 <https://discord.com/channels/826570251612323860/1330643963501351004/1331346597367386224>

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -50,7 +50,9 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       uint8_t path_sz = flags & 0x03;  // NEW v1.11+: lower 2 bits is path hash size
 
       uint8_t len = pkt->payload_len - i;
-      uint8_t offset = pkt->path_len << path_sz;
+      // path_len*entry_size can exceed 255 (path_len up to 63, entry_size up to 8);
+      // a uint8_t offset would wrap and steer the isHashMatch() read to the wrong place.
+      uint16_t offset = (uint16_t)pkt->path_len << path_sz;
       if (offset >= len) {   // TRACE has reached end of given path
         onTraceRecv(pkt, trace_tag, auth_code, flags, pkt->path, &pkt->payload[i], len);
       } else if (self_id.isHashMatch(&pkt->payload[i + offset], 1 << path_sz) && allowPacketForward(pkt) && !_tables->hasSeen(pkt)) {

--- a/variants/lilygo_teth_elite/TETHEliteBoard.h
+++ b/variants/lilygo_teth_elite/TETHEliteBoard.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <helpers/ESP32Board.h>
+
+class TETHEliteBoard : public ESP32Board {
+public:
+  const char* getManufacturerName() const override {
+    return "LilyGO T-ETH Elite";
+  }
+};

--- a/variants/lilygo_teth_elite/platformio.ini
+++ b/variants/lilygo_teth_elite/platformio.ini
@@ -1,0 +1,99 @@
+[LilyGo_TETH_Elite_sx1262]
+extends = esp32_base
+board = esp32s3box
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/lilygo_teth_elite
+  -D BOARD_HAS_PSRAM
+  -D LILYGO_TETH_ELITE
+  -D LILYGO_T_ETH_ELITE_ESP32S3
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D P_LORA_DIO_1=8
+  -D P_LORA_NSS=40
+  -D P_LORA_RESET=46
+  -D P_LORA_BUSY=16
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=9
+  -D P_LORA_MOSI=11
+  -D P_LORA_TX_LED=38
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=8
+  -D SX126X_RX_BOOSTED_GAIN=1
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lilygo_teth_elite>
+lib_deps =
+  ${esp32_base.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_repeater]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_room_server]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_usb]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_ble]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_teth_elite/target.cpp
+++ b/variants/lilygo_teth_elite/target.cpp
@@ -1,0 +1,43 @@
+#include <Arduino.h>
+#include "target.h"
+
+TETHEliteBoard board;
+
+static SPIClass spi(HSPI);
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+#ifndef LORA_CR
+  #define LORA_CR      5
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&spi);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/lilygo_teth_elite/target.h
+++ b/variants/lilygo_teth_elite/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include "TETHEliteBoard.h"
+
+extern TETHEliteBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
Original Problem:
A new LilyGo T-Beam Supreme with a functioning display (in terms of hardware) would not show any output on the screen when flashed with MeshCore firmware. LilyGo Hardware check firmware shows that the display does function normally.

NOTE:
While I had this issue, I pointed Claude Code at both the MeshCore repo and the LilyGo repo to diagnose and solve the issue. I understand if we do not like AI generated code in here, but this has solved my issue, and should work for other users/devices. Feel free to close if not appropriate.

Claude Code Explanation:
Found it. The V3.1 schematic has explicit notes in the OLED Display section:

▎ Slave 7 bit address definition:
▎ VHF: R52=0R R51=NC → 0x3C
▎ UHF: R52=NC R51=0R → 0x3D

The OLED's I²C address is selected by solder resistors (R51/R52) on the OLED daughter‑board, and LilyGo uses
different addresses for VHF vs UHF variants of the T‑Beam S3 Supreme V3.1.

Root cause

src/helpers/ui/SH1106Display.h:14 hard‑codes DISPLAY_ADDRESS 0x3C, and SH1106Display::begin() only ever talks to that
address. On a UHF/V3.1 board where the OLED is at 0x3D, the I²C write fails silently and the display stays dark —
even though Wire, power (ALDO1), and the SH1106 controller itself are all fine. The display is on Wire (GPIO 17/18)
and Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL) is called correctly by ESP32Board::begin(), so the bus is up — it's just
being addressed at the wrong slave.

LilyGo's hardware test firmware works on the same board because examples/Factory/LoRaBoards.cpp scans the bus and
accepts the OLED at either 0x3C or 0x3D (LoRaBoards.cpp:1015‑1028, plus the default display_address = 0x3c; // It
might be 0x3D comment at line 51).

Why one device works and one doesn't

Your two "identical" Supremes are almost certainly different sub‑variants (likely V3.0 vs V3.1, or VHF vs UHF V3.1) —
the OLED daughter‑boards have different solder‑bridge configurations. The MeshCore firmware happens to work on the
0x3C unit and fails on the 0x3D unit.

Solution:

src/helpers/ui/SH1106Display.cpp — one change: begin() now probes 0x3C and 0x3D, reads register 0x00 at each, and
skips any candidate that returns 0x80 (the QMC6310N magnetometer's chip ID). Whichever address remains is the OLED.
What was actually wrong: the I²C scan on the affected board showed devices at both 0x3C and 0x3D — the OLED was at
one, a QMC6310N magnetometer was at the other. My first patch just took the first one that ACK'd, which happened to
be the magnetometer; writing SH1106 init commands at it did nothing visible. LilyGo's factory firmware avoids this by
checking the magnetometer's chip‑ID register before deciding which is the display.