### PR TITLE
fix(heltec-v3): powerOff() arms user button + LoRa-DIO1 wake mask

### DIFF
--- a/variants/heltec_v3/HeltecV3Board.h
+++ b/variants/heltec_v3/HeltecV3Board.h
@@ -76,7 +76,7 @@ public:
   }
 
   void powerOff() override {
-    enterDeepSleep(0);
+    enterDeepSleep(0, PIN_USER_BTN);
   }
 
   uint16_t getBattMilliVolts() override {


### PR DESCRIPTION
HeltecV3Board::powerOff() calls enterDeepSleep(0) which falls through to the default `pin_wake_btn = -1`. The wake mask thus arms only LoRa-DIO1 -- the user button is never armed despite typical long-hold-button-to-hibernate UX (the OLED prompt commonly says "Tap button to wake").

**Discovery context:** the identical bug shape on HeltecV4Board bit our downstream conduit firmware fork (`akkerkid/meshomatic-conduit-firmware`) in May 2026 and shipped to ~80 conduit units before we caught it. While porting our conduit feature work to V3 in May 2026 we found V3 carrying the same bug -- mirroring the V4 fix is one line.

## Fix

`variants/heltec_v3/HeltecV3Board.h`:

```cpp
void powerOff() override {
  enterDeepSleep(0, PIN_USER_BTN);
}
```

Pre-fix:

```cpp
void powerOff() override {
  enterDeepSleep(0);  // falls through to pin_wake_btn = -1; only LoRa-DIO1 armed
}
```

## Scope

- Single-line change, no API change. `enterDeepSleep`'s existing `int pin_wake_btn = -1` default stays for any other caller that genuinely wants radio-only wake.
- Doesn't touch any other Heltec board class. Sibling variants (V2, TrackerV2, T096, T190, E213, E290, RAK3112, ThinknodeM2/M5, StationG2, TDeck, etc.) may have the same shape but are out of scope for this PR -- happy to file follow-ups if it makes sense.
- No compile breakage. PIN_USER_BTN is defined in `variants/heltec_v3/platformio.ini` via `-D PIN_USER_BTN=0` build flag; the symbol is already in scope in HeltecV3Board.h. Verified locally with `build.sh build-firmware Heltec_v3_repeater` -- SUCCESS, 20.78s.

Happy to address review feedback. Filed with DCO sign-off.