### PR TITLE
docs: remove duplicate radio.rxgain entry and fix hardware note

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -219,20 +219,6 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
-#### View or change the boosted receive gain mode
-**Usage:**
-- `get radio.rxgain`
-- `set radio.rxgain <state>`
-
-**Parameters:**
-- `state`: `on`|`off`
-
-**Default:** `off`
-
-**Note:** Only available on SX1262 and SX1268 based boards.
-
----
-
 #### Change the radio parameters for a set duration
 **Usage:** 
 - `tempradio <freq>,<bw>,<sf>,<cr>,<timeout_mins>`
@@ -263,7 +249,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
-#### View or change this node's rx boosted gain mode (SX12xx only, v1.14.1+)
+#### View or change this node's rx boosted gain mode (SX12xx and LR1110, v1.14.1+)
 **Usage:**
 - `get radio.rxgain`
 - `set radio.rxgain <state>`


### PR DESCRIPTION
Two separate PRs (#2103 and #2106) documented the `radio.rxgain` command on the same day (March 20), but were merged a month apart: PR #2106 on March 23 and PR #2103 on April 18. This resulted in a duplicate entry.

* Remove the outdated first entry from PR #2103 (incorrect default value `off`, incomplete hardware note)
* Update the remaining entry's title from `SX12xx only` to `SX12xx and LR1110` to reflect support added in PR #2235 for LR1110-based boards (T1000-E)