### PR TITLE
Station G2 GPS improvements

### DIFF
--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -71,6 +71,19 @@ void UITask::renderCurrScreen() {
     _display->setColor(DisplayDriver::GREEN);
     _display->print(_node_prefs->node_name);
 
+#if ENV_INCLUDE_GPS
+    if (_gps && _gps->isEnabled()) {
+      _display->setCursor(0, 10);
+      _display->setColor(DisplayDriver::YELLOW);
+      if (_gps->isValid()) {
+        sprintf(tmp, "GPS: fix %ld sat", _gps->satellitesCount());
+      } else {
+        sprintf(tmp, "GPS: no fix %ld sat", _gps->satellitesCount());
+      }
+      _display->print(tmp);
+    }
+#endif
+
     // freq / sf
     _display->setCursor(0, 20);
     _display->setColor(DisplayDriver::YELLOW);

--- a/examples/simple_repeater/UITask.h
+++ b/examples/simple_repeater/UITask.h
@@ -3,17 +3,27 @@
 #include <helpers/ui/DisplayDriver.h>
 #include <helpers/CommonCLI.h>
 
+#if ENV_INCLUDE_GPS
+#include <helpers/sensors/LocationProvider.h>
+#endif
+
 class UITask {
   DisplayDriver* _display;
   unsigned long _next_read, _next_refresh, _auto_off;
   int _prevBtnState;
   NodePrefs* _node_prefs;
   char _version_info[32];
+#if ENV_INCLUDE_GPS
+  LocationProvider* _gps = nullptr;
+#endif
 
   void renderCurrScreen();
 public:
   UITask(DisplayDriver& display) : _display(&display) { _next_read = _next_refresh = 0; }
   void begin(NodePrefs* node_prefs, const char* build_date, const char* firmware_version);
+#if ENV_INCLUDE_GPS
+  void setGPS(LocationProvider* gps) { _gps = gps; }
+#endif
 
   void loop();
 };

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -97,6 +97,9 @@ void setup() {
 
 #ifdef DISPLAY_CLASS
   ui_task.begin(the_mesh.getNodePrefs(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
+  #if ENV_INCLUDE_GPS
+  ui_task.setGPS(sensors.getLocationProvider());
+  #endif
 #endif
 
   // send out initial zero hop Advertisement to the mesh

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -412,7 +412,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
         bool enabled = l->isEnabled(); // is EN pin on ?
         bool fix = l->isValid();       // has fix ?
         int sats = l->satellitesCount();
-        bool active = !strcmp(_sensors->getSettingByKey("gps"), "1");
+        const char* gps_val = _sensors->getSettingByKey("gps");
+        bool active = (gps_val != NULL) && !strcmp(gps_val, "1");
         if (enabled) {
           sprintf(reply, "on, %s, %s, %d sats",
             active?"active":"deactivated",

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -614,8 +614,10 @@ void EnvironmentSensorManager::initBasicGPS() {
     MESH_DEBUG_PRINTLN("No GPS wake/reset pin found for this board. Continuing on...");
   #endif
 
+#ifndef ENV_SKIP_GPS_DETECT
   // Give GPS a moment to power up and send data
   delay(1000);
+#endif
 
   // We'll consider GPS detected if we see any data on Serial1
 #ifdef ENV_SKIP_GPS_DETECT

--- a/variants/station_g2/StationG2Board.h
+++ b/variants/station_g2/StationG2Board.h
@@ -4,8 +4,6 @@
 #include <helpers/ESP32Board.h>
 #include <driver/rtc_io.h>
 
-#define ENV_SKIP_GPS_DETECT
-
 class StationG2Board : public ESP32Board {
 public:
   void begin() {

--- a/variants/station_g2/StationG2Board.h
+++ b/variants/station_g2/StationG2Board.h
@@ -4,6 +4,8 @@
 #include <helpers/ESP32Board.h>
 #include <driver/rtc_io.h>
 
+#define ENV_SKIP_GPS_DETECT
+
 class StationG2Board : public ESP32Board {
 public:
   void begin() {

--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -7,6 +7,7 @@ build_flags =
   -I variants/station_g2
   -I src/helpers/ui
   -D STATION_G2
+  -D ENV_SKIP_GPS_DETECT
   -D USE_SX1262
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper


### PR DESCRIPTION
commoncli: avoid null pointer deref when gps_detected is false
examples/simple_repeater: add a 'gps:' display line only when GPS is enabled.
environmentsensormanager: no need to delay(1000) if gps is not enabled.

This is made worse because of #2258.