### PR TITLE
Add WiFi provisioning, admin web UI, MQTT publisher, and chat decoder for ESP32-S3 boards

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: meshcore-dev

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MeshCore provides the ability to create wireless mesh networks, similar to Mesht
 
 ## 🚀 How to Get Started
 
-- Watch the [MeshCore Intro Video](https://www.youtube.com/watch?v=t1qne8uJBAc) by Andy Kirby.
+- Watch the [MeshCore QuickStart Playlist](https://www.youtube.com/watch?v=iaFltojJrAc&list=PLshzThxhw4O4WU_iZo3NmNZOv6KMrUuF9) by The Comms Channel
 - Watch the [MeshCore Technical Presentation](https://www.youtube.com/watch?v=OwmkVkZQTf4) by Liam Cottle.
 - Read through our [Frequently Asked Questions](./docs/faq.md) and [Documentation](https://docs.meshcore.io).
 - Flash the MeshCore firmware on a supported device.

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -405,6 +405,11 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+#### View this node's firmware version
+**Usage:** `ver`
+
+---
+
 #### View this node's configured role
 **Usage:** `get role`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,7 +111,6 @@ Anyone is able to build anything they like on top of MeshCore without paying any
 - MeshCore Firmware on GitHub: [https://github.com/meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore)
 - MeshCore Companion Web App: [https://app.meshcore.nz](https://app.meshcore.nz)
 - MeshCore Map: [https://map.meshcore.io](https://map.meshcore.io)
-- Andy Kirby's [MeshCore Intro Video](https://www.youtube.com/watch?v=t1qne8uJBAc)
 - Liam Cottle's [MeshCore Technical Presentation](https://www.youtube.com/watch?v=OwmkVkZQTf4)
 
 You need LoRa hardware devices to run MeshCore firmware as clients or server (repeater and room server).
@@ -404,9 +403,6 @@ Another way to download map tiles is to use this Python script to get the tiles 
 There is also a modified script that adds additional error handling and parallel downloads:
 <https://discord.com/channels/826570251612323860/1330643963501351004/1338775811548905572>
 
-UK map tiles are available separately from Andy Kirby on his discord server:
-<https://discord.com/channels/826570251612323860/1330643963501351004/1331346597367386224>
-
 ### 4.8. Q: Where do the map tiles go?
 Once you have the tiles downloaded, copy the `\tiles` folder to the root of your T-Deck's SD card.
 
@@ -562,10 +558,6 @@ save, then run:
 pio run -e RAK_4631_Repeater
 ```
 then you'll find `firmware.zip` in `.pio/build/RAK_4631_Repeater`
-
-Andy also has a video on how to build using VS Code:
-*How to build and flash Meshcore repeater firmware | Heltec V3*
-<https://www.youtube.com/watch?v=WJvg6dt13hk> *(Link referenced in the Discord post)*
 
 ### 5.10. Q: Are there other MeshCore related open source projects?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -401,7 +401,7 @@ Another way to download map tiles is to use this Python script to get the tiles 
 <https://github.com/fistulareffigy/MTD-Script>
 
 There is also a modified script that adds additional error handling and parallel downloads:
-<https://discord.com/channels/826570251612323860/1330643963501351004/1338775811548905572>
+<https://github.com/TheBestJohn/MTD-Script>
 
 ### 4.8. Q: Where do the map tiles go?
 Once you have the tiles downloaded, copy the `\tiles` folder to the root of your T-Deck's SD card.

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -35,11 +35,27 @@ static uint32_t _atoi(const char* sp) {
 #endif
 
 #ifdef ESP32
-  #ifdef WIFI_SSID
+  #if defined(WIFI_PROVISIONING) || defined(WIFI_SSID)
     #include <helpers/esp32/SerialWifiInterface.h>
     SerialWifiInterface serial_interface;
     #ifndef TCP_PORT
       #define TCP_PORT 5000
+    #endif
+    #ifdef WIFI_PROVISIONING
+      #include <helpers/esp32/WifiProvisioning.h>
+      static WifiProvisioning::Config _wifi_cfg = []() {
+        WifiProvisioning::Config c;
+        c.ap_password = "meshcore123";
+        #ifdef PIN_USER_BTN
+        c.user_btn_pin = PIN_USER_BTN;
+        #endif
+        #ifdef WIFI_SSID
+        c.bootstrap_ssid = WIFI_SSID;
+        c.bootstrap_password = WIFI_PWD;
+        #endif
+        return c;
+      }();
+      WifiProvisioning wifi_provisioning(_wifi_cfg);
     #endif
   #elif defined(BLE_PIN_CODE)
     #include <helpers/esp32/SerialBLEInterface.h>
@@ -199,7 +215,11 @@ void setup() {
     #endif
   );
 
-#ifdef WIFI_SSID
+#if defined(WIFI_PROVISIONING)
+  board.setInhibitSleep(true);   // prevent sleep when WiFi is active
+  wifi_provisioning.begin();
+  serial_interface.begin(TCP_PORT);
+#elif defined(WIFI_SSID)
   board.setInhibitSleep(true);   // prevent sleep when WiFi is active
   WiFi.setAutoReconnect(true);
 
@@ -247,6 +267,9 @@ void loop() {
   sensors.loop();
 #ifdef DISPLAY_CLASS
   ui_task.loop();
+#endif
+#ifdef WIFI_PROVISIONING
+  wifi_provisioning.loop();
 #endif
   rtc_clock.tick();
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1,6 +1,14 @@
 #include "MyMesh.h"
 #include <algorithm>
 
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  #include <base64.hpp>
+  #include <Preferences.h>
+  // Well-known PSK for MeshCore's default "Public" group channel.
+  // Sourced from companion_radio/MyMesh.cpp.
+  #define REPEATER_PUBLIC_GROUP_PSK "izOH6cXN6mrJ5e26oRXNcg=="
+#endif
+
 /* ------------------------------ Config -------------------------------- */
 
 #ifndef LORA_FREQ
@@ -428,6 +436,25 @@ void MyMesh::sendFloodReply(mesh::Packet* packet, unsigned long delay_millis, ui
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
+
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  // Drop ADVERTs from blacklisted node names.
+  if (_num_block_patterns > 0 && packet->getPayloadType() == PAYLOAD_TYPE_ADVERT) {
+    const int app_off = PUB_KEY_SIZE + 4 + SIGNATURE_SIZE;
+    if (packet->payload_len > app_off) {
+      AdvertDataParser ap(&packet->payload[app_off], packet->payload_len - app_off);
+      if (ap.isValid() && ap.hasName()) {
+        int hit = _matchesBlockPattern(ap.getName());
+        if (hit >= 0) {
+          _block_hits[hit]++;
+          MESH_DEBUG_PRINTLN("blacklist: dropping ADVERT from '%s' (pattern '%s')", ap.getName(), _block_patterns[hit]);
+          return false;
+        }
+      }
+    }
+  }
+#endif
+
   if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
   if (packet->isRouteFlood() && recv_pkt_region == NULL) {
     MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
@@ -466,6 +493,14 @@ void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
   mesh::Utils::printHex(Serial, raw, len);
   Serial.println();
 #endif
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  extern void wifiAdminPushRxPacket(float snr, float rssi, const uint8_t* raw, int len);
+  wifiAdminPushRxPacket(snr, rssi, raw, len);
+#endif
+#if defined(ESP_PLATFORM) && defined(MQTT_PUBLISHER)
+  extern void mqttPublishRawPacket(float snr, float rssi, const uint8_t* raw, int len);
+  mqttPublishRawPacket(snr, rssi, raw, len);
+#endif
 }
 
 void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
@@ -498,6 +533,23 @@ void MyMesh::logTx(mesh::Packet *pkt, int len) {
 #ifdef WITH_BRIDGE
   if (_prefs.bridge_pkt_src == 0) {
     bridge.sendPacket(pkt);
+  }
+#endif
+
+#if (defined(ESP_PLATFORM) && (defined(MQTT_PUBLISHER) || defined(WIFI_PROVISIONING)))
+  {
+    uint8_t buf[256];
+    uint8_t wire_len = pkt->writeTo(buf);
+    if (wire_len > 0) {
+      #if defined(WIFI_PROVISIONING)
+      extern void wifiAdminPushTxPacket(const uint8_t* raw, int len);
+      wifiAdminPushTxPacket(buf, wire_len);
+      #endif
+      #if defined(MQTT_PUBLISHER)
+      extern void mqttPublishTxPacket(const uint8_t* raw, int len);
+      mqttPublishTxPacket(buf, wire_len);
+      #endif
+    }
   }
 #endif
 
@@ -632,6 +684,16 @@ static bool isShare(const mesh::Packet *packet) {
 
 void MyMesh::onAdvertRecv(mesh::Packet *packet, const mesh::Identity &id, uint32_t timestamp,
                           const uint8_t *app_data, size_t app_data_len) {
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  // If this advert matches the blacklist, skip neighbour-table insertion entirely.
+  // allowPacketForward will also drop the forwarding side; this prevents stats churn.
+  if (_num_block_patterns > 0) {
+    AdvertDataParser ap(app_data, app_data_len);
+    if (ap.isValid() && ap.hasName() && _matchesBlockPattern(ap.getName()) >= 0) {
+      return;
+    }
+  }
+#endif
   mesh::Mesh::onAdvertRecv(packet, id, timestamp, app_data, app_data_len); // chain to super impl
 
   // if this a zero hop advert (and not via 'Share'), add it to neighbours
@@ -918,6 +980,221 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   memset(default_scope.key, 0, sizeof(default_scope.key));
 }
 
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+namespace {
+  // Stash the base64 PSK alongside the in-memory channel so we can re-serialize
+  // user-added channels back to NVS without round-tripping bytes through base64.
+  // Kept as a parallel static array to avoid changing GroupChannel's footprint.
+  char _chat_chan_psks[8][48];   // 8 == MAX_CHAT_CHANS
+  bool _chat_chan_persistent[8] = {false};   // true for user-added (NVS-stored)
+}
+
+bool MyMesh::addChatChannel(const char* name, const char* psk_base64) {
+  if (_num_chat_chans >= MAX_CHAT_CHANS) return false;
+  // Reject duplicate names so the table stays sane after repeated saves.
+  for (int i = 0; i < _num_chat_chans; i++) {
+    if (strcmp(_chat_chan_names[i], name) == 0) return false;
+  }
+  mesh::GroupChannel& ch = _chat_chans[_num_chat_chans];
+  memset(ch.secret, 0, sizeof(ch.secret));
+  int len = decode_base64((unsigned char*)psk_base64, strlen(psk_base64), ch.secret);
+  if (len != 16 && len != 32) return false;
+  mesh::Utils::sha256(ch.hash, sizeof(ch.hash), ch.secret, len);
+  strncpy(_chat_chan_names[_num_chat_chans], name, sizeof(_chat_chan_names[0]) - 1);
+  _chat_chan_names[_num_chat_chans][sizeof(_chat_chan_names[0]) - 1] = 0;
+  strncpy(_chat_chan_psks[_num_chat_chans], psk_base64, sizeof(_chat_chan_psks[0]) - 1);
+  _chat_chan_psks[_num_chat_chans][sizeof(_chat_chan_psks[0]) - 1] = 0;
+  _chat_chan_persistent[_num_chat_chans] = false;
+  _num_chat_chans++;
+  return true;
+}
+
+void MyMesh::loadPersistentChatChannels() {
+  Preferences p;
+  p.begin("mc-chans", true);
+  String blob = p.getString("list", "");
+  p.end();
+  // Format: "name1|psk1\nname2|psk2\n..."
+  int start = 0;
+  while (start < (int)blob.length() && _num_chat_chans < MAX_CHAT_CHANS) {
+    int nl = blob.indexOf('\n', start);
+    if (nl < 0) nl = blob.length();
+    int bar = blob.indexOf('|', start);
+    if (bar > start && bar < nl) {
+      String name = blob.substring(start, bar);
+      String psk  = blob.substring(bar + 1, nl);
+      if (addChatChannel(name.c_str(), psk.c_str())) {
+        _chat_chan_persistent[_num_chat_chans - 1] = true;
+      }
+    }
+    start = nl + 1;
+  }
+}
+
+bool MyMesh::addPersistentChatChannel(const char* name, const char* psk_base64) {
+  if (!addChatChannel(name, psk_base64)) return false;
+  _chat_chan_persistent[_num_chat_chans - 1] = true;
+  // Re-serialize all persistent channels.
+  String blob;
+  for (int i = 0; i < _num_chat_chans; i++) {
+    if (!_chat_chan_persistent[i]) continue;
+    blob += _chat_chan_names[i]; blob += '|'; blob += _chat_chan_psks[i]; blob += '\n';
+  }
+  Preferences p;
+  p.begin("mc-chans", false);
+  p.putString("list", blob);
+  p.end();
+  return true;
+}
+
+namespace {
+// Simple glob matcher: '*' matches any run of chars, '?' matches any single char.
+bool _wildMatch(const char* pat, const char* s) {
+  if (!*pat) return !*s;
+  if (*pat == '*') {
+    while (*pat == '*') pat++;
+    if (!*pat) return true;
+    while (*s) {
+      if (_wildMatch(pat, s)) return true;
+      s++;
+    }
+    return false;
+  }
+  if (!*s) return false;
+  if (*pat == '?' || *pat == *s) return _wildMatch(pat + 1, s + 1);
+  return false;
+}
+}
+
+int MyMesh::_matchesBlockPattern(const char* name) {
+  if (!name || !*name) return -1;
+  for (int i = 0; i < _num_block_patterns; i++) {
+    if (_wildMatch(_block_patterns[i], name)) return i;
+  }
+  return -1;
+}
+
+bool MyMesh::addBlockPattern(const char* pattern) {
+  if (!pattern || !*pattern) return false;
+  if (_num_block_patterns >= MAX_BLOCK_PATTERNS) return false;
+  for (int i = 0; i < _num_block_patterns; i++) {
+    if (strcmp(_block_patterns[i], pattern) == 0) return false;   // duplicate
+  }
+  strncpy(_block_patterns[_num_block_patterns], pattern, sizeof(_block_patterns[0]) - 1);
+  _block_patterns[_num_block_patterns][sizeof(_block_patterns[0]) - 1] = 0;
+  _block_hits[_num_block_patterns] = 0;
+  _num_block_patterns++;
+  // Re-serialize to NVS.
+  String blob;
+  for (int i = 0; i < _num_block_patterns; i++) { blob += _block_patterns[i]; blob += '\n'; }
+  Preferences p; p.begin("mc-block", false); p.putString("list", blob); p.end();
+  return true;
+}
+
+bool MyMesh::removeBlockPattern(const char* pattern) {
+  if (!pattern) return false;
+  for (int i = 0; i < _num_block_patterns; i++) {
+    if (strcmp(_block_patterns[i], pattern) == 0) {
+      for (int j = i; j < _num_block_patterns - 1; j++) {
+        memcpy(_block_patterns[j], _block_patterns[j + 1], sizeof(_block_patterns[0]));
+        _block_hits[j] = _block_hits[j + 1];
+      }
+      _num_block_patterns--;
+      String blob;
+      for (int k = 0; k < _num_block_patterns; k++) { blob += _block_patterns[k]; blob += '\n'; }
+      Preferences p; p.begin("mc-block", false); p.putString("list", blob); p.end();
+      return true;
+    }
+  }
+  return false;
+}
+
+void MyMesh::loadBlockPatterns() {
+  Preferences p; p.begin("mc-block", true);
+  String blob = p.getString("list", "");
+  p.end();
+  int start = 0;
+  while (start < (int)blob.length() && _num_block_patterns < MAX_BLOCK_PATTERNS) {
+    int nl = blob.indexOf('\n', start);
+    if (nl < 0) nl = blob.length();
+    if (nl > start) {
+      String pat = blob.substring(start, nl);
+      strncpy(_block_patterns[_num_block_patterns], pat.c_str(), sizeof(_block_patterns[0]) - 1);
+      _block_patterns[_num_block_patterns][sizeof(_block_patterns[0]) - 1] = 0;
+      _block_hits[_num_block_patterns] = 0;
+      _num_block_patterns++;
+    }
+    start = nl + 1;
+  }
+}
+
+void MyMesh::listBlockPatterns(char* out, size_t out_size) {
+  char* dp = out; size_t remain = out_size;
+  for (int i = 0; i < _num_block_patterns && remain > 16; i++) {
+    int n = snprintf(dp, remain, "%s|%u\n", _block_patterns[i], (unsigned)_block_hits[i]);
+    if (n <= 0 || (size_t)n >= remain) break;
+    dp += n; remain -= n;
+  }
+  *dp = 0;
+}
+
+void MyMesh::listChatChannels(char* out, size_t out_size) {
+  char* dp = out;
+  size_t remain = out_size;
+  for (int i = 0; i < _num_chat_chans && remain > 16; i++) {
+    int n = snprintf(dp, remain, "%s|%02x|%c\n",
+                     _chat_chan_names[i],
+                     (unsigned)_chat_chans[i].hash[0],
+                     _chat_chan_persistent[i] ? 'p' : 'b');
+    if (n <= 0 || (size_t)n >= remain) break;
+    dp += n; remain -= n;
+  }
+  *dp = 0;
+}
+
+int MyMesh::searchChannelsByHash(const uint8_t* hash, mesh::GroupChannel channels[], int max_matches) {
+  int n = 0;
+  for (int i = 0; i < _num_chat_chans && n < max_matches; i++) {
+    if (memcmp(_chat_chans[i].hash, hash, PATH_HASH_SIZE) == 0) {
+      channels[n++] = _chat_chans[i];
+    }
+  }
+  return n;
+}
+
+void MyMesh::onGroupDataRecv(mesh::Packet* packet, uint8_t type, const mesh::GroupChannel& channel, uint8_t* data, size_t len) {
+  if (type != PAYLOAD_TYPE_GRP_TXT || len < 5) return;
+  uint8_t txt_type = data[4] >> 2;
+  if (txt_type != 0) return;   // only plain text for now
+
+  uint32_t timestamp;
+  memcpy(&timestamp, data, 4);
+  data[len] = 0;   // null-terminate (Mesh.cpp's decrypt buffer has the slack)
+  const char* body = (const char*)&data[5];
+
+  // Resolve channel name by comparing secret back to our table.
+  const char* chan_name = "?";
+  for (int i = 0; i < _num_chat_chans; i++) {
+    if (memcmp(_chat_chans[i].secret, channel.secret, sizeof(channel.secret)) == 0) {
+      chan_name = _chat_chan_names[i]; break;
+    }
+  }
+
+  // Split "Sender: text" if present.
+  const char* sep = strstr(body, ": ");
+  char sender[24]; sender[0] = 0;
+  const char* text = body;
+  if (sep && (sep - body) < (int)sizeof(sender)) {
+    size_t n = sep - body;
+    memcpy(sender, body, n); sender[n] = 0;
+    text = sep + 2;
+  }
+
+  extern void wifiAdminPushChat(const char* channel, const char* sender, const char* text, uint32_t timestamp);
+  wifiAdminPushChat(chan_name, sender, text, timestamp);
+}
+#endif
+
 void MyMesh::begin(FILESYSTEM *fs) {
   mesh::Mesh::begin();
   _fs = fs;
@@ -967,6 +1244,12 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
 #if ENV_INCLUDE_GPS == 1
   applyGpsPrefs();
+#endif
+
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  addChatChannel("Public", REPEATER_PUBLIC_GROUP_PSK);
+  loadPersistentChatChannels();
+  loadBlockPatterns();
 #endif
 }
 

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -165,6 +165,25 @@ protected:
 
   bool filterRecvFloodPacket(mesh::Packet* pkt) override;
 
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  // Decoded-chat support: store group-channel PSKs so the repeater can decrypt
+  // public/hashtag-channel GRP_TXT frames it observes.
+  static constexpr int MAX_CHAT_CHANS = 8;
+  int _num_chat_chans = 0;
+  mesh::GroupChannel _chat_chans[MAX_CHAT_CHANS];
+  char _chat_chan_names[MAX_CHAT_CHANS][24];
+  int searchChannelsByHash(const uint8_t* hash, mesh::GroupChannel channels[], int max_matches) override;
+  void onGroupDataRecv(mesh::Packet* packet, uint8_t type, const mesh::GroupChannel& channel, uint8_t* data, size_t len) override;
+
+  // Name-pattern blacklist: drop ADVERTs whose advertised name matches any pattern.
+  // Patterns are simple globs ('*' and '?'). Persisted in NVS namespace mc-block.
+  static constexpr int MAX_BLOCK_PATTERNS = 8;
+  char _block_patterns[MAX_BLOCK_PATTERNS][32];
+  uint32_t _block_hits[MAX_BLOCK_PATTERNS] = {0};
+  int _num_block_patterns = 0;
+  int _matchesBlockPattern(const char* name);   // returns pattern idx or -1
+#endif
+
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;
   void getPeerSharedSecret(uint8_t* dest_secret, int peer_idx) override;
@@ -187,6 +206,19 @@ public:
   NodePrefs* getNodePrefs() {
     return &_prefs;
   }
+
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  bool addChatChannel(const char* name, const char* psk_base64);
+  bool addPersistentChatChannel(const char* name, const char* psk_base64);
+  void listChatChannels(char* out, size_t out_size);
+  void loadPersistentChatChannels();
+
+  // Name-pattern blacklist API (user-facing).
+  bool addBlockPattern(const char* pattern);
+  bool removeBlockPattern(const char* pattern);
+  void listBlockPatterns(char* out, size_t out_size);   // "pat|hits\n" lines
+  void loadBlockPatterns();
+#endif
 
   void savePrefs() override {
     _cli.savePrefs(_fs);

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -2,6 +2,10 @@
 #include <Arduino.h>
 #include <helpers/CommonCLI.h>
 
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  #include <WiFi.h>
+#endif
+
 #ifndef USER_BTN_PRESSED
 #define USER_BTN_PRESSED LOW
 #endif
@@ -89,6 +93,25 @@ void UITask::renderCurrScreen() {
     _display->setCursor(0, 30);
     sprintf(tmp, "BW: %03.2f CR: %d", _node_prefs->bw, _node_prefs->cr);
     _display->print(tmp);
+
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+    // WiFi state: STA shows IP+RSSI (green if connected), AP shows the setup SSID.
+    _display->setCursor(0, 42);
+    if (WiFi.getMode() == WIFI_AP || WiFi.status() != WL_CONNECTED) {
+      _display->setColor(DisplayDriver::YELLOW);
+      String ssid = WiFi.softAPSSID();
+      if (ssid.length() == 0) ssid = "(not up)";
+      sprintf(tmp, "AP: %s", ssid.c_str());
+      _display->print(tmp);
+    } else {
+      _display->setColor(DisplayDriver::GREEN);
+      sprintf(tmp, "IP: %s", WiFi.localIP().toString().c_str());
+      _display->print(tmp);
+      _display->setCursor(0, 52);
+      sprintf(tmp, "RSSI: %d dBm", (int)WiFi.RSSI());
+      _display->print(tmp);
+    }
+#endif
   }
 }
 

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -13,6 +13,66 @@ SimpleMeshTables tables;
 
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  #include <helpers/esp32/WifiProvisioning.h>
+  #include <helpers/esp32/WifiAdminUI.h>
+  #include <helpers/esp32/WifiCliBridge.h>
+  #ifdef MQTT_PUBLISHER
+    #include <helpers/esp32/MqttPublisher.h>
+  #endif
+  static WifiProvisioning::Config _wifi_cfg = []() {
+    WifiProvisioning::Config c;
+    c.ap_password = "meshcore123";
+    #ifdef PIN_USER_BTN
+    c.user_btn_pin = PIN_USER_BTN;
+    #endif
+    #ifdef WIFI_SSID
+    c.bootstrap_ssid = WIFI_SSID;
+    c.bootstrap_password = WIFI_PWD;
+    #endif
+    return c;
+  }();
+  WifiProvisioning wifi_provisioning(_wifi_cfg);
+
+  class _RepeaterMeshInfo : public MeshInfoProvider {
+  public:
+    const char* nodeName() override { return the_mesh.getNodeName(); }
+    const char* role() override { return the_mesh.getRole(); }
+    const char* firmwareVer() override { return the_mesh.getFirmwareVer(); }
+    void formatNeighbours(char* out) override { the_mesh.formatNeighborsReply(out); }
+    void formatStats(char* out) override { the_mesh.formatStatsReply(out); }
+    void formatRadioStats(char* out) override { the_mesh.formatRadioStatsReply(out); }
+    void formatPacketStats(char* out) override { the_mesh.formatPacketStatsReply(out); }
+    void listChannels(char* out) override { the_mesh.listChatChannels(out, 512); }
+    bool addChannel(const char* name, const char* psk_base64) override {
+      return the_mesh.addPersistentChatChannel(name, psk_base64);
+    }
+    void listBlocked(char* out) override { the_mesh.listBlockPatterns(out, 512); }
+    bool addBlocked(const char* pattern) override { return the_mesh.addBlockPattern(pattern); }
+    bool removeBlocked(const char* pattern) override { return the_mesh.removeBlockPattern(pattern); }
+    void formatRadioConfig(char* out) override {
+      NodePrefs* p = the_mesh.getNodePrefs();
+      sprintf(out,
+        "{\"freq\":%.3f,\"bw\":%.1f,\"sf\":%u,\"cr\":%u,\"tx_power\":%d,"
+        "\"path_hash_mode\":%u,\"path_hash_bytes\":%u,\"rx_boosted\":%u}",
+        p->freq, p->bw, (unsigned)p->sf, (unsigned)p->cr, (int)p->tx_power_dbm,
+        (unsigned)p->path_hash_mode, (unsigned)(p->path_hash_mode + 1),
+        (unsigned)p->rx_boosted_gain);
+    }
+  };
+  static _RepeaterMeshInfo _mesh_info;
+  static WifiAdminUI* admin_ui = nullptr;
+
+  static void _cli_adapter(const char* cmd, char* reply) {
+    char buf[256];
+    strncpy(buf, cmd, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = 0;
+    the_mesh.handleCommand(0, buf, reply);
+  }
+  static WifiCliBridge cli_bridge(5050, _cli_adapter);
+  // Same adapter wired into the web admin UI's /api/cmd route.
+#endif
+
 void halt() {
   while (1) ;
 }
@@ -99,6 +159,26 @@ void setup() {
   ui_task.begin(the_mesh.getNodePrefs(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
 #endif
 
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  board.setInhibitSleep(true);   // WiFi dies when board sleeps
+  wifi_provisioning.begin();
+  if (wifi_provisioning.inStaMode() && wifi_provisioning.webServer()) {
+    admin_ui = new WifiAdminUI(wifi_provisioning.webServer(), &_mesh_info, _cli_adapter);
+    admin_ui->begin();
+    cli_bridge.begin();
+    #ifdef MQTT_PUBLISHER
+    mqttPublisher().attachWebRoutes(wifi_provisioning.webServer());
+    mqttPublisher().begin();
+    #endif
+  }
+  #ifdef MQTT_PUBLISHER
+  else if (wifi_provisioning.webServer()) {
+    // AP-mode setup: still let user configure MQTT for after they connect.
+    mqttPublisher().attachWebRoutes(wifi_provisioning.webServer());
+  }
+  #endif
+#endif
+
   // send out initial zero hop Advertisement to the mesh
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
@@ -153,6 +233,15 @@ void loop() {
   sensors.loop();
 #ifdef DISPLAY_CLASS
   ui_task.loop();
+#endif
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  wifi_provisioning.loop();
+  if (wifi_provisioning.inStaMode()) {
+    cli_bridge.loop();
+    #ifdef MQTT_PUBLISHER
+    mqttPublisher().loop();
+    #endif
+  }
 #endif
   rtc_clock.tick();
 

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -2,6 +2,10 @@
 #include <Arduino.h>
 #include <helpers/CommonCLI.h>
 
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+  #include <WiFi.h>
+#endif
+
 #ifndef USER_BTN_PRESSED
 #define USER_BTN_PRESSED LOW
 #endif
@@ -89,6 +93,25 @@ void UITask::renderCurrScreen() {
     _display->setCursor(0, 30);
     sprintf(tmp, "BW: %03.2f CR: %d", _node_prefs->bw, _node_prefs->cr);
     _display->print(tmp);
+
+#if defined(ESP_PLATFORM) && defined(WIFI_PROVISIONING)
+    // WiFi state: STA shows IP+RSSI (green), AP shows the setup SSID (yellow).
+    _display->setCursor(0, 42);
+    if (WiFi.getMode() == WIFI_AP || WiFi.status() != WL_CONNECTED) {
+      _display->setColor(DisplayDriver::YELLOW);
+      String ssid = WiFi.softAPSSID();
+      if (ssid.length() == 0) ssid = "(not up)";
+      sprintf(tmp, "AP: %s", ssid.c_str());
+      _display->print(tmp);
+    } else {
+      _display->setColor(DisplayDriver::GREEN);
+      sprintf(tmp, "IP: %s", WiFi.localIP().toString().c_str());
+      _display->print(tmp);
+      _display->setCursor(0, 52);
+      sprintf(tmp, "RSSI: %d dBm", (int)WiFi.RSSI());
+      _display->print(tmp);
+    }
+#endif
   }
 }
 

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -12,6 +12,46 @@ StdRNG fast_rng;
 SimpleMeshTables tables;
 MyMesh the_mesh(board, radio_driver, *new ArduinoMillis(), fast_rng, rtc_clock, tables);
 
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  #include <helpers/esp32/WifiProvisioning.h>
+  #include <helpers/esp32/WifiAdminUI.h>
+  #include <helpers/esp32/WifiCliBridge.h>
+  static WifiProvisioning::Config _wifi_cfg = []() {
+    WifiProvisioning::Config c;
+    c.ap_password = "meshcore123";
+    #ifdef PIN_USER_BTN
+    c.user_btn_pin = PIN_USER_BTN;
+    #endif
+    #ifdef WIFI_SSID
+    c.bootstrap_ssid = WIFI_SSID;
+    c.bootstrap_password = WIFI_PWD;
+    #endif
+    return c;
+  }();
+  WifiProvisioning wifi_provisioning(_wifi_cfg);
+
+  class _RoomMeshInfo : public MeshInfoProvider {
+  public:
+    const char* nodeName() override { return the_mesh.getNodeName(); }
+    const char* role() override { return the_mesh.getRole(); }
+    const char* firmwareVer() override { return the_mesh.getFirmwareVer(); }
+    void formatNeighbours(char* out) override { the_mesh.formatNeighborsReply(out); }
+    void formatStats(char* out) override { the_mesh.formatStatsReply(out); }
+    void formatRadioStats(char* out) override { the_mesh.formatRadioStatsReply(out); }
+    void formatPacketStats(char* out) override { the_mesh.formatPacketStatsReply(out); }
+  };
+  static _RoomMeshInfo _mesh_info;
+  static WifiAdminUI* admin_ui = nullptr;
+
+  static void _cli_adapter(const char* cmd, char* reply) {
+    char buf[256];
+    strncpy(buf, cmd, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = 0;
+    the_mesh.handleCommand(0, buf, reply);
+  }
+  static WifiCliBridge cli_bridge(5050, _cli_adapter);
+#endif
+
 void halt() {
   while (1) ;
 }
@@ -76,6 +116,16 @@ void setup() {
   ui_task.begin(the_mesh.getNodePrefs(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
 #endif
 
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  board.setInhibitSleep(true);   // WiFi dies when board sleeps
+  wifi_provisioning.begin();
+  if (wifi_provisioning.inStaMode() && wifi_provisioning.webServer()) {
+    admin_ui = new WifiAdminUI(wifi_provisioning.webServer(), &_mesh_info);
+    admin_ui->begin();
+    cli_bridge.begin();
+  }
+#endif
+
   // send out initial zero hop Advertisement to the mesh
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
@@ -113,6 +163,10 @@ void loop() {
   sensors.loop();
 #ifdef DISPLAY_CLASS
   ui_task.loop();
+#endif
+#if defined(ESP32) && defined(WIFI_PROVISIONING)
+  wifi_provisioning.loop();
+  if (wifi_provisioning.inStaMode()) cli_bridge.loop();
 #endif
   rtc_clock.tick();
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -50,7 +50,9 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       uint8_t path_sz = flags & 0x03;  // NEW v1.11+: lower 2 bits is path hash size
 
       uint8_t len = pkt->payload_len - i;
-      uint8_t offset = pkt->path_len << path_sz;
+      // path_len*entry_size can exceed 255 (path_len up to 63, entry_size up to 8);
+      // a uint8_t offset would wrap and steer the isHashMatch() read to the wrong place.
+      uint16_t offset = (uint16_t)pkt->path_len << path_sz;
       if (offset >= len) {   // TRACE has reached end of given path
         onTraceRecv(pkt, trace_tag, auth_code, flags, pkt->path, &pkt->payload[i], len);
       } else if (self_id.isHashMatch(&pkt->payload[i + offset], 1 << path_sz) && allowPacketForward(pkt) && !_tables->hasSeen(pkt)) {

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -14,7 +14,7 @@ bool ESP32Board::startOTAUpdate(const char* id, char reply[]) {
   inhibit_sleep = true;   // prevent sleep during OTA
   WiFi.softAP("MeshCore-OTA", NULL);
 
-  sprintf(reply, "Started: http://%s/update", WiFi.softAPIP().toString().c_str());
+  sprintf(reply, "Started: http://%s:8306/update", WiFi.softAPIP().toString().c_str());
   MESH_DEBUG_PRINTLN("startOTAUpdate: %s", reply);
 
   static char id_buf[60];
@@ -22,7 +22,7 @@ bool ESP32Board::startOTAUpdate(const char* id, char reply[]) {
   static char home_buf[90];
   sprintf(home_buf, "<H2>Hi! I am a MeshCore Repeater. ID: %s</H2>", id);
 
-  AsyncWebServer* server = new AsyncWebServer(80);
+  AsyncWebServer* server = new AsyncWebServer(8306);
 
   server->on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
     request->send(200, "text/html", home_buf);

--- a/src/helpers/esp32/MqttPublisher.cpp
+++ b/src/helpers/esp32/MqttPublisher.cpp
@@ -1,0 +1,278 @@
+#if defined(ESP_PLATFORM) && defined(MQTT_PUBLISHER)
+
+#include "MqttPublisher.h"
+#include <Preferences.h>
+
+#ifdef WIFI_DEBUG_LOGGING
+  #define MQTT_LOG(fmt, ...) Serial.printf("[mqtt] " fmt "\n", ##__VA_ARGS__)
+#else
+  #define MQTT_LOG(fmt, ...) do {} while (0)
+#endif
+
+namespace {
+const char SETUP_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html lang=en><head>
+<meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1">
+<title>MeshCore MQTT</title><link rel=stylesheet href=/style.css></head>
+<body><div class=wrap>
+<header class=top>
+  <div><h1>MQTT publisher</h1>
+    <div class=meta>forwards every RX and TX (repeated) mesh packet as JSON</div></div>
+  <div class=btns><a class=btn href="/">&larr; Home</a></div>
+</header>
+<div class=card><h2>Broker</h2>
+  <small>Published to <code>&lt;topic&gt;/rx</code> and <code>&lt;topic&gt;/tx</code>. Leave host blank to disable.</small>
+  <form id=f onsubmit="return save(event)">
+    <div class=row>
+      <div class=grow><label>Host<input id=host name=host maxlength=120 placeholder="broker.example.com"></label></div>
+      <div class=port><label>Port<input id=port name=port type=number value=1883></label></div>
+    </div>
+    <label>Username (optional)<input id=user name=user maxlength=64></label>
+    <label>Password (optional)<input id=pwd name=pwd type=password maxlength=64></label>
+    <label>Topic<input id=topic name=topic maxlength=120></label>
+    <button type=submit class=primary>Save</button>
+  </form>
+  <div id=msg></div>
+  <small>Saving does not reconnect immediately &mdash; reboot from the home page to apply.</small>
+</div>
+<div class=card><h2>Status</h2><table id=st></table></div>
+<script>
+const $=(id)=>document.getElementById(id);
+async function load(){const r=await fetch('/mqtt-status');if(!r.ok)return;const j=await r.json();
+  $('host').value=j.host||'';$('port').value=j.port||1883;
+  $('user').value=j.user||'';$('topic').value=j.topic||'';
+  $('st').innerHTML=`<tr><th>Connected</th><td>${j.connected?'yes':'no'} (state ${j.state})</td></tr>
+    <tr><th>Published</th><td>${j.published}</td></tr>
+    <tr><th>Queue depth</th><td>${j.queue_depth}</td></tr>
+    <tr><th>Dropped</th><td>${j.dropped}</td></tr>
+    <tr><th>Errors</th><td>${j.errors}</td></tr>`;
+}
+async function save(ev){ev.preventDefault();const m=$('msg');m.className='msg';m.textContent='Saving…';
+  const fd=new FormData($('f'));
+  try{const r=await fetch('/mqtt-save',{method:'POST',body:new URLSearchParams(fd)});
+    if(r.ok){m.className='msg ok';m.textContent='Saved. Reboot to apply.';}
+    else{m.className='msg err';m.textContent='Save failed.'}
+  }catch(e){m.className='msg err';m.textContent='Save failed: '+e}return false}
+load();setInterval(load,5000);
+</script></body></html>)HTML";
+}  // namespace
+
+MqttPublisher& mqttPublisher() {
+  static MqttPublisher _inst;
+  return _inst;
+}
+
+void mqttPublishRawPacket(float snr, float rssi, const uint8_t* raw, int len) {
+  mqttPublisher().enqueueRawPacket(snr, rssi, raw, len);
+}
+
+void mqttPublishTxPacket(const uint8_t* raw, int len) {
+  mqttPublisher().enqueueTxPacket(raw, len);
+}
+
+MqttPublisher::MqttPublisher() : _client(_net) {}
+
+String MqttPublisher::_defaultTopic() {
+  // Base topic; per-direction suffix ("/rx" or "/tx") is appended at publish time.
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  char buf[40];
+  snprintf(buf, sizeof(buf), "meshcore/%02x%02x%02x%02x%02x%02x",
+           mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  return String(buf);
+}
+
+void MqttPublisher::_loadConfig() {
+  Preferences p;
+  p.begin("mc-mqtt", true);
+  _host = p.getString("host", "");
+  _port = p.getUShort("port", 1883);
+  _user = p.getString("user", "");
+  _pwd = p.getString("pwd", "");
+  _topic = p.getString("topic", _defaultTopic());
+  p.end();
+  if (_client_id.length() == 0) {
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    char buf[24];
+    snprintf(buf, sizeof(buf), "mc-%02x%02x%02x%02x%02x%02x",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    _client_id = buf;
+  }
+}
+
+void MqttPublisher::_saveConfig(const String& host, uint16_t port, const String& user,
+                                const String& pwd, const String& topic) {
+  Preferences p;
+  p.begin("mc-mqtt", false);
+  p.putString("host", host);
+  p.putUShort("port", port);
+  p.putString("user", user);
+  p.putString("pwd", pwd);
+  p.putString("topic", topic.length() ? topic : _defaultTopic());
+  p.end();
+}
+
+void MqttPublisher::begin() {
+  _loadConfig();
+  if (!isConfigured()) {
+    MQTT_LOG("not configured, idle");
+    return;
+  }
+  _client.setServer(_host.c_str(), _port);
+  _client.setBufferSize(1024);
+  MQTT_LOG("configured: %s:%u topic=%s", _host.c_str(), _port, _topic.c_str());
+}
+
+bool MqttPublisher::_ensureConnected() {
+  if (_client.connected()) return true;
+  if (!isConfigured()) return false;
+  if (millis() - _last_attempt_ms < _retry_backoff_ms) return false;
+  _last_attempt_ms = millis();
+
+  bool ok;
+  if (_user.length() > 0) {
+    ok = _client.connect(_client_id.c_str(), _user.c_str(), _pwd.c_str());
+  } else {
+    ok = _client.connect(_client_id.c_str());
+  }
+  if (ok) {
+    MQTT_LOG("connected to %s:%u as %s", _host.c_str(), _port, _client_id.c_str());
+    _retry_backoff_ms = 2000;
+  } else {
+    MQTT_LOG("connect failed, state=%d", _client.state());
+    _retry_backoff_ms = min<uint32_t>(_retry_backoff_ms * 2, 60000);
+  }
+  return ok;
+}
+
+void MqttPublisher::enqueueRawPacket(float snr, float rssi, const uint8_t* raw, int len) {
+  if (!isConfigured()) return;
+  if (len < 0) return;
+  if ((size_t)len > sizeof(Entry::data)) len = sizeof(Entry::data);
+
+  uint8_t next = (_q_head + 1) % QUEUE_LEN;
+  if (next == _q_tail) {
+    _q_tail = (_q_tail + 1) % QUEUE_LEN;
+    _dropped++;
+  }
+  Entry& e = _queue[_q_head];
+  e.dir = Dir::RX;
+  e.ts = millis();
+  e.snr = snr;
+  e.rssi = rssi;
+  e.len = (uint16_t)len;
+  memcpy(e.data, raw, len);
+  _q_head = next;
+}
+
+void MqttPublisher::enqueueTxPacket(const uint8_t* raw, int len) {
+  if (!isConfigured()) return;
+  if (len < 0) return;
+  if ((size_t)len > sizeof(Entry::data)) len = sizeof(Entry::data);
+
+  uint8_t next = (_q_head + 1) % QUEUE_LEN;
+  if (next == _q_tail) {
+    _q_tail = (_q_tail + 1) % QUEUE_LEN;
+    _dropped++;
+  }
+  Entry& e = _queue[_q_head];
+  e.dir = Dir::TX;
+  e.ts = millis();
+  e.snr = 0.0f;
+  e.rssi = 0;
+  e.len = (uint16_t)len;
+  memcpy(e.data, raw, len);
+  _q_head = next;
+}
+
+void MqttPublisher::_publishOne() {
+  if (_q_head == _q_tail) return;
+  Entry& e = _queue[_q_tail];
+
+  char hex[2 * sizeof(Entry::data) + 1];
+  static const char H[] = "0123456789abcdef";
+  for (uint16_t i = 0; i < e.len; i++) {
+    hex[2 * i]     = H[(e.data[i] >> 4) & 0xF];
+    hex[2 * i + 1] = H[e.data[i] & 0xF];
+  }
+  hex[2 * e.len] = 0;
+
+  char payload[2 * sizeof(Entry::data) + 128];
+  const bool is_rx = (e.dir == Dir::RX);
+  int n;
+  if (is_rx) {
+    n = snprintf(payload, sizeof(payload),
+      "{\"dir\":\"rx\",\"ts\":%u,\"rssi\":%d,\"snr\":%.2f,\"len\":%u,\"raw\":\"%s\"}",
+      (unsigned)e.ts, (int)e.rssi, e.snr, (unsigned)e.len, hex);
+  } else {
+    n = snprintf(payload, sizeof(payload),
+      "{\"dir\":\"tx\",\"ts\":%u,\"len\":%u,\"raw\":\"%s\"}",
+      (unsigned)e.ts, (unsigned)e.len, hex);
+  }
+  if (n <= 0 || (size_t)n >= sizeof(payload)) {
+    _publish_errs++;
+    _q_tail = (_q_tail + 1) % QUEUE_LEN;
+    return;
+  }
+
+  String full_topic = _topic + (is_rx ? "/rx" : "/tx");
+  if (_client.publish(full_topic.c_str(), payload)) {
+    _published++;
+    _q_tail = (_q_tail + 1) % QUEUE_LEN;
+  } else {
+    _publish_errs++;
+    // leave entry in queue; will retry on next loop tick after reconnect
+  }
+}
+
+void MqttPublisher::loop() {
+  if (!isConfigured()) return;
+  if (WiFi.status() != WL_CONNECTED) return;
+  if (!_ensureConnected()) return;
+  _client.loop();
+  // Drain a few per tick to keep up under bursts without hogging the loop.
+  for (int i = 0; i < 4 && _client.connected(); i++) {
+    if (_q_head == _q_tail) break;
+    _publishOne();
+  }
+}
+
+void MqttPublisher::attachWebRoutes(AsyncWebServer* server) {
+  if (!server) return;
+
+  server->on("/mqtt-setup", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", SETUP_HTML);
+  });
+
+  server->on("/mqtt-status", HTTP_GET, [this](AsyncWebServerRequest* req) {
+    String out = "{";
+    out += "\"host\":\"";  out += _host; out += "\",";
+    out += "\"port\":";    out += String(_port); out += ",";
+    out += "\"user\":\"";  out += _user; out += "\",";
+    out += "\"topic\":\""; out += _topic; out += "\",";
+    out += "\"connected\":"; out += (_client.connected() ? "true" : "false"); out += ",";
+    out += "\"state\":";   out += String(_client.state()); out += ",";
+    out += "\"published\":"; out += String(_published); out += ",";
+    out += "\"dropped\":"; out += String(_dropped); out += ",";
+    out += "\"errors\":";  out += String(_publish_errs); out += ",";
+    out += "\"queue_depth\":"; out += String((uint8_t)((_q_head + QUEUE_LEN - _q_tail) % QUEUE_LEN));
+    out += "}";
+    req->send(200, "application/json", out);
+  });
+
+  server->on("/mqtt-save", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    String host  = req->hasParam("host", true)  ? req->getParam("host", true)->value()  : String();
+    String puser = req->hasParam("user", true)  ? req->getParam("user", true)->value()  : String();
+    String ppwd  = req->hasParam("pwd", true)   ? req->getParam("pwd", true)->value()   : String();
+    String topic = req->hasParam("topic", true) ? req->getParam("topic", true)->value() : String();
+    uint16_t port = 1883;
+    if (req->hasParam("port", true)) {
+      long v = req->getParam("port", true)->value().toInt();
+      if (v > 0 && v < 65536) port = (uint16_t)v;
+    }
+    _saveConfig(host, port, puser, ppwd, topic);
+    req->send(200, "text/plain", "ok");
+  });
+}
+
+#endif // ESP_PLATFORM && MQTT_PUBLISHER

--- a/src/helpers/esp32/MqttPublisher.h
+++ b/src/helpers/esp32/MqttPublisher.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#if defined(ESP_PLATFORM) && defined(MQTT_PUBLISHER)
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include <ESPAsyncWebServer.h>
+
+// Publishes raw received mesh packets to an MQTT broker as JSON.
+// Configuration is stored in NVS (Preferences namespace 'mc-mqtt') and
+// editable via the /mqtt-setup web routes this module registers.
+//
+// Packets are enqueued from any context (e.g. radio rx callback) and drained
+// from loop() so the MQTT publish call never blocks the mesh path.
+
+class MqttPublisher {
+public:
+  MqttPublisher();
+
+  // Load config from NVS and start. Must be called after WiFi is in STA mode.
+  void begin();
+
+  // Drive reconnects and drain the publish queue. Call from main loop.
+  void loop();
+
+  // Producer side: safe to call from logRxRaw / logTx. Drops oldest if queue is full.
+  void enqueueRawPacket(float snr, float rssi, const uint8_t* raw, int len);
+  void enqueueTxPacket(const uint8_t* raw, int len);
+
+  // Register /mqtt-setup (GET form, POST save) and /mqtt-status (JSON) on the
+  // given web server. Reads/writes NVS; does NOT auto-reconnect on save —
+  // user-triggered reboot picks up the new config.
+  void attachWebRoutes(AsyncWebServer* server);
+
+  bool isConnected() { return _client.connected(); }
+  bool isConfigured() const { return _host.length() > 0; }
+  const String& host() const { return _host; }
+  uint16_t port() const { return _port; }
+  const String& topic() const { return _topic; }
+
+private:
+  void _loadConfig();
+  void _saveConfig(const String& host, uint16_t port, const String& user,
+                   const String& pwd, const String& topic);
+  bool _ensureConnected();
+  void _publishOne();
+  static String _defaultTopic();
+
+  WiFiClient _net;
+  PubSubClient _client;
+  String _host;
+  uint16_t _port = 1883;
+  String _user;
+  String _pwd;
+  String _topic;
+  String _client_id;
+  uint32_t _last_attempt_ms = 0;
+  uint32_t _retry_backoff_ms = 2000;
+
+  enum class Dir : uint8_t { RX = 0, TX = 1 };
+  struct Entry {
+    Dir dir;
+    uint32_t ts;
+    float snr;     // valid for RX only
+    float rssi;    // valid for RX only
+    uint16_t len;
+    uint8_t data[256];
+  };
+  static constexpr size_t QUEUE_LEN = 16;
+  Entry _queue[QUEUE_LEN];
+  volatile uint8_t _q_head = 0;
+  volatile uint8_t _q_tail = 0;
+  volatile uint32_t _dropped = 0;
+  uint32_t _published = 0;
+  uint32_t _publish_errs = 0;
+};
+
+// Singleton accessor + free functions for use from logRxRaw / logTx without
+// pulling in the full header at every hook site.
+MqttPublisher& mqttPublisher();
+void mqttPublishRawPacket(float snr, float rssi, const uint8_t* raw, int len);
+void mqttPublishTxPacket(const uint8_t* raw, int len);
+
+#endif // ESP_PLATFORM && MQTT_PUBLISHER

--- a/src/helpers/esp32/WifiAdminUI.cpp
+++ b/src/helpers/esp32/WifiAdminUI.cpp
@@ -359,25 +359,56 @@ function renderRadio(j){
   ]);
 }
 let _lastRadioCfg=null;
+// Common starting points by region. Format: [label, freq, bw, sf, cr]
+const RADIO_PRESETS=[
+  ['USA / Canada (Recommended)', 910.525, 62.5, 7, 5],
+  ['EU868 (Default)',            869.618, 62.5, 8, 5],
+  ['Legacy Wide (pre-1.14)',     869.525, 250.0, 11, 5],
+];
 function renderRadioCfg(j){
   if(!j||!j.freq){return $('rcfg').textContent='(unavailable)';}
   _lastRadioCfg=j;
   const phb=j.path_hash_bytes|0;
   const phCls=phb>=2?'good':'warn';
-  const txEd=`<input id=tx-ed type=number min=-9 max=22 step=1 value="${j.tx_power}" onchange="setTx(this.value)"> dBm`;
+  const bwOpts=[7.8,10.4,15.6,20.8,31.25,41.7,62.5,125,250,500];
+  const fEd=`<input id=f-ed type=number min=150 max=2500 step=0.025 value="${j.freq.toFixed(3)}" onchange="setFreq(this.value)"> MHz`;
+  const bwEd=`<select id=bw-ed onchange="setBw(this.value)">`+
+    bwOpts.map(b=>`<option value=${b} ${b===j.bw?'selected':''}>${b.toFixed(b<10?2:1)} kHz</option>`).join('')+`</select>`;
+  const sfEd=`<select id=sf-ed onchange="setSf(this.value)">`+
+    [5,6,7,8,9,10,11,12].map(s=>`<option value=${s} ${s==j.sf?'selected':''}>SF${s}</option>`).join('')+`</select>`;
   const crEd=`<select id=cr-ed onchange="setCr(this.value)">`+
     [5,6,7,8].map(c=>`<option value=${c} ${c==j.cr?'selected':''}>4/${c}</option>`).join('')+`</select>`;
+  const txEd=`<input id=tx-ed type=number min=-9 max=22 step=1 value="${j.tx_power}" onchange="setTx(this.value)"> dBm`;
   const phEd=`<select id=ph-ed onchange="setPh(this.value)">`+
     [[0,'1B (default)'],[1,'2B (recommended)'],[2,'3B']].map(([v,l])=>`<option value=${v} ${v==j.path_hash_mode?'selected':''}>${l}</option>`).join('')+`</select>`;
   renderKV($('rcfg'),[
-    ['Frequency', `${j.freq.toFixed(3)} MHz`],
-    ['Bandwidth', `${j.bw.toFixed(1)} kHz`],
-    ['Spreading factor', `SF${j.sf}`],
+    ['Frequency', fEd],
+    ['Bandwidth', bwEd],
+    ['Spreading factor', sfEd],
     ['Coding rate', crEd],
     ['TX power', txEd],
     ['Path hash size', phEd, phCls],
     ['RX boosted gain', j.rx_boosted ? 'on' : 'off'],
   ]);
+  // Region preset chips below the kv grid.
+  const presets=document.createElement('div');
+  presets.style.cssText='margin-top:.5em;display:flex;flex-wrap:wrap;gap:.3em';
+  presets.innerHTML='<div style="width:100%;font-size:.8em;color:var(--mute);margin-bottom:.15em">Region presets (sets freq/BW/SF/CR; reboot to apply):</div>'+
+    RADIO_PRESETS.map((p,i)=>`<button style="font-size:.8em;padding:.25em .55em" onclick="applyPreset(${i})">${p[0]}</button>`).join('');
+  $('rcfg').appendChild(presets);
+}
+async function setRadio(freq,bw,sf,cr,reason){
+  const cmd=`set radio ${freq},${bw},${sf},${cr}`;
+  const t=await _runCmd(cmd);
+  $('out').value+=`\n> ${cmd}\n${t}`;$('out').scrollTop=$('out').scrollHeight;
+  if(t.indexOf('reboot')>=0)alert(`${reason} saved. Reboot the node from the home page to apply.`);
+  refresh();
+}
+async function setFreq(v){if(!_lastRadioCfg)return;const j=_lastRadioCfg;setRadio(parseFloat(v),j.bw,j.sf,j.cr,'Frequency');}
+async function setBw(v){if(!_lastRadioCfg)return;const j=_lastRadioCfg;setRadio(j.freq,parseFloat(v),j.sf,j.cr,'Bandwidth');}
+async function setSf(v){if(!_lastRadioCfg)return;const j=_lastRadioCfg;setRadio(j.freq,j.bw,parseInt(v,10),j.cr,'Spreading factor');}
+function applyPreset(i){const p=RADIO_PRESETS[i];if(!confirm(`Apply preset "${p[0]}":\n  ${p[1]} MHz, BW ${p[2]}, SF${p[3]}, CR 4/${p[4]}\n\nReboot required to take effect.`))return;
+  setRadio(p[1],p[2],p[3],p[4],`Preset "${p[0]}"`);
 }
 async function _runCmd(cmd){
   const r=await fetch('/api/cmd',{method:'POST',body:new URLSearchParams({cmd})});

--- a/src/helpers/esp32/WifiAdminUI.cpp
+++ b/src/helpers/esp32/WifiAdminUI.cpp
@@ -1,0 +1,672 @@
+#ifdef ESP_PLATFORM
+
+#include "WifiAdminUI.h"
+#include <WiFi.h>
+#include <AsyncWebSocket.h>
+
+namespace {
+
+// Singleton pointer for the free-function packet push helpers.
+WifiAdminUI* g_admin_ui = nullptr;
+
+// Shared CSS served at /style.css so admin sub-pages (MQTT setup, Channels) can
+// link to it instead of duplicating styles.
+const char SHARED_CSS[] PROGMEM = R"CSS(
+:root{--bg:#f6f7fb;--card:#fff;--ink:#111;--mute:#666;--line:#e2e5ec;--accent:#1a73e8;--warn:#ef6c00;--danger:#c62828;--good:#2e7d32;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+@media (prefers-color-scheme:dark){:root{--bg:#0e1116;--card:#161a22;--ink:#e6e8ee;--mute:#8b93a3;--line:#252b36}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.4 system-ui,sans-serif}
+.wrap{max-width:780px;margin:0 auto;padding:.8em}
+header.top{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6em;justify-content:space-between;padding:.4em .2em .6em}
+header.top h1{font-size:1.25em;margin:0}
+header.top .meta{color:var(--mute);font-size:.85em}
+.btns{display:flex;flex-wrap:wrap;gap:.4em}
+button,a.btn{font:inherit;padding:.4em .8em;border-radius:5px;border:1px solid var(--line);background:var(--card);color:var(--ink);cursor:pointer;text-decoration:none;display:inline-block}
+button:hover,a.btn:hover{border-color:var(--accent)}
+button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+button.warn{background:var(--warn);color:#fff;border:0}
+button.danger{background:var(--danger);color:#fff;border:0}
+.card{background:var(--card);border:1px solid var(--line);border-radius:6px;padding:.8em;margin-top:.6em}
+.card h2{margin:0 0 .4em;font-size:.95em}
+label{display:block;margin:.6em 0 .2em;font-size:.9em;color:var(--mute)}
+input,select{font:inherit;width:100%;padding:.5em;box-sizing:border-box;border:1px solid var(--line);background:var(--bg);color:var(--ink);border-radius:4px}
+.row{display:flex;gap:.5em}.row .grow{flex:1}.row .port{flex:0 0 6em}
+.msg{padding:.5em .6em;border-radius:4px;margin-top:.8em;font-size:.9em}
+.msg.ok{background:rgba(46,125,50,.12);color:var(--good)}
+.msg.err{background:rgba(198,40,40,.12);color:var(--danger)}
+small{color:var(--mute)}
+table{width:100%;border-collapse:collapse;font:13px var(--mono)}
+th,td{text-align:left;padding:.35em .4em;border-bottom:1px solid var(--line)}
+th{color:var(--mute);font-weight:normal;font-size:.85em}
+.tag{display:inline-block;padding:.1em .45em;border-radius:3px;font-size:.75em;border:1px solid var(--line);color:var(--mute)}
+.tag.persistent{border-color:var(--accent);color:var(--accent)}
+)CSS";
+
+const char BLACKLIST_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html lang=en><head>
+<meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1">
+<title>MeshCore Blacklist</title><link rel=stylesheet href=/style.css></head>
+<body><div class=wrap>
+<header class=top>
+  <div><h1>Forwarding blacklist</h1>
+    <div class=meta>drop ADVERTs from nodes whose name matches a pattern</div></div>
+  <div class=btns><a class=btn href="/">&larr; Home</a></div>
+</header>
+<div class=card><h2>Active patterns</h2>
+  <table><thead><tr><th>Pattern</th><th>Hits</th><th></th></tr></thead><tbody id=pats></tbody></table>
+  <small id=cnt></small>
+</div>
+<div class=card><h2>Add pattern</h2>
+  <form id=f onsubmit="return add(event)">
+    <label>Pattern (use * and ? for wildcards)<input id=pat name=pattern required maxlength=31 placeholder="e.g. BadActor* or *spammer*"></label>
+    <button type=submit class=primary>Add &amp; save</button>
+  </form>
+  <div id=msg></div>
+  <small>Patterns are matched against the advertised node name. ADVERT packets from matches are dropped (not forwarded, not added to neighbours). Direct messages still pass through since we can't see the sender of an encrypted DM. Capacity: 8 patterns.</small>
+</div>
+<script>
+const $=(id)=>document.getElementById(id);
+function escHtml(s){return (s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+async function refresh(){
+  const t=await(await fetch('/api/blacklist')).text();
+  const rows=t.split('\n').filter(l=>l.indexOf('|')>0);
+  $('pats').innerHTML=rows.map(l=>{const p=l.split('|');return `<tr><td><code>${escHtml(p[0])}</code></td><td>${escHtml(p[1])}</td><td><button onclick="del('${escHtml(p[0]).replace(/'/g,"\\'")}')">Remove</button></td></tr>`}).join('');
+  if(!rows.length)$('pats').innerHTML='<tr><td colspan=3 style=color:var(--mute)>no patterns configured</td></tr>';
+  $('cnt').textContent=`${rows.length} pattern${rows.length===1?'':'s'} configured`;
+}
+async function add(ev){ev.preventDefault();const m=$('msg');m.className='msg';m.textContent='Saving…';
+  const fd=new FormData($('f'));
+  try{const r=await fetch('/api/blacklist-save',{method:'POST',body:new URLSearchParams(fd)});
+    const t=await r.text();
+    if(r.ok){m.className='msg ok';m.textContent='Saved. '+t;$('pat').value='';refresh();}
+    else{m.className='msg err';m.textContent='Failed: '+t}
+  }catch(e){m.className='msg err';m.textContent='Failed: '+e}return false}
+async function del(pat){if(!confirm('Remove pattern '+pat+'?'))return;
+  try{const r=await fetch('/api/blacklist-remove',{method:'POST',body:new URLSearchParams({pattern:pat})});
+    if(r.ok)refresh();else alert('Remove failed: '+await r.text());
+  }catch(e){alert('Remove failed: '+e)}}
+refresh();
+</script></body></html>)HTML";
+
+const char CHANNELS_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html lang=en><head>
+<meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1">
+<title>MeshCore Channels</title><link rel=stylesheet href=/style.css></head>
+<body><div class=wrap>
+<header class=top>
+  <div><h1>Group channels</h1>
+    <div class=meta>configure additional channels so the repeater can decrypt their messages</div></div>
+  <div class=btns><a class=btn href="/">&larr; Home</a></div>
+</header>
+<div class=card><h2>Configured channels</h2>
+  <table><thead><tr><th>Name</th><th>Hash</th><th>Source</th></tr></thead><tbody id=chans></tbody></table>
+  <small id=cnt></small>
+</div>
+<div class=card><h2>Add channel</h2>
+  <form id=f onsubmit="return add(event)">
+    <label>Channel name<input id=name name=name required maxlength=23 placeholder="e.g. NorCal"></label>
+    <label>PSK (base64, 16 or 32 bytes)<input id=psk name=psk required maxlength=47 placeholder="e.g. izOH6cXN6mrJ5e26oRXNcg=="></label>
+    <button type=submit class=primary>Add &amp; save</button>
+  </form>
+  <div id=msg></div>
+  <small>Channels persist in NVS and reload on boot. Capacity: 8 total incl. built-in Public.</small>
+</div>
+<script>
+const $=(id)=>document.getElementById(id);
+function escHtml(s){return (s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+async function refresh(){
+  const t=await(await fetch('/api/channels')).text();
+  const rows=t.split('\n').filter(l=>l.indexOf('|')>0);
+  $('chans').innerHTML=rows.map(l=>{const p=l.split('|');return `<tr><td>${escHtml(p[0])}</td><td>0x${escHtml(p[1])}</td><td><span class="tag ${p[2]==='p'?'persistent':''}">${p[2]==='p'?'NVS':'built-in'}</span></td></tr>`}).join('');
+  if(!rows.length)$('chans').innerHTML='<tr><td colspan=3 style=color:var(--mute)>none configured</td></tr>';
+  $('cnt').textContent=`${rows.length} channel${rows.length===1?'':'s'} configured`;
+}
+async function add(ev){ev.preventDefault();const m=$('msg');m.className='msg';m.textContent='Saving…';
+  const fd=new FormData($('f'));
+  try{const r=await fetch('/api/channels-save',{method:'POST',body:new URLSearchParams(fd)});
+    const t=await r.text();
+    if(r.ok){m.className='msg ok';m.textContent='Saved. '+t;$('name').value='';$('psk').value='';refresh();}
+    else{m.className='msg err';m.textContent='Failed: '+t}
+  }catch(e){m.className='msg err';m.textContent='Failed: '+e}return false}
+refresh();
+</script></body></html>)HTML";
+
+const char ADMIN_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html lang=en><head>
+<meta charset=utf-8>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>MeshCore Admin</title>
+<style>
+:root{--bg:#f6f7fb;--card:#fff;--ink:#111;--mute:#666;--line:#e2e5ec;--accent:#1a73e8;--rx:#1565c0;--tx:#2e7d32;--warn:#ef6c00;--danger:#c62828;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+@media (prefers-color-scheme:dark){:root{--bg:#0e1116;--card:#161a22;--ink:#e6e8ee;--mute:#8b93a3;--line:#252b36;--rx:#64b5f6;--tx:#81c784}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.4 system-ui,sans-serif}
+.wrap{max-width:1280px;margin:0 auto;padding:.8em}
+header{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6em;justify-content:space-between;padding:.4em .2em .6em}
+header h1{font-size:1.25em;margin:0}
+header .meta{color:var(--mute);font-size:.85em}
+.btns{display:flex;flex-wrap:wrap;gap:.4em}
+button{font:inherit;padding:.4em .8em;border-radius:5px;border:1px solid var(--line);background:var(--card);color:var(--ink);cursor:pointer}
+button:hover{border-color:var(--accent)}
+button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+button.warn{background:var(--warn);color:#fff;border:0}
+button.danger{background:var(--danger);color:#fff;border:0}
+button.ghost{background:transparent}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.6em;margin:.6em 0}
+.card{background:var(--card);border:1px solid var(--line);border-radius:6px;padding:.6em}
+.card h3{margin:0 0 .3em;font-size:.85em;color:var(--mute);text-transform:uppercase;letter-spacing:.04em}
+.card pre{margin:0;font:12px/1.4 var(--mono);white-space:pre-wrap;word-break:break-all;color:var(--ink)}
+.kv{display:grid;grid-template-columns:auto 1fr;gap:.18em .8em;font:13px/1.4 system-ui,sans-serif}
+.kv .k{color:var(--mute);font-size:.85em}
+.kv .v{font-family:var(--mono);text-align:right;color:var(--ink)}
+.kv .v.warn{color:var(--warn)}.kv .v.bad{color:var(--danger)}.kv .v.good{color:var(--tx)}
+.kv input[type=number],.kv select{padding:.15em .4em;font:inherit;font-family:var(--mono);border:1px solid var(--line);border-radius:3px;background:var(--bg);color:var(--ink);min-width:6em;text-align:right}
+.kv select{text-align:left;text-align-last:left}
+.main{display:grid;grid-template-columns:1fr 360px;gap:.6em;margin-top:.4em}
+@media (max-width:880px){.main{grid-template-columns:1fr}}
+.panel{background:var(--card);border:1px solid var(--line);border-radius:6px;display:flex;flex-direction:column;min-height:320px}
+.panel header{padding:.4em .6em;border-bottom:1px solid var(--line);background:transparent}
+.panel header h2{margin:0;font-size:.95em}
+.panel header .ctrls{display:flex;gap:.3em}
+.feed{flex:1;overflow:auto;font:12px/1.35 var(--mono);padding:.3em .6em;max-height:60vh;min-height:280px}
+.feed .row{padding:.15em 0;border-bottom:1px dotted var(--line);white-space:pre-wrap;word-break:break-all}
+.feed .row:last-child{border:0}
+.feed .row.rx{color:var(--rx)}
+.feed .row.tx{color:var(--tx)}
+.feed .ts{color:var(--mute)}
+.chat{flex:1;overflow:auto;padding:.4em .6em;max-height:32vh;min-height:140px;display:flex;flex-direction:column;gap:.35em;font:13px/1.35 system-ui,sans-serif}
+.chat .msg{padding:.35em .5em;border-radius:6px;background:rgba(127,127,127,.08);border-left:3px solid var(--accent)}
+.chat .msg .h{font-size:.78em;color:var(--mute);display:flex;gap:.5em;flex-wrap:wrap;margin-bottom:.15em}
+.chat .msg .h .ch{color:var(--accent);font-weight:600}
+.chat .msg .h .who{color:var(--ink);font-weight:600}
+.chat .msg .t{white-space:pre-wrap;word-break:break-word}
+.chat .empty{color:var(--mute);font-size:.85em;font-style:italic}
+.cli{padding:.5em .6em;border-top:1px solid var(--line)}
+.cli textarea{width:100%;font:12px/1.4 var(--mono);min-height:5em;max-height:14em;padding:.4em;border:1px solid var(--line);background:var(--bg);color:var(--ink);border-radius:4px;resize:vertical}
+.cli .input{display:flex;gap:.3em;margin-top:.3em}
+.cli .input input{flex:1;font:13px var(--mono);padding:.4em;border:1px solid var(--line);background:var(--bg);color:var(--ink);border-radius:4px}
+.presets{display:flex;flex-wrap:wrap;gap:.25em;margin-top:.4em}
+.presets button{font-size:.8em;padding:.25em .55em}
+.neigh{margin-top:.6em}
+.neigh table{width:100%;border-collapse:collapse;font:12px var(--mono)}
+.neigh th,.neigh td{text-align:left;padding:.25em .4em;border-bottom:1px solid var(--line)}
+.neigh th{color:var(--mute);font-weight:normal;font-size:.85em}
+.statusbar{position:sticky;bottom:0;background:var(--card);border-top:1px solid var(--line);padding:.3em .6em;font-size:.8em;color:var(--mute);display:flex;gap:1em;justify-content:space-between;margin-top:.6em;border-radius:0 0 6px 6px}
+.dot{display:inline-block;width:.7em;height:.7em;border-radius:50%;background:#888;margin-right:.3em;vertical-align:-.05em}
+.dot.on{background:#2e7d32}.dot.off{background:#c62828}
+</style></head><body><div class=wrap>
+
+<header>
+  <div><h1 id=name>MeshCore</h1>
+    <div class=meta><span id=role></span> &middot; fw <span id=fw>?</span> &middot; up <span id=up>?</span></div></div>
+  <div class=btns>
+    <button onclick=refresh()>Refresh</button>
+    <button id=chan-btn class=ghost style="display:none" onclick="location.href='/channels'">Channels</button>
+    <button id=blacklist-btn class=ghost style="display:none" onclick="location.href='/blacklist'">Blacklist</button>
+    <button id=mqtt-btn class=ghost style="display:none" onclick="location.href='/mqtt-setup'">MQTT</button>
+    <button class=warn onclick="if(confirm('Reboot node?'))fetch('/api/reboot',{method:'POST'}).then(()=>setTimeout(refresh,5000))">Reboot</button>
+    <button class=danger onclick="if(confirm('Wipe WiFi creds and reboot into AP setup?'))fetch('/wipe-wifi',{method:'POST'}).then(()=>document.body.innerHTML='<p>Rebooting&hellip;</p>')">Wipe WiFi</button>
+  </div>
+</header>
+
+<section class=cards>
+  <div class=card><h3>Network</h3><div id=net class=kv>&hellip;</div></div>
+  <div class=card><h3>Radio config</h3><div id=rcfg class=kv>&hellip;</div></div>
+  <div class=card><h3>Mesh</h3><div id=stats class=kv>&hellip;</div></div>
+  <div class=card><h3>Radio stats</h3><div id=rstats class=kv>&hellip;</div></div>
+  <div class=card><h3>Packets</h3><div id=pstats class=kv>&hellip;</div></div>
+</section>
+
+<div class=main>
+
+  <div style="display:flex;flex-direction:column;gap:.6em;min-width:0">
+    <div class=panel>
+      <header><h2>Chat <span id=chat-count style="color:var(--mute);font-weight:normal;font-size:.85em"></span></h2>
+        <div class=ctrls>
+          <button id=chat-pause-btn onclick=toggleChatPause()>Pause</button>
+          <button onclick="document.getElementById('chat').innerHTML='<div class=empty>cleared</div>'">Clear</button>
+        </div>
+      </header>
+      <div id=chat class=chat><div class=empty>waiting for chat messages on known channels (Public)&hellip;</div></div>
+    </div>
+    <div class=panel>
+      <header><h2>Packet feed</h2>
+        <div class=ctrls>
+          <button id=pause-btn onclick=togglePause()>Pause</button>
+          <button onclick="document.getElementById('feed').innerHTML=''">Clear</button>
+        </div>
+      </header>
+      <div id=feed class=feed>(connecting&hellip;)</div>
+    </div>
+  </div>
+
+  <div class=panel>
+    <header><h2>Console</h2><div class=ctrls></div></header>
+    <div class=cli>
+      <textarea id=out readonly placeholder="command output&hellip;"></textarea>
+      <div class=input>
+        <input id=cmd autocomplete=off placeholder="type a CLI command, e.g. 'neighbors'">
+        <button class=primary onclick=runCmd()>Run</button>
+      </div>
+      <div class=presets>
+        <button onclick="preset('ver')">ver</button>
+        <button onclick="preset('clock')">clock</button>
+        <button onclick="preset('neighbors')">neighbors</button>
+        <button onclick="preset('advert')">advert</button>
+        <button onclick="preset('get name')">get name</button>
+        <button onclick="preset('get freq')">get freq</button>
+        <button onclick="preset('get tx_power')">get tx_power</button>
+        <button onclick="preset('help')">help</button>
+      </div>
+      <div class=neigh><table id=neigh-tbl><thead><tr><th>id</th><th>age (s)</th><th>snr</th></tr></thead><tbody id=neigh-body></tbody></table></div>
+    </div>
+  </div>
+
+</div>
+
+<div class=statusbar>
+  <div><span class=dot id=ws-dot></span><span id=ws-state>websocket connecting&hellip;</span></div>
+  <div id=pkt-counts>rx 0 / tx 0</div>
+</div>
+
+</div>
+<script>
+const $=(id)=>document.getElementById(id);
+let paused=false, chatPaused=false, rxCount=0, txCount=0, chatCount=0, ws=null;
+let history=JSON.parse(localStorage.getItem('mc_hist')||'[]'), histIdx=history.length;
+
+function togglePause(){paused=!paused;$('pause-btn').textContent=paused?'Resume':'Pause'}
+function toggleChatPause(){chatPaused=!chatPaused;$('chat-pause-btn').textContent=chatPaused?'Resume':'Pause'}
+function escHtml(s){return (s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+function fmtChatTs(ts){if(!ts)return fmtTs();const d=new Date(ts*1000);return pad2(d.getHours())+':'+pad2(d.getMinutes())+':'+pad2(d.getSeconds())}
+function onChat(m){
+  if(chatPaused)return;
+  const el=$('chat');
+  if(el.firstChild && el.firstChild.classList && el.firstChild.classList.contains('empty'))el.innerHTML='';
+  const sender=m.sender||'(unknown)';
+  const div=document.createElement('div');div.className='msg';
+  div.innerHTML=`<div class=h><span class=ts>${fmtChatTs(m.ts)}</span><span class=ch>#${escHtml(m.channel)}</span><span class=who>${escHtml(sender)}</span></div><div class=t>${escHtml(m.text)}</div>`;
+  el.appendChild(div);
+  while(el.children.length>200)el.removeChild(el.firstChild);
+  el.scrollTop=el.scrollHeight;
+  chatCount++;$('chat-count').textContent=`(${chatCount})`;
+}
+function pad2(n){return n<10?'0'+n:''+n}
+function fmtTs(){const d=new Date();return pad2(d.getHours())+':'+pad2(d.getMinutes())+':'+pad2(d.getSeconds())}
+function appendRow(text,cls){
+  if(paused)return;
+  const el=$('feed');
+  if(el.firstChild && el.firstChild.textContent==='(connecting…)')el.innerHTML='';
+  const div=document.createElement('div');div.className='row '+cls;div.innerHTML=text;
+  el.appendChild(div);
+  while(el.children.length>500)el.removeChild(el.firstChild);
+  el.scrollTop=el.scrollHeight;
+}
+function onPacket(p){
+  const truncRaw=p.raw.length>64?p.raw.slice(0,64)+'…':p.raw;
+  if(p.dir==='rx'){
+    rxCount++;
+    appendRow(`<span class=ts>${fmtTs()}</span>  RX  rssi=${p.rssi} snr=${p.snr.toFixed(1)}  len=${p.len}  ${truncRaw}`,'rx');
+  } else {
+    txCount++;
+    appendRow(`<span class=ts>${fmtTs()}</span>  TX                       len=${p.len}  ${truncRaw}`,'tx');
+  }
+  $('pkt-counts').textContent=`rx ${rxCount} / tx ${txCount}`;
+}
+
+function wsConnect(){
+  const proto=location.protocol==='https:'?'wss:':'ws:';
+  ws=new WebSocket(proto+'//'+location.host+'/ws');
+  ws.onopen=()=>{$('ws-dot').classList.add('on');$('ws-dot').classList.remove('off');$('ws-state').textContent='websocket connected';
+    appendRow('<span class=ts>'+fmtTs()+'</span>  -- live feed --','ts');};
+  ws.onclose=()=>{$('ws-dot').classList.add('off');$('ws-dot').classList.remove('on');$('ws-state').textContent='websocket disconnected, retrying';
+    setTimeout(wsConnect,2000);};
+  ws.onerror=()=>{};
+  ws.onmessage=(e)=>{try{const m=JSON.parse(e.data);if(m.type==='chat')onChat(m);else if(m.dir)onPacket(m);}catch(err){}};
+}
+
+function fmtUptime(s){s=s|0;if(s<60)return s+'s';
+  const d=(s/86400)|0,h=((s%86400)/3600)|0,m=((s%3600)/60)|0,sec=s%60;
+  if(d)return `${d}d ${h}h ${m}m`;
+  if(h)return `${h}h ${m}m`;
+  return `${m}m ${sec}s`;}
+function fmtSecsCompact(s){s=s|0;if(s<60)return s+' s';if(s<3600)return ((s/60)|0)+'m '+(s%60)+'s';return ((s/3600)|0)+'h '+(((s%3600)/60)|0)+'m';}
+function fmtRssi(v){if(v==null)return '-';const cls=v>-65?'good':v>-85?'':'warn';return `<span class="v ${cls}">${v} dBm</span>`}
+function rssiClass(v){return v>-65?'good':v>-85?'':'warn'}
+function fmtBatt(mv){if(mv==null||mv===0)return '-';const v=(mv/1000).toFixed(2);return `${v} V <span style="color:var(--mute)">(${mv} mV)</span>`}
+function rowHTML(rows){return rows.map(([k,v,cls])=>`<div class=k>${k}</div><div class="v ${cls||''}">${v}</div>`).join('')}
+function renderKV(el,rows){el.innerHTML=rowHTML(rows)}
+
+function renderNetwork(s){renderKV($('net'),[
+  ['SSID', s.ssid||'-'],
+  ['IP', s.ip||'-'],
+  ['RSSI', `${s.rssi} dBm`, rssiClass(s.rssi)],
+  ['MAC', s.mac||'-'],
+]);}
+function renderMesh(j){
+  if(!j)return $('stats').textContent='(unavailable)';
+  const errs=j.errors||0;
+  renderKV($('stats'),[
+    ['Battery', fmtBatt(j.battery_mv)],
+    ['Uptime', fmtUptime(j.uptime_secs)],
+    ['TX queue', (j.queue_len|0)+' pkt'],
+    ['Errors', errs, errs?'bad':'good'],
+  ]);
+}
+function renderRadio(j){
+  if(!j)return $('rstats').textContent='(unavailable)';
+  renderKV($('rstats'),[
+    ['Noise floor', `${j.noise_floor} dBm`],
+    ['Last RSSI', `${j.last_rssi} dBm`, rssiClass(j.last_rssi)],
+    ['Last SNR', `${(+j.last_snr).toFixed(1)} dB`],
+    ['Air TX', fmtSecsCompact(j.tx_air_secs)],
+    ['Air RX', fmtSecsCompact(j.rx_air_secs)],
+  ]);
+}
+let _lastRadioCfg=null;
+function renderRadioCfg(j){
+  if(!j||!j.freq){return $('rcfg').textContent='(unavailable)';}
+  _lastRadioCfg=j;
+  const phb=j.path_hash_bytes|0;
+  const phCls=phb>=2?'good':'warn';
+  const txEd=`<input id=tx-ed type=number min=-9 max=22 step=1 value="${j.tx_power}" onchange="setTx(this.value)"> dBm`;
+  const crEd=`<select id=cr-ed onchange="setCr(this.value)">`+
+    [5,6,7,8].map(c=>`<option value=${c} ${c==j.cr?'selected':''}>4/${c}</option>`).join('')+`</select>`;
+  const phEd=`<select id=ph-ed onchange="setPh(this.value)">`+
+    [[0,'1B (default)'],[1,'2B (recommended)'],[2,'3B']].map(([v,l])=>`<option value=${v} ${v==j.path_hash_mode?'selected':''}>${l}</option>`).join('')+`</select>`;
+  renderKV($('rcfg'),[
+    ['Frequency', `${j.freq.toFixed(3)} MHz`],
+    ['Bandwidth', `${j.bw.toFixed(1)} kHz`],
+    ['Spreading factor', `SF${j.sf}`],
+    ['Coding rate', crEd],
+    ['TX power', txEd],
+    ['Path hash size', phEd, phCls],
+    ['RX boosted gain', j.rx_boosted ? 'on' : 'off'],
+  ]);
+}
+async function _runCmd(cmd){
+  const r=await fetch('/api/cmd',{method:'POST',body:new URLSearchParams({cmd})});
+  return await r.text();
+}
+async function setTx(v){
+  const t=await _runCmd('set tx '+v);
+  $('out').value+=`\n> set tx ${v}\n${t}`;$('out').scrollTop=$('out').scrollHeight;
+  refresh();
+}
+async function setPh(v){
+  const t=await _runCmd('set path.hash.mode '+v);
+  $('out').value+=`\n> set path.hash.mode ${v}\n${t}`;$('out').scrollTop=$('out').scrollHeight;
+  refresh();
+}
+async function setCr(v){
+  if(!_lastRadioCfg){return}
+  const j=_lastRadioCfg;
+  const cmd=`set radio ${j.freq},${j.bw},${j.sf},${v}`;
+  const t=await _runCmd(cmd);
+  $('out').value+=`\n> ${cmd}\n${t}`;$('out').scrollTop=$('out').scrollHeight;
+  if(t.indexOf('reboot')>=0)alert('Coding rate saved. Reboot the node from the home page to apply.');
+  refresh();
+}
+function renderPackets(j){
+  if(!j)return $('pstats').textContent='(unavailable)';
+  const errs=j.recv_errors|0;
+  renderKV($('pstats'),[
+    ['Received', j.recv|0],
+    ['Sent', j.sent|0],
+    ['Flood TX / RX', `${j.flood_tx|0} / ${j.flood_rx|0}`],
+    ['Direct TX / RX', `${j.direct_tx|0} / ${j.direct_rx|0}`],
+    ['RX errors', errs, errs?'warn':'good'],
+  ]);
+}
+async function jsonOrNull(url){try{const r=await fetch(url);if(!r.ok)return null;const t=await r.text();try{return JSON.parse(t)}catch(e){return null}}catch(e){return null}}
+
+async function refresh(){
+  const s=await jsonOrNull('/api/status');
+  if(s){
+    $('name').textContent=s.name||'MeshCore';
+    $('role').textContent=s.role||'';
+    $('fw').textContent=s.fw||'?';
+    $('up').textContent=fmtUptime(s.uptime_s);
+    renderNetwork(s);
+  }
+  renderRadioCfg(await jsonOrNull('/api/radio-config'));
+  renderMesh(await jsonOrNull('/api/stats'));
+  renderRadio(await jsonOrNull('/api/radio-stats'));
+  renderPackets(await jsonOrNull('/api/packet-stats'));
+  const ntext=await(await fetch('/api/neighbours')).text().catch(()=>'');
+  renderNeigh(ntext);
+}
+function renderNeigh(t){
+  const body=$('neigh-body');body.innerHTML='';
+  if(!t||t==='-none-'){body.innerHTML='<tr><td colspan=3 style=color:var(--mute)>no neighbours yet</td></tr>';return}
+  for(const line of t.split('\n')){
+    const m=line.match(/^([0-9a-fA-F]+):(\d+):(-?\d+)/);
+    if(!m)continue;
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${m[1]}</td><td>${m[2]}</td><td>${m[3]}</td>`;
+    body.appendChild(tr);
+  }
+}
+
+async function runCmd(){
+  const v=$('cmd').value.trim();if(!v)return;
+  $('out').value+=(($('out').value?'\n':'')+'> '+v);
+  $('cmd').value='';
+  history.push(v);if(history.length>50)history.shift();histIdx=history.length;localStorage.setItem('mc_hist',JSON.stringify(history));
+  try{
+    const r=await fetch('/api/cmd',{method:'POST',body:new URLSearchParams({cmd:v})});
+    const t=await r.text();
+    $('out').value+='\n'+(t||'(no reply)');
+    $('out').scrollTop=$('out').scrollHeight;
+    refresh();
+  }catch(e){$('out').value+='\nERROR: '+e}
+}
+function preset(c){$('cmd').value=c;runCmd();}
+
+$('cmd').addEventListener('keydown',(e)=>{
+  if(e.key==='Enter'){e.preventDefault();runCmd();}
+  else if(e.key==='ArrowUp' && histIdx>0){histIdx--;$('cmd').value=history[histIdx]||''}
+  else if(e.key==='ArrowDown' && histIdx<history.length){histIdx++;$('cmd').value=history[histIdx]||''}
+});
+
+fetch('/mqtt-status').then(r=>{if(r.ok)$('mqtt-btn').style.display='inline-block'}).catch(()=>{});
+fetch('/api/channels').then(r=>{if(r.ok)$('chan-btn').style.display='inline-block'}).catch(()=>{});
+fetch('/api/blacklist').then(r=>{if(r.ok)$('blacklist-btn').style.display='inline-block'}).catch(()=>{});
+refresh();setInterval(refresh,15000);
+wsConnect();
+</script></body></html>)HTML";
+
+}  // namespace
+
+WifiAdminUI& _adminInstance() {
+  static WifiAdminUI* dummy = nullptr; (void)dummy;
+  return *g_admin_ui;
+}
+
+void wifiAdminPushRxPacket(float snr, float rssi, const uint8_t* raw, int len) {
+  if (g_admin_ui) g_admin_ui->pushRxPacket(snr, rssi, raw, len);
+}
+
+void wifiAdminPushTxPacket(const uint8_t* raw, int len) {
+  if (g_admin_ui) g_admin_ui->pushTxPacket(raw, len);
+}
+
+void wifiAdminPushChat(const char* channel, const char* sender, const char* text, uint32_t timestamp) {
+  if (g_admin_ui) g_admin_ui->pushChat(channel, sender, text, timestamp);
+}
+
+WifiAdminUI::WifiAdminUI(AsyncWebServer* server, MeshInfoProvider* mesh, WifiCmdHandler cmd_handler)
+  : _server(server), _mesh(mesh), _cmd_handler(cmd_handler) {
+  g_admin_ui = this;
+}
+
+namespace {
+String _packetToJson(bool is_rx, float snr, float rssi, const uint8_t* raw, int len) {
+  static const char H[] = "0123456789abcdef";
+  String hex; hex.reserve(2 * len);
+  for (int i = 0; i < len; i++) { hex += H[(raw[i] >> 4) & 0xF]; hex += H[raw[i] & 0xF]; }
+  String out = "{";
+  if (is_rx) {
+    out += "\"dir\":\"rx\",\"rssi\":"; out += String((int)rssi);
+    out += ",\"snr\":"; out += String(snr, 2);
+    out += ",\"len\":"; out += String(len);
+  } else {
+    out += "\"dir\":\"tx\",\"len\":"; out += String(len);
+  }
+  out += ",\"raw\":\""; out += hex; out += "\"}";
+  return out;
+}
+}
+
+void WifiAdminUI::pushRxPacket(float snr, float rssi, const uint8_t* raw, int len) {
+  if (!_ws || _ws->count() == 0) return;
+  _ws->textAll(_packetToJson(true, snr, rssi, raw, len));
+}
+
+void WifiAdminUI::pushTxPacket(const uint8_t* raw, int len) {
+  if (!_ws || _ws->count() == 0) return;
+  _ws->textAll(_packetToJson(false, 0, 0, raw, len));
+}
+
+namespace {
+String _jsEscape(const char* s) {
+  String out; out.reserve(strlen(s) + 8);
+  for (const char* p = s; *p; p++) {
+    char c = *p;
+    if (c == '"' || c == '\\') { out += '\\'; out += c; }
+    else if (c == '\n') out += "\\n";
+    else if (c == '\r') out += "\\r";
+    else if (c == '\t') out += "\\t";
+    else if ((uint8_t)c < 0x20) { char b[8]; snprintf(b, sizeof(b), "\\u%04x", c); out += b; }
+    else out += c;
+  }
+  return out;
+}
+}
+
+void WifiAdminUI::pushChat(const char* channel, const char* sender, const char* text, uint32_t timestamp) {
+  if (!_ws || _ws->count() == 0) return;
+  String out = "{\"type\":\"chat\",\"ts\":";
+  out += String(timestamp);
+  out += ",\"channel\":\""; out += _jsEscape(channel ? channel : "");
+  out += "\",\"sender\":\""; out += _jsEscape(sender ? sender : "");
+  out += "\",\"text\":\"";   out += _jsEscape(text ? text : "");
+  out += "\"}";
+  _ws->textAll(out);
+}
+
+void WifiAdminUI::begin() {
+  if (!_server) return;
+
+  _ws = new AsyncWebSocket("/ws");
+  _ws->onEvent([](AsyncWebSocket*, AsyncWebSocketClient* c, AwsEventType type, void*, uint8_t*, size_t) {
+    if (type == WS_EVT_CONNECT) {
+      c->text("{\"hello\":\"meshcore\"}");
+    }
+  });
+  _server->addHandler(_ws);
+
+  _server->on("/", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", ADMIN_HTML);
+  });
+
+  _server->on("/api/status", HTTP_GET, [this](AsyncWebServerRequest* req) {
+    String out = "{";
+    out += "\"name\":\""; out += _mesh->nodeName(); out += "\",";
+    out += "\"role\":\""; out += _mesh->role(); out += "\",";
+    out += "\"fw\":\"";   out += _mesh->firmwareVer(); out += "\",";
+    out += "\"uptime_s\":"; out += String(millis() / 1000); out += ",";
+    out += "\"ssid\":\""; out += WiFi.SSID(); out += "\",";
+    out += "\"ip\":\"";   out += WiFi.localIP().toString(); out += "\",";
+    out += "\"rssi\":";   out += String(WiFi.RSSI()); out += ",";
+    out += "\"mac\":\"";  out += WiFi.macAddress(); out += "\"";
+    out += "}";
+    req->send(200, "application/json", out);
+  });
+
+  auto text_route = [this](const char* path, void (MeshInfoProvider::*fn)(char*)) {
+    _server->on(path, HTTP_GET, [this, fn](AsyncWebServerRequest* req) {
+      char buf[2048];
+      buf[0] = '\0';
+      (_mesh->*fn)(buf);
+      req->send(200, "text/plain", buf);
+    });
+  };
+  text_route("/api/stats",        &MeshInfoProvider::formatStats);
+  text_route("/api/radio-stats",  &MeshInfoProvider::formatRadioStats);
+  text_route("/api/packet-stats", &MeshInfoProvider::formatPacketStats);
+  text_route("/api/neighbours",   &MeshInfoProvider::formatNeighbours);
+  text_route("/api/radio-config", &MeshInfoProvider::formatRadioConfig);
+
+  _server->on("/api/reboot", HTTP_POST, [](AsyncWebServerRequest* req) {
+    req->send(200, "text/plain", "ok");
+    delay(200);
+    ESP.restart();
+  });
+
+  // Shared stylesheet for /, /channels, /mqtt-setup so they look like one app.
+  _server->on("/style.css", HTTP_GET, [](AsyncWebServerRequest* req) {
+    AsyncWebServerResponse* r = req->beginResponse_P(200, "text/css", SHARED_CSS);
+    r->addHeader("Cache-Control", "max-age=3600");
+    req->send(r);
+  });
+
+  // Channels admin
+  _server->on("/channels", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", CHANNELS_HTML);
+  });
+  _server->on("/api/channels", HTTP_GET, [this](AsyncWebServerRequest* req) {
+    char buf[512]; buf[0] = 0;
+    _mesh->listChannels(buf);
+    req->send(200, "text/plain", buf);
+  });
+  _server->on("/api/channels-save", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    if (!req->hasParam("name", true) || !req->hasParam("psk", true)) {
+      req->send(400, "text/plain", "missing name or psk"); return;
+    }
+    String name = req->getParam("name", true)->value();
+    String psk  = req->getParam("psk", true)->value();
+    if (name.length() == 0 || name.length() > 23) { req->send(400, "text/plain", "bad name length"); return; }
+    if (psk.length() < 16 || psk.length() > 47) { req->send(400, "text/plain", "bad psk length"); return; }
+    if (_mesh->addChannel(name.c_str(), psk.c_str())) {
+      req->send(200, "text/plain", "channel added");
+    } else {
+      req->send(409, "text/plain", "add failed (duplicate, capacity, or invalid PSK)");
+    }
+  });
+
+  // Forwarding blacklist
+  _server->on("/blacklist", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", BLACKLIST_HTML);
+  });
+  _server->on("/api/blacklist", HTTP_GET, [this](AsyncWebServerRequest* req) {
+    char buf[512]; buf[0] = 0;
+    _mesh->listBlocked(buf);
+    req->send(200, "text/plain", buf);
+  });
+  _server->on("/api/blacklist-save", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    if (!req->hasParam("pattern", true)) { req->send(400, "text/plain", "missing pattern"); return; }
+    String pat = req->getParam("pattern", true)->value();
+    if (pat.length() == 0 || pat.length() > 31) { req->send(400, "text/plain", "bad pattern length"); return; }
+    if (_mesh->addBlocked(pat.c_str())) req->send(200, "text/plain", "pattern added");
+    else req->send(409, "text/plain", "add failed (duplicate or capacity)");
+  });
+  _server->on("/api/blacklist-remove", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    if (!req->hasParam("pattern", true)) { req->send(400, "text/plain", "missing pattern"); return; }
+    String pat = req->getParam("pattern", true)->value();
+    if (_mesh->removeBlocked(pat.c_str())) req->send(200, "text/plain", "removed");
+    else req->send(404, "text/plain", "not found");
+  });
+
+  // POST /api/cmd  body: cmd=<cli string>  → reply text
+  // NOTE: handler runs on the AsyncTCP task. MeshCore is not formally thread-safe;
+  // typical CLI commands read simple state so the practical risk is low. If a race
+  // surfaces, this should be queued and processed from the main loop instead.
+  _server->on("/api/cmd", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    if (!_cmd_handler) { req->send(503, "text/plain", "no cmd handler"); return; }
+    if (!req->hasParam("cmd", true)) { req->send(400, "text/plain", "missing cmd"); return; }
+    String cmd = req->getParam("cmd", true)->value();
+    if (cmd.length() == 0 || cmd.length() > 200) { req->send(400, "text/plain", "bad cmd length"); return; }
+    char buf[256]; strncpy(buf, cmd.c_str(), sizeof(buf) - 1); buf[sizeof(buf) - 1] = 0;
+    char reply[512]; reply[0] = 0;
+    _cmd_handler(buf, reply);
+    req->send(200, "text/plain", reply);
+  });
+}
+
+#endif // ESP_PLATFORM

--- a/src/helpers/esp32/WifiAdminUI.cpp
+++ b/src/helpers/esp32/WifiAdminUI.cpp
@@ -155,8 +155,18 @@ button.ghost{background:transparent}
 .kv .k{color:var(--mute);font-size:.85em}
 .kv .v{font-family:var(--mono);text-align:right;color:var(--ink)}
 .kv .v.warn{color:var(--warn)}.kv .v.bad{color:var(--danger)}.kv .v.good{color:var(--tx)}
-.kv input[type=number],.kv select{padding:.15em .4em;font:inherit;font-family:var(--mono);border:1px solid var(--line);border-radius:3px;background:var(--bg);color:var(--ink);min-width:6em;text-align:right}
+.kv input[type=number],.kv select{padding:.15em .4em;font:inherit;font-family:var(--mono);border:1px solid var(--line);border-radius:3px;background:var(--bg);color:var(--ink);text-align:right}
 .kv select{text-align:left;text-align-last:left}
+.kv input[type=number]{width:7em}.kv select{min-width:9em;max-width:14em}
+.rcard{background:var(--card);border:1px solid var(--line);border-radius:6px;padding:.6em;margin:.6em 0}
+.rcard h3{margin:0 0 .5em;font-size:.85em;color:var(--mute);text-transform:uppercase;letter-spacing:.04em}
+.rcard .kv{grid-template-columns:minmax(9em,11em) auto;column-gap:1em;row-gap:.3em}
+.rcard .kv .v{text-align:left}
+.rcard .unit{color:var(--mute);margin-left:.4em;font-family:var(--mono);font-size:.9em}
+.rcard .presets{margin-top:.7em;padding-top:.5em;border-top:1px dashed var(--line)}
+.rcard .presets .lbl{font-size:.8em;color:var(--mute);margin-bottom:.3em}
+.rcard .presets .row{display:flex;flex-wrap:wrap;gap:.35em}
+.rcard .presets button{font-size:.85em;padding:.3em .7em}
 .main{display:grid;grid-template-columns:1fr 360px;gap:.6em;margin-top:.4em}
 @media (max-width:880px){.main{grid-template-columns:1fr}}
 .panel{background:var(--card);border:1px solid var(--line);border-radius:6px;display:flex;flex-direction:column;min-height:320px}
@@ -206,10 +216,15 @@ button.ghost{background:transparent}
 
 <section class=cards>
   <div class=card><h3>Network</h3><div id=net class=kv>&hellip;</div></div>
-  <div class=card><h3>Radio config</h3><div id=rcfg class=kv>&hellip;</div></div>
   <div class=card><h3>Mesh</h3><div id=stats class=kv>&hellip;</div></div>
   <div class=card><h3>Radio stats</h3><div id=rstats class=kv>&hellip;</div></div>
   <div class=card><h3>Packets</h3><div id=pstats class=kv>&hellip;</div></div>
+</section>
+
+<section class=rcard>
+  <h3>Radio config</h3>
+  <div id=rcfg class=kv>&hellip;</div>
+  <div id=rcfg-presets class=presets></div>
 </section>
 
 <div class=main>
@@ -371,14 +386,14 @@ function renderRadioCfg(j){
   const phb=j.path_hash_bytes|0;
   const phCls=phb>=2?'good':'warn';
   const bwOpts=[7.8,10.4,15.6,20.8,31.25,41.7,62.5,125,250,500];
-  const fEd=`<input id=f-ed type=number min=150 max=2500 step=0.025 value="${j.freq.toFixed(3)}" onchange="setFreq(this.value)"> MHz`;
+  const fEd=`<input id=f-ed type=number min=150 max=2500 step=0.025 value="${j.freq.toFixed(3)}" onchange="setFreq(this.value)"><span class=unit>MHz</span>`;
   const bwEd=`<select id=bw-ed onchange="setBw(this.value)">`+
     bwOpts.map(b=>`<option value=${b} ${b===j.bw?'selected':''}>${b.toFixed(b<10?2:1)} kHz</option>`).join('')+`</select>`;
   const sfEd=`<select id=sf-ed onchange="setSf(this.value)">`+
     [5,6,7,8,9,10,11,12].map(s=>`<option value=${s} ${s==j.sf?'selected':''}>SF${s}</option>`).join('')+`</select>`;
   const crEd=`<select id=cr-ed onchange="setCr(this.value)">`+
     [5,6,7,8].map(c=>`<option value=${c} ${c==j.cr?'selected':''}>4/${c}</option>`).join('')+`</select>`;
-  const txEd=`<input id=tx-ed type=number min=-9 max=22 step=1 value="${j.tx_power}" onchange="setTx(this.value)"> dBm`;
+  const txEd=`<input id=tx-ed type=number min=-9 max=22 step=1 value="${j.tx_power}" onchange="setTx(this.value)"><span class=unit>dBm</span>`;
   const phEd=`<select id=ph-ed onchange="setPh(this.value)">`+
     [[0,'1B (default)'],[1,'2B (recommended)'],[2,'3B']].map(([v,l])=>`<option value=${v} ${v==j.path_hash_mode?'selected':''}>${l}</option>`).join('')+`</select>`;
   renderKV($('rcfg'),[
@@ -390,12 +405,11 @@ function renderRadioCfg(j){
     ['Path hash size', phEd, phCls],
     ['RX boosted gain', j.rx_boosted ? 'on' : 'off'],
   ]);
-  // Region preset chips below the kv grid.
-  const presets=document.createElement('div');
-  presets.style.cssText='margin-top:.5em;display:flex;flex-wrap:wrap;gap:.3em';
-  presets.innerHTML='<div style="width:100%;font-size:.8em;color:var(--mute);margin-bottom:.15em">Region presets (sets freq/BW/SF/CR; reboot to apply):</div>'+
-    RADIO_PRESETS.map((p,i)=>`<button style="font-size:.8em;padding:.25em .55em" onclick="applyPreset(${i})">${p[0]}</button>`).join('');
-  $('rcfg').appendChild(presets);
+  $('rcfg-presets').innerHTML=
+    `<div class=lbl>Region presets (applies freq/BW/SF/CR; reboot to take effect):</div>`+
+    `<div class=row>`+
+    RADIO_PRESETS.map((p,i)=>`<button onclick="applyPreset(${i})">${p[0]}</button>`).join('')+
+    `</div>`;
 }
 async function setRadio(freq,bw,sf,cr,reason){
   const cmd=`set radio ${freq},${bw},${sf},${cr}`;

--- a/src/helpers/esp32/WifiAdminUI.h
+++ b/src/helpers/esp32/WifiAdminUI.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+
+#include <Arduino.h>
+#include <ESPAsyncWebServer.h>
+
+// Read-only view into per-role mesh state for the admin web UI. Implemented by the
+// role's main.cpp (which knows the concrete MyMesh type) so this helper stays generic.
+class MeshInfoProvider {
+public:
+  virtual ~MeshInfoProvider() = default;
+  virtual const char* nodeName() = 0;
+  virtual const char* role() = 0;
+  virtual const char* firmwareVer() = 0;
+  // Each formatter must write a null-terminated string of <= 1024 bytes into 'out'.
+  virtual void formatNeighbours(char* out) = 0;
+  virtual void formatStats(char* out) = 0;
+  virtual void formatRadioStats(char* out) = 0;
+  virtual void formatPacketStats(char* out) = 0;
+
+  // Optional: group-channel management. Default impls return empty / fail so non-
+  // repeater roles don't have to care. Repeater overrides delegate to the_mesh.
+  virtual void listChannels(char* out) { out[0] = 0; }
+  virtual bool addChannel(const char* /*name*/, const char* /*psk_base64*/) { return false; }
+
+  // Optional: name-pattern forwarding blacklist.
+  virtual void listBlocked(char* out) { out[0] = 0; }
+  virtual bool addBlocked(const char* /*pattern*/) { return false; }
+  virtual bool removeBlocked(const char* /*pattern*/) { return false; }
+
+  // Optional: LoRa radio params (freq, bw, sf, cr, tx_power_dbm, path_hash_size).
+  // Default no-op so non-repeater roles don't need to implement it.
+  virtual void formatRadioConfig(char* out) { out[0] = 0; }
+};
+
+// Handler invoked when the user runs a CLI command from the web UI. Same shape as
+// the TCP CLI bridge handler so a single adapter in main.cpp serves both.
+typedef void (*WifiCmdHandler)(const char* command, char* reply);
+
+class AsyncWebSocket;
+
+class WifiAdminUI {
+public:
+  WifiAdminUI(AsyncWebServer* server, MeshInfoProvider* mesh, WifiCmdHandler cmd_handler = nullptr);
+  void begin();
+
+  // Broadcast a packet to all connected WS clients as JSON. Safe to call from the
+  // mesh thread (AsyncWebSocket queues to AsyncTCP task internally).
+  void pushRxPacket(float snr, float rssi, const uint8_t* raw, int len);
+  void pushTxPacket(const uint8_t* raw, int len);
+  void pushChat(const char* channel, const char* sender, const char* text, uint32_t timestamp);
+
+private:
+  AsyncWebServer* _server;
+  AsyncWebSocket* _ws = nullptr;
+  MeshInfoProvider* _mesh;
+  WifiCmdHandler _cmd_handler;
+};
+
+// Singleton helpers, mirroring MqttPublisher pattern. The free functions are
+// no-ops until a WifiAdminUI instance has been constructed.
+void wifiAdminPushRxPacket(float snr, float rssi, const uint8_t* raw, int len);
+void wifiAdminPushTxPacket(const uint8_t* raw, int len);
+void wifiAdminPushChat(const char* channel, const char* sender, const char* text, uint32_t timestamp);
+
+#endif // ESP_PLATFORM

--- a/src/helpers/esp32/WifiCliBridge.cpp
+++ b/src/helpers/esp32/WifiCliBridge.cpp
@@ -1,0 +1,58 @@
+#ifdef ESP_PLATFORM
+
+#include "WifiCliBridge.h"
+
+WifiCliBridge::WifiCliBridge(uint16_t port, Handler handler)
+  : _port(port), _handler(handler), _server(port) {
+  _buf[0] = 0;
+}
+
+void WifiCliBridge::begin() {
+  _server.begin();
+  _server.setNoDelay(true);
+}
+
+void WifiCliBridge::loop() {
+  WiFiClient incoming = _server.available();
+  if (incoming) {
+    if (_client && _client.connected()) {
+      _client.println("(displaced)");
+      _client.stop();
+    }
+    _client = incoming;
+    _len = 0;
+    _buf[0] = 0;
+    _client.print("MeshCore CLI ready. Type 'help'.\r\n> ");
+  }
+
+  if (!_client || !_client.connected()) return;
+
+  while (_client.available()) {
+    char c = (char)_client.read();
+    if (c == '\n') continue;       // tolerate CRLF
+    if (c == '\b' || c == 0x7f) {  // backspace / DEL
+      if (_len > 0) { _len--; _buf[_len] = 0; }
+      continue;
+    }
+    if (c == '\r' || _len >= CMD_BUF - 1) {
+      _buf[_len] = 0;
+      if (_len > 0) {
+        char reply[256];
+        reply[0] = 0;
+        _handler(_buf, reply);
+        if (reply[0]) {
+          _client.print(reply);
+          _client.print("\r\n");
+        }
+      }
+      _len = 0;
+      _buf[0] = 0;
+      _client.print("> ");
+      continue;
+    }
+    _buf[_len++] = c;
+    _buf[_len] = 0;
+  }
+}
+
+#endif // ESP_PLATFORM

--- a/src/helpers/esp32/WifiCliBridge.h
+++ b/src/helpers/esp32/WifiCliBridge.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+// Telnet-style TCP CLI bridge: each '\r'-terminated line from a connected client is
+// passed to the provided handler, whose reply is written back to the client. One
+// client at a time; later connections displace the active one.
+
+class WifiCliBridge {
+public:
+  typedef void (*Handler)(const char* command, char* reply);
+
+  WifiCliBridge(uint16_t port, Handler handler);
+  void begin();
+  void loop();
+  bool hasClient() { return _client && _client.connected(); }
+
+private:
+  uint16_t _port;
+  Handler _handler;
+  WiFiServer _server;
+  WiFiClient _client;
+  static constexpr size_t CMD_BUF = 256;
+  char _buf[CMD_BUF];
+  size_t _len = 0;
+};
+
+#endif // ESP_PLATFORM

--- a/src/helpers/esp32/WifiProvisioning.cpp
+++ b/src/helpers/esp32/WifiProvisioning.cpp
@@ -1,0 +1,294 @@
+#ifdef ESP_PLATFORM
+
+#include "WifiProvisioning.h"
+#include <esp_wifi.h>
+
+#ifdef WIFI_DEBUG_LOGGING
+  #define WIFI_LOG(fmt, ...) Serial.printf("[wifi] " fmt "\n", ##__VA_ARGS__)
+#else
+  #define WIFI_LOG(fmt, ...) do {} while (0)
+#endif
+
+namespace {
+const char PORTAL_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html><head>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>MeshCore WiFi Setup</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:480px;margin:1em auto;padding:0 1em;color:#111}
+h1{font-size:1.2em}label{display:block;margin:.6em 0 .2em}input,select,button{font-size:1em;width:100%;padding:.5em;box-sizing:border-box}
+button{margin-top:1em;background:#1a73e8;color:#fff;border:0;border-radius:4px;padding:.7em}
+.row{display:flex;gap:.5em;align-items:center}.row button{width:auto}
+#networks{margin:.5em 0;max-height:240px;overflow:auto;border:1px solid #ddd;border-radius:4px}
+.net{padding:.5em;border-bottom:1px solid #eee;cursor:pointer;display:flex;justify-content:space-between}
+.net:hover{background:#f4f7ff}.net:last-child{border:0}.rssi{color:#888;font-size:.85em}
+.msg{padding:.5em;border-radius:4px;margin-top:1em}.ok{background:#e6f4ea}.err{background:#fce8e6}
+</style></head><body>
+<h1>MeshCore WiFi Setup</h1>
+<div class=row><div style=flex:1>Pick a network or enter one below.</div><button onclick=scan()>Rescan</button></div>
+<div id=networks>Scanning&hellip;</div>
+<form id=f onsubmit="return save(event)">
+<label>SSID<input id=ssid name=ssid required maxlength=32></label>
+<label>Password<input id=pwd name=pwd type=password maxlength=64></label>
+<button type=submit>Save &amp; connect</button>
+</form>
+<div id=msg></div>
+<script>
+async function scan(){const el=document.getElementById('networks');el.textContent='Scanning…';
+  try{const r=await fetch('/scan');const j=await r.json();
+    if(!j.length){el.textContent='No networks found.';return}
+    el.innerHTML=j.map(n=>`<div class=net data-ssid="${n.s.replace(/"/g,'&quot;')}"><span>${n.s||'(hidden)'} ${n.e?'\u{1F512}':''}</span><span class=rssi>${n.r} dBm</span></div>`).join('');
+    el.querySelectorAll('.net').forEach(d=>d.onclick=()=>{document.getElementById('ssid').value=d.dataset.ssid;document.getElementById('pwd').focus()});
+  }catch(e){el.textContent='Scan failed: '+e}
+}
+async function save(ev){ev.preventDefault();const m=document.getElementById('msg');m.className='msg';m.textContent='Saving…';
+  const fd=new FormData(document.getElementById('f'));
+  try{const r=await fetch('/save',{method:'POST',body:new URLSearchParams(fd)});
+    if(r.ok){m.className='msg ok';m.textContent='Saved. Device is rebooting and joining the network.';}
+    else{m.className='msg err';m.textContent='Save failed.'}
+  }catch(e){m.className='msg err';m.textContent='Save failed: '+e}return false}
+scan();
+</script></body></html>)HTML";
+
+const char STATUS_HTML[] PROGMEM = R"HTML(<!DOCTYPE html><html><head>
+<meta name=viewport content="width=device-width,initial-scale=1"><title>MeshCore</title>
+<style>body{font-family:system-ui,sans-serif;max-width:520px;margin:1em auto;padding:0 1em}
+button{font-size:1em;padding:.5em 1em;margin-right:.5em}.danger{background:#c62828;color:#fff;border:0;border-radius:4px}
+pre{background:#f4f4f4;padding:.6em;border-radius:4px;overflow:auto}</style></head><body>
+<h1>MeshCore</h1><pre id=s>loading…</pre>
+<button class=danger onclick="if(confirm('Wipe WiFi credentials and reboot?'))fetch('/wipe-wifi',{method:'POST'}).then(()=>document.body.innerHTML='<p>Rebooting into setup mode…</p>')">Wipe WiFi &amp; reboot</button>
+<script>fetch('/wifi-status').then(r=>r.json()).then(j=>document.getElementById('s').textContent=JSON.stringify(j,null,2));</script>
+</body></html>)HTML";
+}  // namespace
+
+WifiProvisioning::WifiProvisioning(const Config& cfg) : _cfg(cfg) {}
+
+String WifiProvisioning::_buildApSsid() {
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  char buf[40];
+  snprintf(buf, sizeof(buf), "%s-%02X%02X", _cfg.ap_ssid_prefix, mac[4], mac[5]);
+  return String(buf);
+}
+
+IPAddress WifiProvisioning::localIP() const {
+  return _state == State::AP_PORTAL ? WiFi.softAPIP() : WiFi.localIP();
+}
+
+void WifiProvisioning::_checkLongPressWipe() {
+  if (_cfg.user_btn_pin < 0) return;
+  pinMode(_cfg.user_btn_pin, INPUT_PULLUP);
+  delay(20);
+  if (digitalRead(_cfg.user_btn_pin) != LOW) return;
+  WIFI_LOG("button held at boot, timing for wipe...");
+  uint32_t start = millis();
+  while (digitalRead(_cfg.user_btn_pin) == LOW) {
+    if (millis() - start >= _cfg.long_press_ms) {
+      WIFI_LOG("long-press confirmed, clearing creds");
+      _clearCreds();
+      return;
+    }
+    delay(50);
+  }
+}
+
+bool WifiProvisioning::_loadCreds(String& ssid, String& pwd) {
+  _prefs.begin(_cfg.nvs_namespace, true);
+  ssid = _prefs.getString("ssid", "");
+  pwd = _prefs.getString("pwd", "");
+  _prefs.end();
+  if (ssid.length() == 0 && _cfg.bootstrap_ssid) {
+    ssid = _cfg.bootstrap_ssid;
+    pwd = _cfg.bootstrap_password ? _cfg.bootstrap_password : "";
+  }
+  return ssid.length() > 0;
+}
+
+void WifiProvisioning::_saveCreds(const String& ssid, const String& pwd) {
+  _prefs.begin(_cfg.nvs_namespace, false);
+  _prefs.putString("ssid", ssid);
+  _prefs.putString("pwd", pwd);
+  _prefs.end();
+}
+
+void WifiProvisioning::_clearCreds() {
+  _prefs.begin(_cfg.nvs_namespace, false);
+  _prefs.clear();
+  _prefs.end();
+}
+
+bool WifiProvisioning::_tryStaConnect(const String& ssid, const String& pwd) {
+  WIFI_LOG("STA connecting to '%s' (pwd_len=%u)", ssid.c_str(), (unsigned)pwd.length());
+
+  // One-shot event handler to surface low-level disconnect reason codes.
+  // Reason 200+ are auth/4-way-handshake failures, 201 = NO_AP_FOUND, 202 = AUTH_FAIL,
+  // 204 = HANDSHAKE_TIMEOUT, 205 = CONNECTION_FAIL. The bare WL_NO_SSID_AVAIL the
+  // Arduino layer reports can mask several of these.
+  static WiFiEventId_t evt_id = 0;
+  if (evt_id) WiFi.removeEvent(evt_id);
+  evt_id = WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
+    if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED) {
+      WIFI_LOG("STA disconnect reason=%u", (unsigned)info.wifi_sta_disconnected.reason);
+    } else if (event == ARDUINO_EVENT_WIFI_STA_CONNECTED) {
+      WIFI_LOG("STA associated, awaiting IP");
+    } else if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
+      WIFI_LOG("STA got IP");
+    }
+  });
+
+  // Fully clear any prior WiFi state (esp. lingering AP mode from previous boot).
+  WiFi.disconnect(true, true);
+  delay(100);
+  WiFi.mode(WIFI_STA);
+  delay(100);
+  WiFi.setSleep(false);            // helps with RX reliability on some routers
+  WiFi.setAutoReconnect(true);
+  WiFi.begin(ssid.c_str(), pwd.c_str());
+
+  uint32_t deadline = millis() + _cfg.sta_attempt_timeout_ms;
+  while (millis() < deadline) {
+    wl_status_t st = WiFi.status();
+    if (st == WL_CONNECTED) {
+      WIFI_LOG("STA up, IP=%s rssi=%d", WiFi.localIP().toString().c_str(), WiFi.RSSI());
+      return true;
+    }
+    delay(250);
+  }
+  WIFI_LOG("STA attempt timed out (status=%d)", (int)WiFi.status());
+  WiFi.disconnect(true, false);
+  return false;
+}
+
+void WifiProvisioning::_startApPortal() {
+  WIFI_LOG("starting AP portal '%s'", _ap_ssid.c_str());
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP(_ap_ssid.c_str(), _cfg.ap_password);
+  delay(100);
+  IPAddress ip = WiFi.softAPIP();
+  WIFI_LOG("AP IP=%s", ip.toString().c_str());
+
+  _dns = new DNSServer();
+  _dns->setErrorReplyCode(DNSReplyCode::NoError);
+  _dns->start(_cfg.dns_port, "*", ip);
+
+  _server = new AsyncWebServer(_cfg.web_port);
+  _registerPortalRoutes();
+  _server->begin();
+  _state = State::AP_PORTAL;
+}
+
+void WifiProvisioning::_startStaWebServer() {
+  // Lazy: only spin up the server if a caller asks via webServer(); status routes are
+  // attached the first time the server is materialized.
+  if (_server) return;
+  _server = new AsyncWebServer(_cfg.web_port);
+  _registerStatusRoutes();
+  _server->begin();
+}
+
+void WifiProvisioning::_registerPortalRoutes() {
+  _server->on("/", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", PORTAL_HTML);
+  });
+
+  _server->on("/scan", HTTP_GET, [](AsyncWebServerRequest* req) {
+    int n = WiFi.scanComplete();
+    if (n == WIFI_SCAN_RUNNING) { req->send(200, "application/json", "[]"); return; }
+    if (n < 0) { WiFi.scanNetworks(true); req->send(200, "application/json", "[]"); return; }
+    String out = "[";
+    for (int i = 0; i < n; i++) {
+      if (i) out += ',';
+      String s = WiFi.SSID(i);
+      s.replace("\\", "\\\\"); s.replace("\"", "\\\"");
+      out += "{\"s\":\""; out += s;
+      out += "\",\"r\":"; out += String(WiFi.RSSI(i));
+      out += ",\"e\":"; out += (WiFi.encryptionType(i) == WIFI_AUTH_OPEN ? "false" : "true");
+      out += "}";
+    }
+    out += "]";
+    WiFi.scanDelete();
+    WiFi.scanNetworks(true);
+    req->send(200, "application/json", out);
+  });
+
+  _server->on("/save", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    if (!req->hasParam("ssid", true)) { req->send(400, "text/plain", "missing ssid"); return; }
+    String ssid = req->getParam("ssid", true)->value();
+    String pwd = req->hasParam("pwd", true) ? req->getParam("pwd", true)->value() : String();
+    if (ssid.length() == 0 || ssid.length() > 32) { req->send(400, "text/plain", "bad ssid"); return; }
+    _saveCreds(ssid, pwd);
+    req->send(200, "text/plain", "ok");
+    _reboot_pending = true;
+    _reboot_at_ms = millis() + 800;
+  });
+
+  // Captive-portal probes: send everything to root so the OS pops the portal.
+  _server->onNotFound([this](AsyncWebServerRequest* req) {
+    req->redirect("http://" + WiFi.softAPIP().toString() + "/");
+  });
+
+  // Kick off an initial scan in the background.
+  WiFi.scanNetworks(true);
+}
+
+void WifiProvisioning::_registerStatusRoutes() {
+  // STA-mode routes live under /wifi-* so callers (e.g. WifiAdminUI) own '/'.
+  _server->on("/wifi-setup", HTTP_GET, [](AsyncWebServerRequest* req) {
+    req->send_P(200, "text/html", STATUS_HTML);
+  });
+  _server->on("/wifi-status", HTTP_GET, [this](AsyncWebServerRequest* req) {
+    String out = "{";
+    out += "\"ssid\":\"" + WiFi.SSID() + "\",";
+    out += "\"ip\":\"" + WiFi.localIP().toString() + "\",";
+    out += "\"rssi\":" + String(WiFi.RSSI()) + ",";
+    out += "\"mac\":\"" + WiFi.macAddress() + "\"";
+    out += "}";
+    req->send(200, "application/json", out);
+  });
+  _server->on("/wipe-wifi", HTTP_POST, [this](AsyncWebServerRequest* req) {
+    req->send(200, "text/plain", "ok");
+    _clearCreds();
+    _reboot_pending = true;
+    _reboot_at_ms = millis() + 500;
+  });
+}
+
+void WifiProvisioning::wipeAndReboot() {
+  _clearCreds();
+  delay(200);
+  ESP.restart();
+}
+
+void WifiProvisioning::begin() {
+  _ap_ssid = _buildApSsid();
+  _checkLongPressWipe();
+
+  String ssid, pwd;
+  bool have_creds = _loadCreds(ssid, pwd);
+
+  if (have_creds) {
+    _state = State::STA_CONNECTING;
+    for (uint8_t i = 0; i < _cfg.sta_max_attempts; i++) {
+      if (_tryStaConnect(ssid, pwd)) {
+        _state = State::STA_CONNECTED;
+        _startStaWebServer();
+        return;
+      }
+      delay(500);
+    }
+    WIFI_LOG("STA failed %u times, falling back to AP", (unsigned)_cfg.sta_max_attempts);
+  }
+  _startApPortal();
+}
+
+void WifiProvisioning::loop() {
+  if (_reboot_pending && (int32_t)(millis() - _reboot_at_ms) >= 0) {
+    WIFI_LOG("rebooting on request");
+    delay(50);
+    ESP.restart();
+  }
+  if (_state == State::AP_PORTAL && _dns) {
+    _dns->processNextRequest();
+  }
+}
+
+#endif // ESP_PLATFORM

--- a/src/helpers/esp32/WifiProvisioning.h
+++ b/src/helpers/esp32/WifiProvisioning.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <Preferences.h>
+#include <DNSServer.h>
+#include <ESPAsyncWebServer.h>
+
+// AP-first WiFi provisioning with NVS-persisted STA credentials.
+// Boot order: long-press USER_BTN to force AP, else try STA from NVS (3 attempts),
+// else fall back to AP captive portal. Save from the portal triggers a reboot into STA.
+
+class WifiProvisioning {
+public:
+  struct Config {
+    const char* nvs_namespace = "mc-wifi";
+    const char* ap_ssid_prefix = "MeshCore-Setup";
+    const char* ap_password = "meshcore123";       // 8+ chars required by ESP32 softAP
+    int user_btn_pin = -1;                          // <0 disables long-press wipe
+    uint32_t long_press_ms = 5000;
+    uint8_t sta_max_attempts = 3;
+    uint32_t sta_attempt_timeout_ms = 15000;
+    uint16_t web_port = 80;
+    uint16_t dns_port = 53;
+    const char* bootstrap_ssid = nullptr;           // optional: seed NVS on first boot
+    const char* bootstrap_password = nullptr;
+  };
+
+  enum class State { BOOT, STA_CONNECTING, STA_CONNECTED, AP_PORTAL };
+
+  explicit WifiProvisioning(const Config& cfg);
+
+  // Blocks until STA is up or AP portal is running. Safe to call once from setup().
+  void begin();
+
+  // Must be polled from loop(); drives DNSServer in AP mode and reconnect logic in STA.
+  void loop();
+
+  bool isReady() const { return _state == State::STA_CONNECTED || _state == State::AP_PORTAL; }
+  bool inApMode() const { return _state == State::AP_PORTAL; }
+  bool inStaMode() const { return _state == State::STA_CONNECTED; }
+  State state() const { return _state; }
+
+  IPAddress localIP() const;
+  String apSsid() const { return _ap_ssid; }
+
+  // Returns the underlying server so other modules (e.g. WifiAdminUI) can attach routes
+  // after provisioning is complete. Only valid once STA is up; in AP mode the server is
+  // dedicated to the captive portal.
+  AsyncWebServer* webServer() { return _server; }
+
+  // Wipes saved creds and reboots into AP portal. Safe to call from a web handler.
+  void wipeAndReboot();
+
+private:
+  void _checkLongPressWipe();
+  bool _loadCreds(String& ssid, String& pwd);
+  void _saveCreds(const String& ssid, const String& pwd);
+  void _clearCreds();
+  bool _tryStaConnect(const String& ssid, const String& pwd);
+  void _startApPortal();
+  void _startStaWebServer();
+  void _registerPortalRoutes();
+  void _registerStatusRoutes();
+  String _buildApSsid();
+
+  Config _cfg;
+  Preferences _prefs;
+  DNSServer* _dns = nullptr;
+  AsyncWebServer* _server = nullptr;
+  State _state = State::BOOT;
+  String _ap_ssid;
+  bool _portal_routes_registered = false;
+  bool _status_routes_registered = false;
+  // Saved-cred staging for /save handler -> main loop reboot:
+  volatile bool _reboot_pending = false;
+  uint32_t _reboot_at_ms = 0;
+};
+
+#endif // ESP_PLATFORM

--- a/variants/heltec_e213/platformio.ini
+++ b/variants/heltec_e213/platformio.ini
@@ -171,3 +171,52 @@ lib_deps =
 extends = Heltec_E213_base
 build_src_filter = ${Heltec_E213_base.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:Heltec_E213_repeater_wifi]
+extends = Heltec_E213_base
+build_flags =
+  ${Heltec_E213_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec E213 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_E213_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_E213_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_E213_room_server_wifi]
+extends = Heltec_E213_base
+build_flags =
+  ${Heltec_E213_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec E213 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_E213_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_E213_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0

--- a/variants/heltec_e290/platformio.ini
+++ b/variants/heltec_e290/platformio.ini
@@ -166,3 +166,52 @@ lib_deps =
 extends = Heltec_E290_base
 build_src_filter = ${Heltec_E290_base.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:Heltec_E290_repeater_wifi]
+extends = Heltec_E290_base
+build_flags =
+  ${Heltec_E290_base.build_flags}
+  -D DISPLAY_CLASS=E290Display
+  -D ADVERT_NAME='"Heltec E290 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_E290_base.build_src_filter}
+  +<helpers/ui/E290Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_E290_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_E290_room_server_wifi]
+extends = Heltec_E290_base
+build_flags =
+  ${Heltec_E290_base.build_flags}
+  -D DISPLAY_CLASS=E290Display
+  -D ADVERT_NAME='"Heltec E290 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_E290_base.build_src_filter}
+  +<helpers/ui/E290Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_E290_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0

--- a/variants/heltec_t190/platformio.ini
+++ b/variants/heltec_t190/platformio.ini
@@ -158,3 +158,47 @@ lib_deps =
 extends = Heltec_T190_base
 build_src_filter = ${Heltec_T190_base.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:Heltec_T190_repeater_wifi_]
+extends = Heltec_T190_base
+build_flags =
+  ${Heltec_T190_base.build_flags}
+  -D ADVERT_NAME='"Heltec T190 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_T190_base.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_T190_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_T190_room_server_wifi_]
+extends = Heltec_T190_base
+build_flags =
+  ${Heltec_T190_base.build_flags}
+  -D ADVERT_NAME='"Heltec T190 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_T190_base.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_T190_base.lib_deps}
+  ${esp32_ota.lib_deps}

--- a/variants/heltec_tracker/platformio.ini
+++ b/variants/heltec_tracker/platformio.ini
@@ -191,3 +191,53 @@ lib_deps =
 extends = Heltec_tracker_base
 build_src_filter = ${Heltec_tracker_base.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:Heltec_Wireless_Tracker_repeater_wifi]
+extends = Heltec_tracker_base
+build_flags =
+  ${Heltec_tracker_base.build_flags}
+  -D DISPLAY_ROTATION=1
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_tracker_base.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_tracker_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_Wireless_Tracker_room_server_wifi]
+extends = Heltec_tracker_base
+build_flags =
+  ${Heltec_tracker_base.build_flags}
+  -D DISPLAY_ROTATION=1
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_tracker_base.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_tracker_base.lib_deps}
+  ${esp32_ota.lib_deps}

--- a/variants/heltec_tracker_v2/platformio.ini
+++ b/variants/heltec_tracker_v2/platformio.ini
@@ -185,8 +185,9 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D DISPLAY_CLASS=ST7735Display
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"mypwd"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"mypwd"'
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -198,7 +199,56 @@ build_src_filter = ${Heltec_tracker_v2.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${Heltec_tracker_v2.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:heltec_tracker_v2_repeater_wifi]
+extends = Heltec_tracker_v2
+build_flags =
+  ${Heltec_tracker_v2.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_tracker_v2.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_tracker_v2.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:heltec_tracker_v2_room_server_wifi]
+extends = Heltec_tracker_v2
+build_flags =
+  ${Heltec_tracker_v2.build_flags}
+  -D DISPLAY_CLASS=ST7735Display
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_tracker_v2.build_src_filter}
+  +<helpers/ui/ST7735Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_tracker_v2.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:heltec_tracker_v2_sensor]
 extends = Heltec_tracker_v2

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -188,8 +188,9 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D DISPLAY_CLASS=SSD1306Display
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"mypwd"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"mypwd"'
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -201,7 +202,56 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:Heltec_v3_repeater_wifi]
+extends = Heltec_lora32_v3
+build_flags =
+  ${Heltec_lora32_v3.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_v3_room_server_wifi]
+extends = Heltec_lora32_v3
+build_flags =
+  ${Heltec_lora32_v3.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:Heltec_v3_sensor]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -232,8 +232,9 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=SSD1306Display
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"mypwd"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"mypwd"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${heltec_v4_oled.build_src_filter}
@@ -244,7 +245,56 @@ build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_repeater_wifi]
+extends = heltec_v4_oled
+build_flags =
+  ${heltec_v4_oled.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_oled.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:heltec_v4_room_server_wifi]
+extends = heltec_v4_oled
+build_flags =
+  ${heltec_v4_oled.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_oled.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:heltec_v4_sensor]
 extends = heltec_v4_oled
@@ -396,8 +446,9 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=ST7789LCDDisplay
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"mypwd"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"mypwd"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${heltec_v4_tft.build_src_filter}
@@ -408,7 +459,56 @@ build_src_filter = ${heltec_v4_tft.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_tft_repeater_wifi]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:heltec_v4_tft_room_server_wifi]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
 
 [env:heltec_v4_tft_sensor]
 extends = heltec_v4_tft

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -170,3 +170,52 @@ lib_deps =
 extends = Heltec_Wireless_Paper_base
 build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
   +<../examples/kiss_modem/>
+
+[env:Heltec_Wireless_Paper_repeater_wifi]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec WP Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:Heltec_Wireless_Paper_room_server_wifi]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec WP Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0

--- a/variants/lilygo_teth_elite/TETHEliteBoard.h
+++ b/variants/lilygo_teth_elite/TETHEliteBoard.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <helpers/ESP32Board.h>
+
+class TETHEliteBoard : public ESP32Board {
+public:
+  const char* getManufacturerName() const override {
+    return "LilyGO T-ETH Elite";
+  }
+};

--- a/variants/lilygo_teth_elite/platformio.ini
+++ b/variants/lilygo_teth_elite/platformio.ini
@@ -1,0 +1,99 @@
+[LilyGo_TETH_Elite_sx1262]
+extends = esp32_base
+board = esp32s3box
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/lilygo_teth_elite
+  -D BOARD_HAS_PSRAM
+  -D LILYGO_TETH_ELITE
+  -D LILYGO_T_ETH_ELITE_ESP32S3
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D P_LORA_DIO_1=8
+  -D P_LORA_NSS=40
+  -D P_LORA_RESET=46
+  -D P_LORA_BUSY=16
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=9
+  -D P_LORA_MOSI=11
+  -D P_LORA_TX_LED=38
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=8
+  -D SX126X_RX_BOOSTED_GAIN=1
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lilygo_teth_elite>
+lib_deps =
+  ${esp32_base.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_repeater]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_room_server]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_usb]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:LilyGo_TETH_Elite_sx1262_companion_radio_ble]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_teth_elite/platformio.ini
+++ b/variants/lilygo_teth_elite/platformio.ini
@@ -65,6 +65,50 @@ lib_deps =
   ${LilyGo_TETH_Elite_sx1262.lib_deps}
   ${esp32_ota.lib_deps}
 
+[env:LilyGo_TETH_Elite_sx1262_repeater_wifi]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:LilyGo_TETH_Elite_sx1262_room_server_wifi]
+extends = LilyGo_TETH_Elite_sx1262
+build_flags =
+  ${LilyGo_TETH_Elite_sx1262.build_flags}
+  -D ADVERT_NAME='"T-ETH Elite Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${LilyGo_TETH_Elite_sx1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
 [env:LilyGo_TETH_Elite_sx1262_companion_radio_usb]
 extends = LilyGo_TETH_Elite_sx1262
 build_flags =

--- a/variants/lilygo_teth_elite/target.cpp
+++ b/variants/lilygo_teth_elite/target.cpp
@@ -1,0 +1,43 @@
+#include <Arduino.h>
+#include "target.h"
+
+TETHEliteBoard board;
+
+static SPIClass spi(HSPI);
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+#ifndef LORA_CR
+  #define LORA_CR      5
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&spi);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/lilygo_teth_elite/target.h
+++ b/variants/lilygo_teth_elite/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include "TETHEliteBoard.h"
+
+extern TETHEliteBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();

--- a/variants/rak3112/platformio.ini
+++ b/variants/rak3112/platformio.ini
@@ -115,6 +115,50 @@ lib_deps =
   ${rak3112.lib_deps}
   ${esp32_ota.lib_deps}
 
+[env:RAK_3112_repeater_wifi]
+extends = rak3112
+build_flags =
+  ${rak3112.build_flags}
+  -D ADVERT_NAME='"RAK3112 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak3112.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${rak3112.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+  bakercp/CRC32 @ ^2.0.0
+
+[env:RAK_3112_room_server_wifi]
+extends = rak3112
+build_flags =
+  ${rak3112.build_flags}
+  -D ADVERT_NAME='"RAK3112 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak3112.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${rak3112.lib_deps}
+  ${esp32_ota.lib_deps}
+
 [env:RAK_3112_terminal_chat]
 extends = rak3112
 build_flags =
@@ -174,8 +218,9 @@ build_flags =
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"mypwd"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"mypwd"'
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -185,6 +230,7 @@ build_src_filter = ${rak3112.build_src_filter}
   +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =
   ${rak3112.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:RAK_3112_sensor]

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -3,17 +3,11 @@ extends = esp32_base
 board = seeed_xiao_esp32s3
 board_check = true
 board_build.mcu = esp32s3
-build_unflags =
-  -D LORA_FREQ=869.618
-  -D LORA_SF=8
 build_flags = ${esp32_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/xiao_s3_wio
   -UENV_INCLUDE_GPS
   -D SEEED_XIAO_S3
-  ; USA/Canada region (per docs/faq.md): 910.525 MHz, BW 62.5 (base), SF 7, CR 5 (default)
-  -D LORA_FREQ=910.525
-  -D LORA_SF=7
   -D P_LORA_DIO_1=39
   -D P_LORA_NSS=41
   -D P_LORA_RESET=42   ; RADIOLIB_NC

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -3,11 +3,17 @@ extends = esp32_base
 board = seeed_xiao_esp32s3
 board_check = true
 board_build.mcu = esp32s3
+build_unflags =
+  -D LORA_FREQ=869.618
+  -D LORA_SF=8
 build_flags = ${esp32_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/xiao_s3_wio
   -UENV_INCLUDE_GPS
   -D SEEED_XIAO_S3
+  ; USA/Canada region (per docs/faq.md): 910.525 MHz, BW 62.5 (base), SF 7, CR 5 (default)
+  -D LORA_FREQ=910.525
+  -D LORA_SF=7
   -D P_LORA_DIO_1=39
   -D P_LORA_NSS=41
   -D P_LORA_RESET=42   ; RADIOLIB_NC
@@ -76,6 +82,29 @@ lib_deps =
 ;   ${Xiao_S3_WIO.lib_deps}
 ;   ${esp32_ota.lib_deps}
 
+[env:Xiao_S3_WIO_repeater_wifi]
+extends = Xiao_S3_WIO
+build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_repeater/*.cpp>
+build_flags =
+  ${Xiao_S3_WIO.build_flags}
+  -D ADVERT_NAME='"XiaoS3 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
+  -D MQTT_PUBLISHER=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_S3_WIO.lib_deps}
+  ${esp32_ota.lib_deps}
+  knolleary/PubSubClient @ ^2.8
+  densaugeo/base64 @ ~1.4.0
+
 [env:Xiao_S3_WIO_repeater_bridge_espnow]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
@@ -107,6 +136,26 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_S3_WIO.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Xiao_S3_WIO_room_server_wifi]
+extends = Xiao_S3_WIO
+build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/simple_room_server>
+build_flags =
+  ${Xiao_S3_WIO.build_flags}
+  -D ADVERT_NAME='"XiaoS3 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D WIFI_PROVISIONING=1
+  -D WIFI_DEBUG_LOGGING=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 lib_deps =
@@ -210,13 +259,15 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D OFFLINE_QUEUE_SIZE=256
   -D WIFI_DEBUG_LOGGING=1
-  -D WIFI_SSID='"myssid"'
-  -D WIFI_PWD='"password"'
+  -D WIFI_PROVISIONING=1
+  ; -D WIFI_SSID='"myssid"'   ; optional: bootstrap creds on first boot
+  ; -D WIFI_PWD='"password"'
   ; -D BLE_DEBUG_LOGGING=1
   ; -D MESH_PACKET_LOGGING=1
   ; -D MESH_DEBUG=1
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
+  ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:Xiao_S3_WIO_sensor]


### PR DESCRIPTION
## Summary

  Adds runtime WiFi provisioning (AP captive portal → STA, NVS-persisted) and a
  self-contained web admin / TCP-CLI / MQTT stack to MeshCore's ESP32-S3
  variants. Everything is opt-in via build flags and gated by `#ifdef
  WIFI_PROVISIONING` / `#ifdef MQTT_PUBLISHER`, so all existing envs are
  unchanged. New `_repeater_wifi` and `_room_server_wifi` envs are added for
  every WiFi-capable ESP32-S3 board MeshCore supports; existing
  `_companion_radio_wifi` envs are migrated from baked `WIFI_SSID`/`WIFI_PWD`
  to the provisioning portal.

  ## Motivation

  Today, getting a MeshCore node onto a network requires baking the SSID and
  password into firmware at compile time, and there is no in-firmware
  remote-admin surface beyond the serial CLI. For users running headless
  repeaters and room servers - exactly the roles where being unable to plug
  in a USB cable matters most - that means re-flashing to change networks
  and no live visibility into mesh traffic without external tooling.

  This PR closes that gap on the ESP32-S3 family (where the chip already has
  WiFi + BLE silicon that today is mostly idle in repeater/room-server
  roles):

  - **Provision over WiFi without recompiling.** Boot, connect to the AP,
    pick a network, save. Falls back to AP automatically after 3 failed STA
    attempts so a router password change doesn't brick the node.
  - **See and control the node from a phone or laptop on the same LAN.**
    Status, mesh/radio/packet stats, live decoded chat (Public channel +
    user-added group PSKs), live raw packet feed, editable LoRa params,
    region presets, name-pattern forwarding blacklist, MQTT publisher.
  - **Stream every observed RX and repeated TX packet to MQTT** as JSON for
    external dashboards / Grafana / Home Assistant.

  ## What's included

  ### New shared helpers (under `src/helpers/esp32/`)

  | Module | Purpose |
  |---|---|
  | `WifiProvisioning.{h,cpp}` | AP-first captive portal (SSID `MeshCore-Setup-XXXX`, password `meshcore123`), NVS-persisted STA creds in namespace `mc-wifi`, 3-attempt STA fallback to AP, `USER_BTN` long-press wipe (graceful no-op if
  `PIN_USER_BTN<0`), defensive `WiFi.disconnect(true,true)` + `setAutoReconnect(true)` to recover from first-attempt auth failures observed on some routers. |
  | `WifiAdminUI.{h,cpp}` | `AsyncWebServer` admin UI: home (status / radio config / mesh stats / radio stats / packet stats / network), `/channels` (manage group PSKs), `/blacklist` (wildcard name patterns to drop ADVERTs from),
  `/mqtt-setup`. WebSocket `/ws` streams every RX and TX packet plus decoded chat as JSON. Console panel with inline CLI input, command history (localStorage), preset buttons, and `/api/cmd` POST routed through the same `handleCommand` the
  serial CLI uses. Shared `/style.css` with dark-mode CSS variables; all sub-pages link to it. |
  | `WifiCliBridge.{h,cpp}` | Telnet-style TCP CLI on port 5050, one client at a time, displaces older connections. Lines are routed through the same handler as serial. |
  | `MqttPublisher.{h,cpp}` | `PubSubClient`-based publisher with 16-slot async queue (drops oldest under burst), NVS broker config in namespace `mc-mqtt`, configurable via `/mqtt-setup`. Publishes RX (`logRxRaw`) to `<topic>/rx` and TX
  (`logTx`) to `<topic>/tx` as JSON. |

  ### Role wiring

  - `examples/companion_radio/main.cpp` — `WIFI_PROVISIONING` gate replaces
    the baked `WIFI_SSID`/`WIFI_PWD` `WiFi.begin()` path. `SerialWifiInterface`
    still runs on TCP 5000 once STA is up. Optional `WIFI_SSID`/`WIFI_PWD`
    become bootstrap defaults seeded into NVS on first boot.
  - `examples/simple_repeater/main.cpp` and `MyMesh.{h,cpp}` — wires
    provisioning, admin UI, CLI bridge, MQTT publisher.
    - **Chat decoder**: pre-configures the well-known `Public` group channel
      PSK; `loadPersistentChatChannels()` reads user-added channels from NVS
      namespace `mc-chans` on boot. `searchChannelsByHash` +
      `onGroupDataRecv` overrides extract sender + text from decrypted
      `GRP_TXT` payloads and push to the WS feed.
    - **Forwarding blacklist**: glob patterns (`*` and `?`) matched against
      the advertised node name. Hits drop the ADVERT in
      `allowPacketForward` and skip neighbour-table insert in
      `onAdvertRecv`. Persisted in NVS namespace `mc-block` with per-pattern
      hit counters.
    - `logRxRaw` and `logTx` call `wifiAdminPush*` and `mqttPublish*` extern
      helpers (no-ops if their respective modules aren't compiled in).
  - `examples/simple_room_server/main.cpp` — provisioning + admin + CLI
    bridge (no MQTT, no chat decode by default).
  - `examples/{simple_repeater,simple_room_server}/UITask.cpp` — render WiFi
    state on the home screen below freq/bw/cr: green `IP:` + `RSSI:` in STA
    mode, yellow `AP:` SSID in setup mode. Gated by `WIFI_PROVISIONING` so
    non-WiFi envs are unaffected.

  ### Infrastructure

  - `src/helpers/ESP32Board.cpp` - move legacy WiFi-OTA `AsyncWebServer`
    from port 80 to **8306** to avoid colliding with the provisioning web
    server when both code paths are present on the same boot.

  ### New / modified build envs

  Pattern: every WiFi-capable ESP32-S3 board gets a new `_repeater_wifi` and
  `_room_server_wifi` env; the existing `_companion_radio_wifi` (where
  present) flips from baked SSID/PWD to provisioning.

  | Variant | New envs | Modified env |
  |---|---|---|
  | `xiao_s3_wio` | `Xiao_S3_WIO_repeater_wifi`, `Xiao_S3_WIO_room_server_wifi` | `Xiao_S3_WIO_companion_radio_wifi` |
  | `heltec_v4` (OLED + TFT) | `heltec_v4_repeater_wifi`, `heltec_v4_room_server_wifi`, `heltec_v4_tft_repeater_wifi`, `heltec_v4_tft_room_server_wifi` | `heltec_v4_companion_radio_wifi`, `heltec_v4_tft_companion_radio_wifi` |
  | `heltec_v3` | `Heltec_v3_repeater_wifi`, `Heltec_v3_room_server_wifi` | `Heltec_v3_companion_radio_wifi` |
  | `heltec_tracker` | `Heltec_Wireless_Tracker_repeater_wifi`, `_room_server_wifi` | — |
  | `heltec_tracker_v2` | `heltec_tracker_v2_repeater_wifi`, `_room_server_wifi` | `heltec_tracker_v2_companion_radio_wifi` |
  | `heltec_wireless_paper` | `Heltec_Wireless_Paper_repeater_wifi`, `_room_server_wifi` | — |
  | `heltec_t190` | `Heltec_T190_repeater_wifi_`, `_room_server_wifi_` | — |
  | `rak3112` | `RAK_3112_repeater_wifi`, `RAK_3112_room_server_wifi` | `RAK_3112_companion_radio_wifi` |
  | `lilygo_teth_elite` | `LilyGo_TETH_Elite_sx1262_repeater_wifi`, `_room_server_wifi` | — |
  | `heltec_e213` | `Heltec_E213_repeater_wifi`, `Heltec_E213_room_server_wifi` | — |
  | `heltec_e290` | `Heltec_E290_repeater_wifi`, `Heltec_E290_room_server_wifi` | — |

  No existing envs were removed or had their existing behavior changed
  beyond the explicit `_companion_radio_wifi` migration noted above. BLE,
  USB, serial, plain-repeater, plain-room-server, sensor, and bridge envs
  are all untouched.

  ## Hardware testing

  - **Validated end-to-end on Seeed XIAO ESP32-S3 + Wio-SX1262** (US 910.525
    / SF7 / BW62.5 / CR5): captive portal, STA reconnect (including a
    first-attempt `WIFI_REASON_AUTH_FAIL` that the defensive code now
    recovers from automatically), web admin UI, packet feed via WebSocket,
    chat decoding from the Public channel, blacklist drops verified against
    a live node, inline editing of TX power / coding rate / path hash mode,
    region preset switching.
  - **Compile-verified for all 11 ESP32-S3 variants listed above**
    (`pio run -e <env>` clean for every new `_repeater_wifi`; spot-built
    Companion + Room Server flavors of Heltec V4).
  - **MQTT publishing, the chat decoder on user-added channels, the e-paper
    display variants, and most boards beyond Xiao have not yet been
    hardware-tested.** The shared modules are board-agnostic ESP32 code so
    the per-board risk is limited to integration glue, but worth flagging
    for reviewers.

  ## Things explicitly NOT done in this PR

  - **No auth on web / CLI / WebSocket endpoints.** Anyone on the LAN can
    view stats, reboot, wipe creds, or run arbitrary CLI commands. This
    matches the threat model assumed by today's serial CLI (trusted
    physical/local access) but is worth a separate hardening pass before
    recommending exposure to untrusted LANs.
  - **No TLS** for MQTT or the web admin (plain `PubSubClient` over TCP,
    HTTP-only).
  - **Default AP password is `meshcore123`**, same on every device. Fine for
    initial bring-up; a per-device-derived default would be a worthwhile
  - **TFT WiFi-status rendering only added to Heltec V4 TFT envs** (via the
    existing `UITask` code paths for repeater and room server). Other TFT
    boards' UITasks would benefit from the same treatment in a follow-up.
  - **No nRF52 / RP2040 / STM32 support.** These platforms either don't
    have WiFi hardware or (for RP2040 + Pico W) don't expose it in
    MeshCore today. The modules are ESP32-specific by design.
  - **Companion radio's transport stays single-instance** (WiFi or BLE,
    picked at compile time). Running both simultaneously is a bigger
    refactor and isn't done here.

  ## Test plan for reviewers

  - [ ] Build at least one new env per variant family:
        `pio run -e Xiao_S3_WIO_repeater_wifi -e heltec_v4_repeater_wifi -e RAK_3112_repeater_wifi`
  - [ ] Flash to any ESP32-S3 board, confirm the AP `MeshCore-Setup-XXXX`
        appears, password `meshcore123` connects, captive portal pops up,
        `/scan` lists nearby networks, save → reboot → STA.
  - [ ] On the admin UI: confirm packet feed populates when another node
        transmits, confirm decoded chat appears from a Public-channel
        message, confirm CLI commands (`neighbors`, `stats`, `set tx 20`)
        run through `/api/cmd` and through the TCP CLI bridge on port 5050.
  - [ ] In `/blacklist`, add a glob matching another node's name and
        verify the hit counter increments while that node's adverts no
        longer show up in `neighbors`.
  - [ ] In `/mqtt-setup`, point at a broker, reboot, confirm
        `<base>/rx` and `<base>/tx` messages flow.
  - [ ] Confirm the legacy WiFi-OTA flow (`startOTAUpdate`) still works
        on its new port 8306 and doesn't clash with the provisioning
        server.

  ## Process notes for maintainers

  A few things I'd like to surface up front:

  - **No pre-PR issue was opened** per CONTRIBUTING.md's process for
    larger changes. Happy to open one and split this into smaller PRs if
    you'd prefer — provisioning could land first, admin UI second, MQTT
    third, blacklist + chat decoder fourth.
  - **Branched from `main` not `dev`.** Will rebase onto `dev` on request.
  - **Style** broadly matches the existing codebase, but the new helpers
    use more modern C++ (range-for, lambdas, `String`-based JSON
    assembly). Happy to refactor toward whatever matches the rest of the
    esp32 helpers if there's a preferred style.
