### PR TITLE
ci: update GitHub Actions and Python version

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
 
     - name: Init Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/pip
@@ -12,9 +12,9 @@ runs:
         key: ${{ runner.os }}-pio
 
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.13'
 
     - name: Install PlatformIO
       shell: bash

--- a/.github/workflows/build-companion-firmwares.yml
+++ b/.github/workflows/build-companion-firmwares.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Clone Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Build Environment
         uses: ./.github/actions/setup-build-environment
@@ -27,13 +27,13 @@ jobs:
         run: /usr/bin/env bash build.sh build-companion-firmwares
 
       - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: companion-firmwares
           path: out
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: Companion Firmware ${{ env.GIT_TAG_VERSION }}

--- a/.github/workflows/build-repeater-firmwares.yml
+++ b/.github/workflows/build-repeater-firmwares.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Clone Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Build Environment
         uses: ./.github/actions/setup-build-environment
@@ -27,13 +27,13 @@ jobs:
         run: /usr/bin/env bash build.sh build-repeater-firmwares
 
       - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: repeater-firmwares
           path: out
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: Repeater Firmware ${{ env.GIT_TAG_VERSION }}

--- a/.github/workflows/build-room-server-firmwares.yml
+++ b/.github/workflows/build-room-server-firmwares.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Clone Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Build Environment
         uses: ./.github/actions/setup-build-environment
@@ -27,13 +27,13 @@ jobs:
         run: /usr/bin/env bash build.sh build-room-server-firmwares
 
       - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: room-server-firmwares
           path: out
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: Room Server Firmware ${{ env.GIT_TAG_VERSION }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cname: docs.meshcore.io

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          ruby-version: 3.x
+          python-version: '3.13'
 
       - name: Build
         run: |
@@ -28,7 +28,7 @@ jobs:
           mkdocs build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cname: docs.meshcore.io

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Clone Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Build Environment
         uses: ./.github/actions/setup-build-environment


### PR DESCRIPTION
Update all GitHub Actions to their latest major versions and bump Python to 3.13.
<img width="991" height="554" alt="{1A35E400-DA81-4739-9BAD-3EEB6B1EDDC9}" src="https://github.com/user-attachments/assets/754847b4-656d-4f14-9fb0-4de8f95ca701" />

- `actions/checkout`: v4 → v6
- `actions/upload-artifact`: v4 → v7
- `actions/setup-python`: v5 → v6
- `actions/cache`: v4 → v5
- `softprops/action-gh-release`: v2 → v3
- `peaceiris/actions-gh-pages`: v3 → v4.1.0 (pinned to avoid Node.js 20 deprecation warning)
- Python version: 3.11 → 3.13
- Fix `ruby-version` typo in `github-pages.yml` (should be `python-version`)

All workflows tested successfully on this branch before opening this PR. 
