### PR TITLE
Feature/mainboard boot complete hook

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -238,6 +238,8 @@ void setup() {
 #ifdef DISPLAY_CLASS
   ui_task.begin(disp, &sensors, the_mesh.getNodePrefs());  // still want to pass this in as dependency, as prefs might be moved
 #endif
+
+  board.bootComplete();
 }
 
 void loop() {

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -239,7 +239,7 @@ void setup() {
   ui_task.begin(disp, &sensors, the_mesh.getNodePrefs());  // still want to pass this in as dependency, as prefs might be moved
 #endif
 
-  board.bootComplete();
+  board.onBootComplete();
 }
 
 void loop() {

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -120,7 +120,7 @@ void setup() {
   modem->setGetStatsCallback(onGetStats);
   modem->begin();
 
-  board.bootComplete();
+  board.onBootComplete();
 }
 
 void loop() {

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -119,6 +119,8 @@ void setup() {
   modem->setGetCurrentRssiCallback(onGetCurrentRssi);
   modem->setGetStatsCallback(onGetStats);
   modem->begin();
+
+  board.bootComplete();
 }
 
 void loop() {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -104,7 +104,7 @@ void setup() {
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
 
-  board.bootComplete();
+  board.onBootComplete();
 }
 
 void loop() {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -103,6 +103,8 @@ void setup() {
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
+
+  board.bootComplete();
 }
 
 void loop() {

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -80,6 +80,8 @@ void setup() {
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
+
+  board.bootComplete();
 }
 
 void loop() {

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -81,7 +81,7 @@ void setup() {
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
 
-  board.bootComplete();
+  board.onBootComplete();
 }
 
 void loop() {

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -52,6 +52,10 @@ public:
   virtual void onAfterTransmit() { }
   virtual void reboot() = 0;
   virtual void powerOff() { /* no op */ }
+  // Called by example setup() functions to signal that boot is complete.
+  // Boards may override to stop a boot-indicator LED sequence or similar.
+  // Default no-op: boards that don't care need not implement anything.
+  virtual void bootComplete() { /* no op */ }
   virtual void sleep(uint32_t secs)  { /* no op */ }
   virtual uint32_t getGpio() { return 0; }
   virtual void setGpio(uint32_t values) {}

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -55,7 +55,7 @@ public:
   // Called by example setup() functions to signal that boot is complete.
   // Boards may override to stop a boot-indicator LED sequence or similar.
   // Default no-op: boards that don't care need not implement anything.
-  virtual void bootComplete() { /* no op */ }
+  virtual void onBootComplete() { /* no op */ }
   virtual void sleep(uint32_t secs)  { /* no op */ }
   virtual uint32_t getGpio() { return 0; }
   virtual void setGpio(uint32_t values) {}


### PR DESCRIPTION
Adds `virtual void onbootComplete()` to `MainBoard` as a lifecycle hook (default no-op), called from each example's `setup()` at completion.

**Zero behavior change** for any existing board. Every board inherits the no-op default, so calling `onbootComplete()` is identical to not calling it for boards that don't override.

**Why this exists**: sets up upcoming variant-specific PRs (ThinkNode M6, SenseCAP Solar) that add LED feedback during boot. The visual cue tells users the device is busy starting up, preventing confusion when button presses during boot don't register, and providing positive feedback that the device is successfully powering on.

**Out of scope**: no LED behavior is added by this PR; that's deferred to the variant PRs.

Follows the existing `MainBoard` convention of `virtual <name>() { /* no op */ }` extension points (see `powerOff()`, `sleep()`, `onBeforeTransmit()`, etc.).