### PR TITLE
Fix upload and monitor targets for nrf52 envs

### DIFF
--- a/boards/lilygo_t_impulse_plus_nrf52840.json
+++ b/boards/lilygo_t_impulse_plus_nrf52840.json
@@ -37,7 +37,8 @@
     "onboard_tools": [
       "jlink"
     ],
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52.cfg"
   },
   "frameworks": [
     "arduino"


### PR DESCRIPTION
Fixes upload and monitor targets failing on some NRF52 envs in dev, due to openocd_target missing in lilygo_t_impulse_plus_nrf52840.json

Steps to reproduce:
``pio run -t monitor -e Heltec_t096_companion_radio_ble``

Fails with:
``AssertionError: Missing target configuration for lilygo_t_impulse_plus_nrf52840``