### PR TITLE
Companion repeat: update to more usable default EU frequency

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -987,7 +987,7 @@ static FreqRange repeat_freq_ranges[] = {
   ALLOWED_REPEAT_FREQ_RANGE
   #else
   { 433000, 433000 },
-  { 869000, 869000 },
+  { 869495, 869495 },
   { 918000, 918000 }
   #endif
 };


### PR DESCRIPTION
869.495 is in 869.4 to 869.65 range which does have 10% duty cycle and 500mW ERP.