### PR TITLE
Station G2: use correct partition sizes

### DIFF
--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -1,6 +1,7 @@
 [Station_G2]
 extends = esp32_base
 board = station-g2
+board_build.partitions = default_16MB.csv
 build_flags =
   ${esp32_base.build_flags}
   ${sensor_base.build_flags}


### PR DESCRIPTION
G2's [use the ESP32-S3 with 16mb flash and 8mb psram](https://wiki.bqvoy.com/en/meshtastic/station-g2#features-comparison-of-station-g2-and-station-g1), so they should default to larger partitions.