### PR TITLE
RAK3401: powerOff() override + AIN button LPCOMP wake from SYSTEMOFF

### DIFF
--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -177,7 +177,7 @@ void NRF52Board::enterSystemOff(uint8_t reason) {
   NVIC_SystemReset();
 }
 
-void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
+void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel, bool detect_down) {
   // LPCOMP is not managed by SoftDevice - direct register access required
   // Halt and disable before reconfiguration
   NRF_LPCOMP->TASKS_STOP = 1;
@@ -189,8 +189,10 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
   // Reference: REFSEL (0-6=1/8..7/8, 7=ARef, 8-15=1/16..15/16)
   NRF_LPCOMP->REFSEL = ((uint32_t)refsel << LPCOMP_REFSEL_REFSEL_Pos) & LPCOMP_REFSEL_REFSEL_Msk;
 
-  // Detect UP events (voltage rises above threshold for battery recovery)
-  NRF_LPCOMP->ANADETECT = LPCOMP_ANADETECT_ANADETECT_Up;
+  // Crossing direction: UP for voltage recovery (rises above threshold),
+  // DOWN for an analog button press (pin pulled below threshold).
+  NRF_LPCOMP->ANADETECT = detect_down ? LPCOMP_ANADETECT_ANADETECT_Down
+                                      : LPCOMP_ANADETECT_ANADETECT_Up;
 
   // Enable 50mV hysteresis for noise immunity
   NRF_LPCOMP->HYST = LPCOMP_HYST_HYST_Hyst50mV;
@@ -202,7 +204,7 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
   NRF_LPCOMP->EVENTS_CROSS = 0;
 
   NRF_LPCOMP->INTENCLR = 0xFFFFFFFF;
-  NRF_LPCOMP->INTENSET = LPCOMP_INTENSET_UP_Msk;
+  NRF_LPCOMP->INTENSET = detect_down ? LPCOMP_INTENSET_DOWN_Msk : LPCOMP_INTENSET_UP_Msk;
 
   // Enable LPCOMP
   NRF_LPCOMP->ENABLE = LPCOMP_ENABLE_ENABLE_Enabled;

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -40,7 +40,10 @@ protected:
 
   bool checkBootVoltage(const PowerMgtConfig* config);
   void enterSystemOff(uint8_t reason);
-  void configureVoltageWake(uint8_t ain_channel, uint8_t refsel);
+  // Arm LPCOMP as a SYSTEMOFF wake source on the given analog channel.
+  // detect_down=false wakes on an upward crossing (voltage recovery);
+  // detect_down=true wakes on a downward crossing (e.g. an analog button press).
+  void configureVoltageWake(uint8_t ain_channel, uint8_t refsel, bool detect_down = false);
   virtual void initiateShutdown(uint8_t reason);
 #endif
 

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -4,15 +4,26 @@
 #include "RAK3401Board.h"
 
 #ifdef NRF52_POWER_MANAGEMENT
-#ifdef PIN_USER_BTN_ANA
-// LPCOMP wake config for the AIN user button. Defaults assume PIN_USER_BTN_ANA
-// is pin 31 (P0.31 = AIN7); override via build flags if the button moves.
-#ifndef PWRMGT_BTN_LPCOMP_AIN
-  #define PWRMGT_BTN_LPCOMP_AIN 7
+
+// Analog (LPCOMP) wake source for SYSTEMOFF. Precedence: an explicit
+// PIN_WAKEUP_ANA wins, else the AIN user button. Lets a build point the wake at
+// a different AIN pin than the button (e.g. an INT line wired to that pin)
+// without touching the button define. The pin must idle near VDD and pull low
+// on activity, and must be analog-capable: nRF52840 AIN map is
+// P0.02-05 = AIN0-3, P0.28-31 = AIN4-7.
+#if defined(PIN_WAKEUP_ANA)
+  #define PWRMGT_WAKE_PIN  PIN_WAKEUP_ANA
+#elif defined(PIN_USER_BTN_ANA)
+  #define PWRMGT_WAKE_PIN  PIN_USER_BTN_ANA
 #endif
-#ifndef PWRMGT_BTN_LPCOMP_REFSEL
-  #define PWRMGT_BTN_LPCOMP_REFSEL 3   // 4/8 VDD (~1.65V at 3.3V) threshold
-#endif
+
+#if defined(PWRMGT_WAKE_PIN)
+  #ifndef PWRMGT_WAKE_AIN
+    #define PWRMGT_WAKE_AIN  ((PWRMGT_WAKE_PIN) >= 28 ? (PWRMGT_WAKE_PIN) - 24 : (PWRMGT_WAKE_PIN) - 2)
+  #endif
+  #ifndef PWRMGT_WAKE_REFSEL
+    #define PWRMGT_WAKE_REFSEL  3   // 4/8 VDD (~1.65V at 3.3V) threshold
+  #endif
 #endif
 
 // Static configuration for power management
@@ -35,10 +46,11 @@ void RAK3401Board::initiateShutdown(uint8_t reason) {
     configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
   }
 
-#ifdef PIN_USER_BTN_ANA
-  // Wake-from-SYSTEMOFF on the AIN user button (P0.31 = AIN7).
+#if defined(PWRMGT_WAKE_PIN)
+  // Wake-from-SYSTEMOFF on the analog wake pin (P0.31 = AIN7 by default): the AIN
+  // user button, or whatever PIN_WAKEUP_ANA points at.
   //
-  // This pin is wired as an *analog* button (see MomentaryButton in target.cpp:
+  // The button is wired as an *analog* button (see MomentaryButton in target.cpp:
   // pressed == analogRead() < threshold). GPIO SENSE can't be used as the wake
   // source: using the pin as an analog/SAADC input leaves its digital input
   // buffer disconnected, so NRF_GPIO->IN reads 0 regardless of the real ~VDD
@@ -54,18 +66,20 @@ void RAK3401Board::initiateShutdown(uint8_t reason) {
   //
   // Wait for release first so LPCOMP is armed while the level is above the
   // threshold — otherwise the initial press generates no new downward crossing.
-  // Bounded by a timeout so a stuck/low reading can never wedge shutdown.
+  // Bounded by a timeout so a stuck/low reading can never wedge shutdown. (A pin
+  // driven by an idle-high INT line should be drained to idle by the caller
+  // before shutdown, since this level wait can't observe its release.)
   analogReadResolution(12);  // as getBattMilliVolts() does; makes the threshold below unambiguous
-  const int BTN_RELEASED_ADC = 2048;  // mid-scale at 12-bit: above the ~1/2 VDD LPCOMP threshold
+  const int WAKE_RELEASED_ADC = 2048;  // mid-scale at 12-bit: above the ~1/2 VDD LPCOMP threshold
   uint32_t t0 = millis();
   int released_streak = 0;
   while (released_streak < 5 && (millis() - t0) < 5000) {
-    if (analogRead(PIN_USER_BTN_ANA) > BTN_RELEASED_ADC) released_streak++;
+    if (analogRead(PWRMGT_WAKE_PIN) > WAKE_RELEASED_ADC) released_streak++;
     else released_streak = 0;
     delay(10);
   }
 
-  configureVoltageWake(PWRMGT_BTN_LPCOMP_AIN, PWRMGT_BTN_LPCOMP_REFSEL, /*detect_down=*/true);
+  configureVoltageWake(PWRMGT_WAKE_AIN, PWRMGT_WAKE_REFSEL, /*detect_down=*/true);
 #endif
 
   enterSystemOff(reason);

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -4,6 +4,17 @@
 #include "RAK3401Board.h"
 
 #ifdef NRF52_POWER_MANAGEMENT
+#ifdef PIN_USER_BTN_ANA
+// LPCOMP wake config for the AIN user button. Defaults assume PIN_USER_BTN_ANA
+// is pin 31 (P0.31 = AIN7); override via build flags if the button moves.
+#ifndef PWRMGT_BTN_LPCOMP_AIN
+  #define PWRMGT_BTN_LPCOMP_AIN 7
+#endif
+#ifndef PWRMGT_BTN_LPCOMP_REFSEL
+  #define PWRMGT_BTN_LPCOMP_REFSEL 3   // 4/8 VDD (~1.65V at 3.3V) threshold
+#endif
+#endif
+
 // Static configuration for power management
 // Values set in variant.h defines
 const PowerMgtConfig power_config = {
@@ -23,6 +34,39 @@ void RAK3401Board::initiateShutdown(uint8_t reason) {
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
     configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
   }
+
+#ifdef PIN_USER_BTN_ANA
+  // Wake-from-SYSTEMOFF on the AIN user button (P0.31 = AIN7).
+  //
+  // This pin is wired as an *analog* button (see MomentaryButton in target.cpp:
+  // pressed == analogRead() < threshold). GPIO SENSE can't be used as the wake
+  // source: using the pin as an analog/SAADC input leaves its digital input
+  // buffer disconnected, so NRF_GPIO->IN reads 0 regardless of the real ~VDD
+  // level and SENSE_Low latches immediately (verified on hardware — analogRead
+  // reports ~VDD while IN=0). A GPIO SENSE arm therefore wakes the chip the
+  // instant we enter SYSTEMOFF and it can never stay off.
+  //
+  // LPCOMP works in the analog domain, so it sees the idle level correctly. Arm
+  // it for a DOWN crossing at ~1/2 VDD: released idles near VDD (above), a press
+  // pulls the pin toward 0V (below) -> downward crossing -> wake. The LPCOMP is
+  // otherwise unused for a USER shutdown (voltage wake is only armed for the
+  // low-voltage / boot-protect reasons handled above), so there is no conflict.
+  //
+  // Wait for release first so LPCOMP is armed while the level is above the
+  // threshold — otherwise the initial press generates no new downward crossing.
+  // Bounded by a timeout so a stuck/low reading can never wedge shutdown.
+  analogReadResolution(12);  // as getBattMilliVolts() does; makes the threshold below unambiguous
+  const int BTN_RELEASED_ADC = 2048;  // mid-scale at 12-bit: above the ~1/2 VDD LPCOMP threshold
+  uint32_t t0 = millis();
+  int released_streak = 0;
+  while (released_streak < 5 && (millis() - t0) < 5000) {
+    if (analogRead(PIN_USER_BTN_ANA) > BTN_RELEASED_ADC) released_streak++;
+    else released_streak = 0;
+    delay(10);
+  }
+
+  configureVoltageWake(PWRMGT_BTN_LPCOMP_AIN, PWRMGT_BTN_LPCOMP_REFSEL, /*detect_down=*/true);
+#endif
 
   enterSystemOff(reason);
 }

--- a/variants/rak3401/RAK3401Board.h
+++ b/variants/rak3401/RAK3401Board.h
@@ -20,6 +20,10 @@ public:
   RAK3401Board() : NRF52Board("RAK3401_OTA") {}
   void begin();
 
+#ifdef NRF52_POWER_MANAGEMENT
+  void powerOff() override { initiateShutdown(SHUTDOWN_REASON_USER); }
+#endif
+
   #define BATTERY_SAMPLES 8
 
   uint16_t getBattMilliVolts() override {


### PR DESCRIPTION
Two board-level pieces from @dorfman2's #2414 that are useful for any RAK3401 firmware, not just the repeater variant that PR targets.

## What this changes

1. **`RAK3401Board::powerOff()` override** (`variants/rak3401/RAK3401Board.h`) — routes `_board->powerOff()` through `initiateShutdown(SHUTDOWN_REASON_USER)` so the shutdown reason is properly tagged in `GPREGRET2` instead of falling through to the base class default.

2. **AIN button wake-from-SYSTEMOFF via LPCOMP** (`variants/rak3401/RAK3401Board.cpp`) — when an env defines `PIN_USER_BTN_ANA`, arm a wake source before entering SYSTEMOFF so pressing the button powers the board back on.

3. **`NRF52Board::configureVoltageWake()` gains a `detect_down` flag** (`src/helpers/NRF52Board.{h,cpp}`) — defaults to `false` (the existing upward-crossing voltage-recovery behavior, so no other NRF52 board is affected), and `true` selects a downward crossing for the button wake.

## Why LPCOMP and not GPIO SENSE

#2414's original code armed the pin with `SENSE_Low`. That works for the repeater, where the button is a digital normally-open switch to GND. It does **not** work on the companion_radio build, where the same pin (`PIN_USER_BTN_ANA=31`, P0.31 = AIN7) is wired as an **analog** button — `MomentaryButton` reads it as `analogRead() < threshold`.

Two failures, both reproduced and verified on hardware (companion_radio_ble, on USB *and* battery):

- **Shutdown hung.** The release-wait used `digitalRead()` on this pin, but the SAADC leaves the digital input buffer disconnected, so `digitalRead()` always returns LOW. The loop never exited, SYSTEMOFF was never reached — screen off, but BLE/serial still alive.
- **Immediate self-wake.** Even past that, GPIO `SENSE_Low` reads this line as LOW *at the released idle level* (`analogRead` reports ~VDD while `NRF_GPIO->IN` reads 0 and the `SENSE` latch re-asserts the instant it's cleared), so the chip woke the moment it entered SYSTEMOFF. `RESETREAS = Wake from GPIO (0x10000)`, identical on USB and battery — ruling out VBUS.

The fix arms **LPCOMP** instead. It operates in the analog domain, so it sees the idle level correctly: a DOWN crossing at ~½ VDD wakes on a press (released idles near VDD = above threshold; a press pulls the pin to ~0V = below). The release-wait now uses `analogRead` and is bounded by a 5s timeout so a stuck reading can never wedge shutdown. LPCOMP is otherwise unused for a USER shutdown (voltage wake is only armed for the low-voltage / boot-protect reasons), so there is no conflict. The AIN channel and threshold are overridable build defines.

## Testing

Verified on RAK3401 + RAK19007 + companion_radio_ble build, on both USB and battery:
- `_board->powerOff()` from the companion UI menu enters SYSTEMOFF and the board **stays off** (USB/serial drop, BLE LED dark).
- Pressing the AIN button wakes the board; `RESETREAS = Wake from LPCOMP` and the subsequent boot is normal.
- `RAK_3401_repeater` (no `PIN_USER_BTN_ANA`) and `RAK_3401_companion_radio_ble` both build clean; the `configureVoltageWake()` signature change is backward-compatible via the defaulted parameter.
