### PR TITLE
fix: rename CMD_DEVICE_QEURY to CMD_DEVICE_QUERY

### DIFF
--- a/docs/companion_protocol.md
+++ b/docs/companion_protocol.md
@@ -73,7 +73,7 @@ MeshCore Companion devices expose a BLE service with the following UUIDs:
 
 5. **Send Initial Commands**
     - Send `CMD_APP_START` to identify your app to firmware and get radio settings
-    - Send `CMD_DEVICE_QEURY` to fetch device info and negotiate supported protocol versions
+    - Send `CMD_DEVICE_QUERY` to fetch device info and negotiate supported protocol versions
     - Send `CMD_SET_DEVICE_TIME` to set the firmware clock
     - Send `CMD_GET_CONTACTS` to fetch all contacts
     - Send `CMD_GET_CHANNEL` multiple times to fetch all channel slots

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -24,7 +24,7 @@
 #define CMD_REBOOT                    19
 #define CMD_GET_BATT_AND_STORAGE      20   // was CMD_GET_BATTERY_VOLTAGE
 #define CMD_SET_TUNING_PARAMS         21
-#define CMD_DEVICE_QEURY              22
+#define CMD_DEVICE_QUERY              22
 #define CMD_EXPORT_PRIVATE_KEY        23
 #define CMD_IMPORT_PRIVATE_KEY        24
 #define CMD_SEND_RAW_DATA             25
@@ -81,7 +81,7 @@
 #define RESP_CODE_NO_MORE_MESSAGES    10 // a reply to CMD_SYNC_NEXT_MESSAGE
 #define RESP_CODE_EXPORT_CONTACT      11
 #define RESP_CODE_BATT_AND_STORAGE    12 // a reply to a CMD_GET_BATT_AND_STORAGE
-#define RESP_CODE_DEVICE_INFO         13 // a reply to CMD_DEVICE_QEURY
+#define RESP_CODE_DEVICE_INFO         13 // a reply to CMD_DEVICE_QUERY
 #define RESP_CODE_PRIVATE_KEY         14 // a reply to CMD_EXPORT_PRIVATE_KEY
 #define RESP_CODE_DISABLED            15
 #define RESP_CODE_CONTACT_MSG_RECV_V3 16 // a reply to CMD_SYNC_NEXT_MESSAGE (ver >= 3)
@@ -1006,7 +1006,7 @@ void MyMesh::startInterface(BaseSerialInterface &serial) {
 }
 
 void MyMesh::handleCmdFrame(size_t len) {
-  if (cmd_frame[0] == CMD_DEVICE_QEURY && len >= 2) { // sent when app establishes connection
+  if (cmd_frame[0] == CMD_DEVICE_QUERY && len >= 2) { // sent when app establishes connection
     app_target_ver = cmd_frame[1];                    // which version of protocol does app understand
 
     int i = 0;


### PR DESCRIPTION
Fix typo in constant name: `CMD_DEVICE_QEURY` → `CMD_DEVICE_QUERY`.
- `examples/companion_radio/MyMesh.cpp`: rename `#define`, update comment and usage
- `docs/companion_protocol.md`: update reference to match