### PR TITLE
feat(xiao_s3): add kiss modem env

### DIFF
--- a/variants/xiao_s3/platformio.ini
+++ b/variants/xiao_s3/platformio.ini
@@ -152,3 +152,8 @@ build_flags =
 lib_deps =
   ${Xiao_S3.lib_deps}
   ${esp32_ota.lib_deps}
+
+[env:Xiao_S3_kiss_modem]
+extends = Xiao_S3
+build_src_filter = ${Xiao_S3.build_src_filter}
+  +<../examples/kiss_modem/>


### PR DESCRIPTION
Adds kiss modem environment for Xiao S3, following the same pattern as #2432.

Build verified (RAM: 7.5%, Flash: 16.5%). Hardware not tested.