### PR TITLE
fix: fix typos in source code comments

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -541,7 +541,7 @@ bool DataStore::putBlobByKey(const uint8_t key[], int key_len, const uint8_t src
     uint32_t pos = 0, found_pos = 0;
     uint32_t min_timestamp = 0xFFFFFFFF;
 
-    // search for matching key OR evict by oldest timestmap
+    // search for matching key OR evict by oldest timestamp
     BlobRec tmp;
     file.seek(0);
     while (file.read((uint8_t *) &tmp, sizeof(tmp)) == sizeof(tmp)) {

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -100,7 +100,7 @@ protected:
    * \param  auth_code   a code to authenticate the packet
    * \param  flags       zero for now
    * \param  path_snrs   single byte SNR*4 for each hop in the path
-   * \param  path_hashes hashes if each repeater in the path
+   * \param  path_hashes hashes of each repeater in the path
    * \param  path_len    length of the path_snrs[] and path_hashes[] arrays
   */
   virtual void onTraceRecv(Packet* packet, uint32_t tag, uint32_t auth_code, uint8_t flags, const uint8_t* path_snrs, const uint8_t* path_hashes, uint8_t path_len) { }

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -212,12 +212,12 @@ public:
   void sendDirect(Packet* packet, const uint8_t* path, uint8_t path_len, uint32_t delay_millis=0);
 
   /**
-   * \brief  send a locally-generated Packet to just neigbor nodes (zero hops)
+   * \brief  send a locally-generated Packet to just neighbor nodes (zero hops)
   */
   void sendZeroHop(Packet* packet, uint32_t delay_millis=0);
 
   /**
-   * \brief  send a locally-generated Packet to just neigbor nodes (zero hops), with specific transort codes
+   * \brief  send a locally-generated Packet to just neighbor nodes (zero hops), with specific transport codes
    * \param transport_codes   array of 2 codes to attach to packet
   */
   void sendZeroHop(Packet* packet, uint16_t* transport_codes, uint32_t delay_millis=0);

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -25,7 +25,7 @@ namespace mesh {
 #define PAYLOAD_TYPE_GRP_DATA    0x06    // an (unverified) group datagram (prefixed with channel hash, MAC) (enc data: data_type(uint16), data_len, blob)
 #define PAYLOAD_TYPE_ANON_REQ    0x07    // generic request (prefixed with dest_hash, ephemeral pub_key, MAC) (enc data: ...)
 #define PAYLOAD_TYPE_PATH        0x08    // returned path (prefixed with dest/src hashes, MAC) (enc data: path, extra)
-#define PAYLOAD_TYPE_TRACE       0x09    // trace a path, collecting SNI for each hop
+#define PAYLOAD_TYPE_TRACE       0x09    // trace a path, collecting SNR for each hop
 #define PAYLOAD_TYPE_MULTIPART   0x0A    // packet is one of a set of packets
 #define PAYLOAD_TYPE_CONTROL     0x0B    // a control/discovery packet
 //...

--- a/src/helpers/bridges/ESPNowBridge.cpp
+++ b/src/helpers/bridges/ESPNowBridge.cpp
@@ -32,7 +32,7 @@ void ESPNowBridge::begin() {
   // Initialize WiFi in station mode
   WiFi.mode(WIFI_STA);
   
-  // Set wifi channel
+  // Set Wi-Fi channel
   if (esp_wifi_set_channel(_prefs->bridge_channel, WIFI_SECOND_CHAN_NONE) != ESP_OK) {
     BRIDGE_DEBUG_PRINTLN("Error setting WIFI channel to %d\n", _prefs->bridge_channel);
     return;

--- a/src/helpers/sensors/LPPDataHelpers.h
+++ b/src/helpers/sensors/LPPDataHelpers.h
@@ -142,7 +142,7 @@ public:
       case LPP_GPS:
         _pos += 9; break;
       case LPP_POLYLINE:
-        _pos += 8; break;  // TODO: this is MINIMIUM
+        _pos += 8; break;  // TODO: this is MINIMUM
       case LPP_GYROMETER:
       case LPP_ACCELEROMETER:
         _pos += 6; break;

--- a/src/helpers/stm32/InternalFileSystem.cpp
+++ b/src/helpers/stm32/InternalFileSystem.cpp
@@ -37,7 +37,7 @@ static int _internal_flash_read(const struct lfs_config *c, lfs_block_t block, l
 }    
 
 // Program a region in a block. The block must have previously
-// been erased. Negative error codes are propogated to the user.
+// been erased. Negative error codes are propagated to the user.
 // May return LFS_ERR_CORRUPT if the block should be considered bad.
 static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
 {    
@@ -62,7 +62,7 @@ static int _internal_flash_prog(const struct lfs_config *c, lfs_block_t block, l
 
 // Erase a block. A block must be erased before being programmed.
 // The state of an erased block is undefined. Negative error codes
-// are propogated to the user.
+// are propagated to the user.
 // May return LFS_ERR_CORRUPT if the block should be considered bad.
 static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
 {   
@@ -87,7 +87,7 @@ static int _internal_flash_erase(const struct lfs_config *c, lfs_block_t block)
 }   
 
 // Sync the state of the underlying block device. Negative error codes
-// are propogated to the user.
+// are propagated to the user.
 static int _internal_flash_sync(const struct lfs_config *c)
 {    
     return LFS_ERR_OK; // don't need sync

--- a/src/helpers/ui/OLEDDisplay.cpp
+++ b/src/helpers/ui/OLEDDisplay.cpp
@@ -1155,7 +1155,7 @@ void OLEDDisplay::setFontTableLookupFunction(FontTableLookupFunction function) {
 
 char DefaultFontTableLookup(const uint8_t ch) {
     // UTF-8 to font table index converter
-    // Code form http://playground.arduino.cc/Main/Utf8ascii
+    // Code from http://playground.arduino.cc/Main/Utf8ascii
 	static uint8_t LASTCHAR;
 
 	if (ch < 128) { // Standard ASCII-set 0..0x7F handling
@@ -1166,7 +1166,7 @@ char DefaultFontTableLookup(const uint8_t ch) {
 	uint8_t last = LASTCHAR;   // get last char
 	LASTCHAR = ch;
 
-	switch (last) {    // conversion depnding on first UTF8-character
+	switch (last) {    // conversion depending on first UTF8-character
 		case 0xC2: return (uint8_t) ch;
 		case 0xC3: return (uint8_t) (ch | 0xC0);
 		case 0x82: if (ch == 0xAC) return (uint8_t) 0x80;    // special case Euro-symbol


### PR DESCRIPTION
- `src/helpers/stm32/InternalFileSystem.cpp`: `propogated` → `propagated` (3 occurrences)
- `src/Mesh.h`: `hashes if each repeater` → `hashes of each repeater`
- `src/helpers/ui/OLEDDisplay.cpp`: `Code form http://` → `Code from http://`, `depnding` → `depending`
- `src/helpers/bridges/ESPNowBridge.cpp`: `Set wifi channel` → `Set Wi-Fi channel`
- `examples/companion_radio/DataStore.cpp`: `oldest timestmap` → `oldest timestamp`