### PR TITLE
feat: Integrate BME680 Bosch BSEC support for RAK4631

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -21,17 +21,20 @@
 #include <Adafruit_LittleFS.h>
 #include <InternalFileSystem.h>
 static const uint8_t bsec_config_iaq[] = {
-#include "config/generic_33v_3s_28d/bsec_iaq.txt"
+#include "config/generic_33v_3s_28d/bsec_iaq.txt" // 3.3v, LP, 28 day background calibration window
 };
-static Bsec    bsec_iaq;
-static float   bsec_temperature  = 0;
-static float   bsec_humidity     = 0;
-static float   bsec_pressure_hpa = 0;
-static float   bsec_iaq_val      = 0;
-static uint8_t bsec_accuracy     = 0;
-static bool    bsec_active       = false;
-static bool    bsec_data_ready   = false;
+static Bsec     bsec_iaq;
+static float    bsec_temperature     = 0;
+static float    bsec_humidity        = 0;
+static float    bsec_pressure_hpa    = 0;
+static float    bsec_iaq_val         = 0;
+static uint8_t  bsec_accuracy        = 0;
+static bool     bsec_active          = false;
+static bool     bsec_data_ready      = false;
+static bool     bsec_first_save_done = false;
+static uint32_t bsec_last_save_ms    = 0;
 #define BSEC_STATE_FILE "/bsec_state.bin"
+#define BSEC_SAVE_INTERVAL_MS (8UL * 60 * 60 * 1000) // 8 hour state-save interval
 #endif
 
 #ifdef ENV_INCLUDE_BME680
@@ -501,7 +504,6 @@ static uint8_t init_bme680_bsec(TwoWire* wire, uint8_t addr) {
 
 static void query_bme680_bsec(uint8_t ch, uint8_t, CayenneLPP& lpp) {
   if (!bsec_data_ready) return;
-  bsec_data_ready = false;
   lpp.addTemperature(ch, bsec_temperature);
   lpp.addRelativeHumidity(ch, bsec_humidity);
   lpp.addBarometricPressure(ch, bsec_pressure_hpa);
@@ -906,9 +908,18 @@ void EnvironmentSensorManager::loop() {
     bsec_iaq_val      = bsec_iaq.iaq;
     bsec_accuracy     = bsec_iaq.iaqAccuracy;
     bsec_data_ready   = true;
-    if (bsec_accuracy >= 2 && bsec_accuracy > prev_accuracy)
-      bsec_save_state();
+
+    if (bsec_accuracy == 3) {
+      if (!bsec_first_save_done) {
+        bsec_save_state();
+        bsec_last_save_ms = millis();
+        bsec_first_save_done = true;
+      } else if ((millis() - bsec_last_save_ms) >= BSEC_SAVE_INTERVAL_MS) {
+        bsec_save_state();
+        bsec_last_save_ms = millis();
+      }
+    }
   }
-  #endif
+  #endif  // ENV_INCLUDE_BME680_BSEC
 }
 #endif // ENV_INCLUDE_GPS || ENV_INCLUDE_BME680_BSEC

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -12,13 +12,26 @@
 // Sensor library includes and static driver instances
 // ============================================================
 
-#ifdef ENV_INCLUDE_BME680
+#if ENV_INCLUDE_BME680_BSEC
 #ifndef TELEM_BME680_ADDRESS
 #define TELEM_BME680_ADDRESS 0x76
 #endif
 #define TELEM_BME680_SEALEVELPRESSURE_HPA (1013.25)
-#include <Adafruit_BME680.h>
-static Adafruit_BME680 BME680(TELEM_WIRE);
+#include <bsec.h>
+#include <Adafruit_LittleFS.h>
+#include <InternalFileSystem.h>
+static const uint8_t bsec_config_iaq[] = {
+#include "config/generic_33v_3s_28d/bsec_iaq.txt"
+};
+static Bsec    bsec_iaq;
+static float   bsec_temperature  = 0;
+static float   bsec_humidity     = 0;
+static float   bsec_pressure_hpa = 0;
+static float   bsec_iaq_val      = 0;
+static uint8_t bsec_accuracy     = 0;
+static bool    bsec_active       = false;
+static bool    bsec_data_ready   = false;
+#define BSEC_STATE_FILE "/bsec_state.bin"
 #endif
 
 #ifdef ENV_INCLUDE_BMP085
@@ -217,9 +230,10 @@ static void query_bme680(uint8_t ch, uint8_t, CayenneLPP& lpp) {
   if (BME680.performReading()) {
     lpp.addTemperature(ch, BME680.temperature);
     lpp.addRelativeHumidity(ch, BME680.humidity);
-    lpp.addBarometricPressure(ch, BME680.pressure / 100);
-    lpp.addAltitude(ch, 44330.0 * (1.0 - pow((BME680.pressure / 100) / TELEM_BME680_SEALEVELPRESSURE_HPA, 0.1903)));
-    lpp.addAnalogInput(ch, BME680.gas_resistance);
+    const float pressure_hpa = BME680.pressure / 100.0f;
+    lpp.addBarometricPressure(ch, pressure_hpa);
+    lpp.addAltitude(ch, 44330.0f * (1.0f - powf(pressure_hpa / (float)TELEM_BME680_SEALEVELPRESSURE_HPA, 0.1903f)));
+    lpp.addGenericSensor(ch, BME680.gas_resistance);
   }
 }
 #endif
@@ -431,6 +445,63 @@ static void query_rak12035(uint8_t ch, uint8_t sub_ch, CayenneLPP& lpp) {
 }
 #endif
 
+#if ENV_INCLUDE_BME680_BSEC
+static void bsec_load_state() {
+  using namespace Adafruit_LittleFS_Namespace;
+  File f = InternalFS.open(BSEC_STATE_FILE, FILE_O_READ);
+  if (!f) return;
+  uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
+  f.read(state, BSEC_MAX_STATE_BLOB_SIZE);
+  f.close();
+  bsec_iaq.setState(state);
+}
+
+static void bsec_save_state() {
+  using namespace Adafruit_LittleFS_Namespace;
+  uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
+  bsec_iaq.getState(state);
+  InternalFS.remove(BSEC_STATE_FILE);
+  File f = InternalFS.open(BSEC_STATE_FILE, FILE_O_WRITE);
+  if (!f) return;
+  f.write(state, BSEC_MAX_STATE_BLOB_SIZE);
+  f.close();
+}
+
+static uint8_t init_bme680_bsec(TwoWire* wire, uint8_t addr) {
+  bsec_iaq.begin(addr, *wire);
+  if (bsec_iaq.bsecStatus != BSEC_OK) return 0;
+
+  bsec_iaq.setConfig(bsec_config_iaq);
+  if (bsec_iaq.bsecStatus != BSEC_OK) return 0;
+
+  bsec_virtual_sensor_t outputs[] = {
+    BSEC_OUTPUT_IAQ,
+    BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE,
+    BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY,
+    BSEC_OUTPUT_RAW_PRESSURE,
+    BSEC_OUTPUT_STABILIZATION_STATUS,
+    BSEC_OUTPUT_RUN_IN_STATUS,
+  };
+  bsec_iaq.updateSubscription(outputs, 6, BSEC_SAMPLE_RATE_LP);
+  if (bsec_iaq.bsecStatus != BSEC_OK) return 0;
+
+  bsec_load_state();
+  bsec_active = true;
+  return 1;
+}
+
+static void query_bme680_bsec(uint8_t ch, uint8_t, CayenneLPP& lpp) {
+  if (!bsec_data_ready) return;
+  bsec_data_ready = false;
+  lpp.addTemperature(ch, bsec_temperature);
+  lpp.addRelativeHumidity(ch, bsec_humidity);
+  lpp.addBarometricPressure(ch, bsec_pressure_hpa);
+  lpp.addAltitude(ch, 44330.0f * (1.0f - powf(bsec_pressure_hpa / (float)TELEM_BME680_SEALEVELPRESSURE_HPA, 0.1903f)));
+  lpp.addGenericSensor(ch, (uint16_t)bsec_iaq_val);
+  lpp.addAnalogInput(ch, (float)bsec_accuracy);
+}
+#endif
+
 // ============================================================
 // Sensor descriptor table
 //
@@ -457,6 +528,9 @@ static const SensorDef SENSOR_TABLE[] = {
 #endif
 #ifdef ENV_INCLUDE_BME680
   { TELEM_BME680_ADDRESS,  "BME680",       init_bme680,   query_bme680   },
+#endif
+#if ENV_INCLUDE_BME680_BSEC
+  { TELEM_BME680_ADDRESS,  "BME680+BSEC",   init_bme680_bsec, query_bme680_bsec },
 #endif
 #if ENV_INCLUDE_BME280
   { TELEM_BME280_ADDRESS,  "BME280",       init_bme280,   query_bme280   },
@@ -780,11 +854,13 @@ void EnvironmentSensorManager::stop_gps() {
   MESH_DEBUG_PRINTLN("Stop GPS is N/A on this board. Actual GPS state unchanged");
   #endif
 }
+#endif // ENV_INCLUDE_GPS
 
+#if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC)
 void EnvironmentSensorManager::loop() {
-  static long next_gps_update = 0;
 
   #if ENV_INCLUDE_GPS
+  static long next_gps_update = 0;
   if (gps_active) {
     _location->loop();
   }
@@ -812,5 +888,18 @@ void EnvironmentSensorManager::loop() {
     next_gps_update = millis() + (gps_update_interval_sec * 1000);
   }
   #endif
+  #if ENV_INCLUDE_BME680_BSEC
+  if (bsec_active && bsec_iaq.run()) {
+    uint8_t prev_accuracy = bsec_accuracy;
+    bsec_temperature  = bsec_iaq.temperature;
+    bsec_humidity     = bsec_iaq.humidity;
+    bsec_pressure_hpa = bsec_iaq.pressure / 100.0f;
+    bsec_iaq_val      = bsec_iaq.iaq;
+    bsec_accuracy     = bsec_iaq.iaqAccuracy;
+    bsec_data_ready   = true;
+    if (bsec_accuracy >= 2 && bsec_accuracy > prev_accuracy)
+      bsec_save_state();
+  }
+  #endif
 }
-#endif
+#endif // ENV_INCLUDE_GPS || ENV_INCLUDE_BME680_BSEC

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -34,6 +34,15 @@ static bool    bsec_data_ready   = false;
 #define BSEC_STATE_FILE "/bsec_state.bin"
 #endif
 
+#ifdef ENV_INCLUDE_BME680
+#ifndef TELEM_BME680_ADDRESS
+#define TELEM_BME680_ADDRESS 0x76
+#endif
+#define TELEM_BME680_SEALEVELPRESSURE_HPA (1013.25)
+#include <Adafruit_BME680.h>
+static Adafruit_BME680 BME680(TELEM_WIRE);
+#endif
+
 #ifdef ENV_INCLUDE_BMP085
 #define TELEM_BMP085_SEALEVELPRESSURE_HPA (1013.25)
 #include <Adafruit_BMP085.h>

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -43,7 +43,7 @@ public:
   #endif
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
-  #if ENV_INCLUDE_GPS
+  #if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC)
   void loop() override;
   #endif
   int getNumSettings() const override;

--- a/variants/rak4631/fix_bsec_lib.py
+++ b/variants/rak4631/fix_bsec_lib.py
@@ -1,0 +1,15 @@
+Import('env')
+import os
+
+# Bosch has a goof in their PlatformIO packaging making linking fail.
+# The BSEC library's extra_script.py selects cortex-m4/libalgobsec.a (soft-float ABI).
+# nRF52840 compiles with -mfloat-abi=hard, requiring the fpv4-sp-d16-hard blob.
+# Workaround to prepend the hard-float path so the linker finds it before the 
+# soft-float one.
+bsec_hard = os.path.join(
+    env.subst('$PROJECT_DIR'),
+    '.pio', 'libdeps', env.subst('$PIOENV'),
+    'BSEC Software Library', 'src',
+    'cortex-m4', 'fpv4-sp-d16-hard'
+)
+env.Prepend(LIBPATH=[bsec_hard])

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -2,6 +2,8 @@
 extends = nrf52_base
 board = rak4631
 board_check = true
+extra_scripts = ${nrf52_base.extra_scripts}
+  post:variants/rak4631/fix_bsec_lib.py
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak4631
@@ -21,6 +23,8 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D ENV_INCLUDE_RAK12035=1
+  -UENV_INCLUDE_BME680
+  -D ENV_INCLUDE_BME680_BSEC=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak4631>
   +<helpers/sensors>
@@ -31,6 +35,7 @@ lib_deps =
   ${sensor_base.lib_deps}
   adafruit/Adafruit SSD1306 @ ^2.5.13
   sparkfun/SparkFun u-blox GNSS Arduino Library@^2.2.27
+  boschsensortec/BSEC Software Library @ ^1.8.1492
 
 [env:RAK_4631_repeater]
 extends = rak4631


### PR DESCRIPTION
I'm on a wild tear today! Trying to take advantage of it.

This is a consolidation of my changes for BME680 on RAK4631 nodes. I will close my other PRs related to this and link back to this one.

**Background on change:**

This change replaces the Adafruit BME680 driver on RAK4631 with the Bosch BSEC library. Other boards continue to use the existing Adafruit path via ENV_INCLUDE_BME680.

This makes the IAQ portion of the sensor functional, and more accurate. It also contains the math and/or CayenneLPP fixes from my other PRs. The Bosch code also appears to handle calibrating sensor aging as well, whereas the Adafruit code is just looking at blind values that can drift with time. Pretty cool to see this shooting out useful data!

RAK4631 platform.io is set to override to ENV_INCLUDE_BME680_BSEC while leaving the Adafruit code for other node types. (If this becomes applicable for other node types in future, awesome! I just don't have hardware to test against.)

Using the BSEC library introduces IAQ sensor calibration, and saves the calibration state periodically so it does not have to calibrate again later.

At startup the IAQ sensor takes 30 minutes to heat and to hit a baseline, then starts calibrating. Once calibrated, it will save those settings and will only write settings again if calibration falls back and restores back to state 3.

This fix also has the gas resistance math fix that was in [pull 2146](https://github.com/meshcore-dev/MeshCore/pull/2146) so the adafruit path also can at least show accurate values instead of looping negative.

Also includes the fix from [pull 2149](https://github.com/meshcore-dev/MeshCore/pull/2149) so the pressure output isn't truncated to 1hPa steps.

**Fixes/Changes:**
- Add bsec_config_iaq[] with the 3.3V/3s-LP/28d calibration profile
- BSEC init applies setConfig() for voltage-correct heater targeting
- IAQ, heat-compensated temperature/humidity, pressure, and altitude reported over CayenneLPP
- IAQ accuracy reported as analog input over CayenneLPP (0,1,2,3)
- Calibration state persisted to /bsec_state.bin on nRF52 internal flash; written only when iaqAccuracy improves to >= 2, should keep write frequency well within flash endurance over device lifetime
- Fix non-BSEC query_bme680: float pressure division, addGenericSensor for gas resistance (was addAnalogInput, overflows at > 327 Ohm)
- loop() correctly gated for both GPS and BSEC-only builds
- Add fix_bsec_lib.py extra_script to resolve nRF52840 hard-float ABI mismatch in Bosch's PlatformIO packaging, silly Bosch

One general note outside of this code change: I noticed while BME680 _functions_ in companion nodes, since companion nodes run Bluetooth, BLE preempts the CPU, and can do so mid-I2C-transaction.

This can cause the BME680 to see an anomaly and drop calibration and start a recalibrate. This is behavior that will exist (and has existed) regardless of using the Adafruit or Bosch paths.

This particular companion behavior does not seem to occur in sensor or repeater nodes since their BLE is off. Probably affects other I2C devices as well.

**Tests:**

- RAK19003
- RAK19007
- RAK19001
- repeater, sensor, companion

**24 Hour Grafana Stats Example:** (Graph gap is from a service restart, not the node.)
<img width="1241" height="815" alt="24hr-bme680" src="https://github.com/user-attachments/assets/2c3c5ec1-6f77-4cd6-8234-95dab4a415ae" />
