### PR TITLE
Add ESP32-C3 SuperMini DX-LR20 variant

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -879,7 +879,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _prefs.gps_enabled = 0;       // GPS disabled by default
   _prefs.gps_interval = 0;      // No automatic GPS updates by default
   //_prefs.rx_delay_base = 10.0f;  enable once new algo fixed
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LLCC68)
 #ifdef SX126X_RX_BOOSTED_GAIN
   _prefs.rx_boosted_gain = SX126X_RX_BOOSTED_GAIN;
 #else

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -904,7 +904,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
 
   _prefs.adc_multiplier = 0.0f; // 0.0f means use default board multiplier
 
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LLCC68)
 #ifdef SX126X_RX_BOOSTED_GAIN
   _prefs.rx_boosted_gain = SX126X_RX_BOOSTED_GAIN;
 #else
@@ -1053,7 +1053,7 @@ void MyMesh::setTxPower(int8_t power_dbm) {
   radio_driver.setTxPower(power_dbm);
 }
 
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LLCC68)
 void MyMesh::setRxBoostedGain(bool enable) {
   radio_driver.setRxBoostedGainMode(enable);
 }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -249,7 +249,7 @@ public:
   // To check if there is pending work
   bool hasPendingWork() const;
 
-#if defined(USE_SX1262) || defined(USE_SX1268)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LLCC68)
   void setRxBoostedGain(bool enable) override;
 #endif
 };

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -547,7 +547,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     _prefs->disable_fwd = memcmp(&config[7], "off", 3) == 0;
     savePrefs();
     strcpy(reply, _prefs->disable_fwd ? "OK - repeat is now OFF" : "OK - repeat is now ON");
-#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110) || defined(USE_LLCC68)
   } else if (memcmp(config, "radio.rxgain ", 13) == 0) {
     _prefs->rx_boosted_gain = memcmp(&config[13], "on", 2) == 0;
     strcpy(reply, "OK");
@@ -769,7 +769,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lat));
   } else if (memcmp(config, "lon", 3) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lon));
-#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110)
+#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110) || defined(USE_LLCC68)
   } else if (memcmp(config, "radio.rxgain", 12) == 0) {
     sprintf(reply, "> %s", _prefs->rx_boosted_gain ? "on" : "off");
 #endif

--- a/src/helpers/radiolib/CustomLLCC68.h
+++ b/src/helpers/radiolib/CustomLLCC68.h
@@ -66,11 +66,11 @@ class CustomLLCC68 : public LLCC68 {
       setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
   #endif
   #if defined(SX126X_RXEN) || defined(SX126X_TXEN)
-    #ifndef SX1262X_RXEN
-      #define SX1262X_RXEN RADIOLIB_NC
+    #ifndef SX126X_RXEN
+      #define SX126X_RXEN RADIOLIB_NC
     #endif
-    #ifndef SX1262X_TXEN
-      #define SX1262X_TXEN RADIOLIB_NC
+    #ifndef SX126X_TXEN
+      #define SX126X_TXEN RADIOLIB_NC
     #endif
       setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
   #endif 

--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -4,6 +4,10 @@
 #include "RadioLibWrappers.h"
 #include "SX126xReset.h"
 
+#ifndef USE_LLCC68
+#define USE_LLCC68
+#endif
+
 class CustomLLCC68Wrapper : public RadioLibWrapper {
 public:
   CustomLLCC68Wrapper(CustomLLCC68& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }

--- a/variants/esp32c3_supermini_dxlr20/ESP32C3SuperMiniDXLR20Board.h
+++ b/variants/esp32c3_supermini_dxlr20/ESP32C3SuperMiniDXLR20Board.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+
+#include <driver/rtc_io.h>
+
+class ESP32C3SuperMiniDXLR20Board : public ESP32Board {
+public:
+  void begin() {
+    ESP32Board::begin();
+
+    esp_reset_reason_t reason = esp_reset_reason();
+    if (reason == ESP_RST_DEEPSLEEP) {
+      long wakeup_source = esp_sleep_get_gpio_wakeup_status();
+      if (wakeup_source & (1 << P_LORA_DIO_1)) {
+        startup_reason = BD_STARTUP_RX_PACKET;
+      }
+    }
+  }
+
+  void enterDeepSleep(uint32_t secs, int8_t wake_pin = -1) {
+    gpio_set_direction((gpio_num_t)P_LORA_DIO_1, GPIO_MODE_INPUT);
+    if (wake_pin >= 0) {
+      gpio_set_direction((gpio_num_t)wake_pin, GPIO_MODE_INPUT);
+    }
+
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+    uint64_t wake_mask = 1ULL << P_LORA_DIO_1;
+    if (wake_pin >= 0) {
+      wake_mask |= 1ULL << wake_pin;
+    }
+    esp_deep_sleep_enable_gpio_wakeup(wake_mask, ESP_GPIO_WAKEUP_GPIO_HIGH);
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup(secs * 1000000ULL);
+    }
+
+    esp_deep_sleep_start();
+  }
+
+  void sleep(uint32_t secs) override {
+    if (!inhibit_sleep) {
+      enterDeepSleep(secs);
+    }
+  }
+
+  const char *getManufacturerName() const override {
+    return "ESP32-C3 SuperMini DX-LR20";
+  }
+};

--- a/variants/esp32c3_supermini_dxlr20/platformio.ini
+++ b/variants/esp32c3_supermini_dxlr20/platformio.ini
@@ -1,0 +1,101 @@
+[ESP32C3_SuperMini_DXLR20]
+extends = esp32_base
+board = esp32-c3-devkitm-1
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/esp32c3_supermini_dxlr20
+  -D ESP32_CPU_FREQ=80
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D PIN_BOARD_SDA=-1
+  -D PIN_BOARD_SCL=-1
+  -D RADIOLIB_EXCLUDE_NRF24=1
+  -D RADIOLIB_EXCLUDE_SX127X=1
+  -D RADIOLIB_EXCLUDE_LR11X0=1
+  -D RADIOLIB_EXCLUDE_LR2021=1
+  -D RADIOLIB_EXCLUDE_LORAWAN=1
+  -D RADIOLIB_EXCLUDE_DIRECT_RECEIVE=1
+  -D RADIOLIB_EXCLUDE_FSK4=1
+  -D RADIOLIB_EXCLUDE_PAGER=1
+  -D RADIOLIB_EXCLUDE_ADSB=1
+  -D RADIOLIB_STATIC_ARRAY_SIZE=512
+  -D USE_LLCC68
+  -D RADIO_CLASS=CustomLLCC68
+  -D WRAPPER_CLASS=CustomLLCC68Wrapper
+  -D P_LORA_SCLK=4
+  -D P_LORA_MISO=5
+  -D P_LORA_MOSI=6
+  -D P_LORA_NSS=7
+  -D P_LORA_DIO_1=0
+  -D P_LORA_DIO_2=3
+  -D P_LORA_BUSY=9
+  -D P_LORA_RESET=10
+  -D SX126X_RXEN=1
+  -D SX126X_TXEN=2
+  -D LORA_TX_POWER=22
+  -D LORA_BW=125
+  -D SX126X_DIO3_TCXO_VOLTAGE=0.0f
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D DISABLE_WIFI_OTA=1
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/esp32c3_supermini_dxlr20/target.cpp>
+lib_deps =
+  ${esp32_base.lib_deps}
+
+[env:ESP32C3_SuperMini_DXLR20_repeater]
+extends = ESP32C3_SuperMini_DXLR20
+build_flags =
+  ${ESP32C3_SuperMini_DXLR20.build_flags}
+  -D ADVERT_NAME='"SuperMini DXLR20 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+build_src_filter = ${ESP32C3_SuperMini_DXLR20.build_src_filter}
+  +<../examples/simple_repeater/*.cpp>
+lib_deps =
+  ${ESP32C3_SuperMini_DXLR20.lib_deps}
+
+[env:ESP32C3_SuperMini_DXLR20_room_server]
+extends = ESP32C3_SuperMini_DXLR20
+build_flags =
+  ${ESP32C3_SuperMini_DXLR20.build_flags}
+  -D ADVERT_NAME='"SuperMini DXLR20 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+build_src_filter = ${ESP32C3_SuperMini_DXLR20.build_src_filter}
+  +<../examples/simple_room_server/*.cpp>
+lib_deps =
+  ${ESP32C3_SuperMini_DXLR20.lib_deps}
+
+[env:ESP32C3_SuperMini_DXLR20_companion_radio_usb]
+extends = ESP32C3_SuperMini_DXLR20
+build_flags =
+  ${ESP32C3_SuperMini_DXLR20.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${ESP32C3_SuperMini_DXLR20.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${ESP32C3_SuperMini_DXLR20.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:ESP32C3_SuperMini_DXLR20_companion_radio_ble]
+extends = ESP32C3_SuperMini_DXLR20
+build_flags =
+  ${ESP32C3_SuperMini_DXLR20.build_flags}
+  -D ADVERT_NAME='"SuperMini DXLR20"'
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${ESP32C3_SuperMini_DXLR20.build_src_filter}
+  +<helpers/esp32/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${ESP32C3_SuperMini_DXLR20.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/esp32c3_supermini_dxlr20/target.cpp
+++ b/variants/esp32c3_supermini_dxlr20/target.cpp
@@ -1,0 +1,37 @@
+#include <Arduino.h>
+#include <SPI.h>
+
+#include "target.h"
+
+ESP32C3SuperMiniDXLR20Board board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock rtc_clock;
+SensorManager sensors;
+
+bool radio_init() {
+  rtc_clock.begin();
+  return radio.std_init(&SPI);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/esp32c3_supermini_dxlr20/target.h
+++ b/variants/esp32c3_supermini_dxlr20/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/SensorManager.h>
+#include <helpers/radiolib/CustomLLCC68Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+
+#include "ESP32C3SuperMiniDXLR20Board.h"
+
+extern ESP32C3SuperMiniDXLR20Board board;
+extern WRAPPER_CLASS radio_driver;
+extern ESP32RTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
  ## Summary

  This adds a new board variant for the ESP32-C3 SuperMini paired with a DX-LR20 module, which uses an LLCC68-compatible
  radio.

  The variant defines the ESP32-C3 pin mapping, LLCC68 radio configuration, USB CDC boot settings, and build
  environments for the common MeshCore roles. It also extends the existing LLCC68 support so this radio can use the same
  rx gain CLI controls and RF switch handling path as the SX126x-style radios.

  ## Changes

  - Added variants/esp32c3_supermini_dxlr20
  - Added build environments for:
      - repeater
      - room server
      - companion radio over USB
      - companion radio over BLE
  - Enabled LLCC68 support for radio.rxgain
  - Fixed LLCC68 RF switch pin fallback handling

  ## Hardware Notes

  The DX-LR20 module used here does not rely on DIO3 TCXO power control. RX/TX switching is handled through external RF
  switch pins.

  Tested pin mapping:
| Signal | GPIO |
|--------|------|
| SCK    | 4    |
| MISO   | 5    |
| MOSI   | 6    |
| NSS    | 7    |
| BUSY   | 9    |
| RESET  | 10   |
| RXEN   | 1    |
| TXEN   | 2    |

  ## Testing

  Built successfully:

  - pio run -e ESP32C3_SuperMini_DXLR20_repeater -j 1
  - pio run -e ESP32C3_SuperMini_DXLR20_room_server -t size -j 1
  - pio run -e ESP32C3_SuperMini_DXLR20_companion_radio_usb -t size -j 1
  - pio run -e ESP32C3_SuperMini_DXLR20_companion_radio_ble -j 1

  Hardware checked on an ESP32-C3 SuperMini with DX-LR20:

  - repeater firmware booted without reset loops
  - BLE companion firmware advertised successfully
  
   Related work: I did not find an existing ESP32-C3 SuperMini + DX-LR20 variant PR. This builds on the existing LLCC68  support and adds a tested board-specific variant.
   #114 Add ProMicroLLCC68 builds
   #552 promicro: added sensor role, removed non-functional llcc68 variant envs
   #499 Xiao ESP32 C3 updates
   #1568 Ported SerialBLEInterface to NimBLE from Bluedroid to support C3 variants
   #1687 Added PowerSaving for all ESP32-based repeaters
   #2131 Add error-aware SX126x receive hook