### PR TITLE
Fix: ESP32 KISS modem becomes permanently unresponsive under TX backpressure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,7 @@ get_pio_envs_ending_with_string() {
 # $1 should be the environment name
 get_platform_for_env() {
   local env_name=$1
-  echo "$PIO_CONFIG_JSON" | python3 -c "
+  printf '%s' "$PIO_CONFIG_JSON" | python3 -c "
 import sys, json, re
 data = json.load(sys.stdin)
 for section, options in data:

--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -38,15 +38,15 @@ void KissModem::beginFrameWrite() {
 }
 
 void KissModem::rawWrite(uint8_t b) {
-  /* Once a frame has been aborted, swallow the rest of it so we never emit a
-     truncated KISS frame to the host. */
+  /* A frame is sent all-or-nothing; once we start dropping, swallow the rest so
+     we never emit a truncated KISS frame. */
   if (_tx_write_aborted) return;
 
-  /* Strictly non-blocking: if there is no room in the TX buffer, drop the rest
-     of this frame rather than wait. A stalled/absent USB-CDC host must never
-     stall loop() (any wait here starves the RX read loop and lets the TinyUSB
-     RX path overflow). Only write() when there is space, so write() can never
-     enter its internal busy-wait either. */
+  /* Non-blocking: if the TX buffer is full, drop this frame instead of waiting.
+     loop() is single-threaded and also services RX and the radio, so it must not
+     stall on a host that has stopped reading. Writing only when space is free
+     keeps the underlying write() from blocking; a dropped reply is harmless as
+     the host retries. */
   if (_serial.availableForWrite() <= 0) {
     _tx_write_aborted = true;
     return;

--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -22,7 +22,6 @@ KissModem::KissModem(Stream& serial, mesh::LocalIdentity& identity, mesh::RNG& r
   _getStatsCallback = nullptr;
   _config = {0, 0, 0, 0, 0};
   _signal_report_enabled = true;
-  _tx_write_aborted = false;
 }
 
 void KissModem::begin() {
@@ -33,58 +32,60 @@ void KissModem::begin() {
   _tx_state = TX_IDLE;
 }
 
-void KissModem::beginFrameWrite() {
-  _tx_write_aborted = false;
+size_t KissModem::escapedLength(uint8_t b) const {
+  return (b == KISS_FEND || b == KISS_FESC) ? 2 : 1;
 }
 
-void KissModem::rawWrite(uint8_t b) {
-  /* A frame is sent all-or-nothing; once we start dropping, swallow the rest so
-     we never emit a truncated KISS frame. */
-  if (_tx_write_aborted) return;
-
-  /* Non-blocking: if the TX buffer is full, drop this frame instead of waiting.
-     loop() is single-threaded and also services RX and the radio, so it must not
-     stall on a host that has stopped reading. Writing only when space is free
-     keeps the underlying write() from blocking; a dropped reply is harmless as
-     the host retries. */
-  if (_serial.availableForWrite() <= 0) {
-    _tx_write_aborted = true;
-    return;
+size_t KissModem::escapedLength(const uint8_t* data, size_t len) const {
+  size_t total = 0;
+  for (size_t i = 0; i < len; i++) {
+    total += escapedLength(data[i]);
   }
-  _serial.write(b);
+  return total;
+}
+
+bool KissModem::canWriteFrame(size_t total_len) const {
+  int available = _serial.availableForWrite();
+  return available > 0 && (size_t)available >= total_len;
+}
+
+void KissModem::writeEscapedFrame(const uint8_t* prefix, size_t prefix_len, const uint8_t* data, uint16_t len) {
+  // All-or-nothing: only write if the whole escaped frame fits, so loop() never blocks and frames are never truncated
+  size_t total_len = 2;  // frame delimiters
+  total_len += escapedLength(prefix, prefix_len);
+  total_len += escapedLength(data, len);
+  if (!canWriteFrame(total_len)) return;
+
+  _serial.write(KISS_FEND);
+  for (size_t i = 0; i < prefix_len; i++) {
+    writeByte(prefix[i]);
+  }
+  for (uint16_t i = 0; i < len; i++) {
+    writeByte(data[i]);
+  }
+  _serial.write(KISS_FEND);
 }
 
 void KissModem::writeByte(uint8_t b) {
   if (b == KISS_FEND) {
-    rawWrite(KISS_FESC);
-    rawWrite(KISS_TFEND);
+    _serial.write(KISS_FESC);
+    _serial.write(KISS_TFEND);
   } else if (b == KISS_FESC) {
-    rawWrite(KISS_FESC);
-    rawWrite(KISS_TFESC);
+    _serial.write(KISS_FESC);
+    _serial.write(KISS_TFESC);
   } else {
-    rawWrite(b);
+    _serial.write(b);
   }
 }
 
 void KissModem::writeFrame(uint8_t type, const uint8_t* data, uint16_t len) {
-  beginFrameWrite();
-  rawWrite(KISS_FEND);
-  writeByte(type);
-  for (uint16_t i = 0; i < len; i++) {
-    writeByte(data[i]);
-  }
-  rawWrite(KISS_FEND);
+  uint8_t prefix[] = { type };
+  writeEscapedFrame(prefix, sizeof(prefix), data, len);
 }
 
 void KissModem::writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len) {
-  beginFrameWrite();
-  rawWrite(KISS_FEND);
-  writeByte(KISS_CMD_SETHARDWARE);
-  writeByte(sub_cmd);
-  for (uint16_t i = 0; i < len; i++) {
-    writeByte(data[i]);
-  }
-  rawWrite(KISS_FEND);
+  uint8_t prefix[] = { KISS_CMD_SETHARDWARE, sub_cmd };
+  writeEscapedFrame(prefix, sizeof(prefix), data, len);
 }
 
 void KissModem::writeHardwareError(uint8_t error_code) {

--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -22,6 +22,7 @@ KissModem::KissModem(Stream& serial, mesh::LocalIdentity& identity, mesh::RNG& r
   _getStatsCallback = nullptr;
   _config = {0, 0, 0, 0, 0};
   _signal_report_enabled = true;
+  _tx_write_aborted = false;
 }
 
 void KissModem::begin() {
@@ -32,35 +33,58 @@ void KissModem::begin() {
   _tx_state = TX_IDLE;
 }
 
+void KissModem::beginFrameWrite() {
+  _tx_write_aborted = false;
+}
+
+void KissModem::rawWrite(uint8_t b) {
+  /* Once a frame has been aborted, swallow the rest of it so we never emit a
+     truncated KISS frame to the host. */
+  if (_tx_write_aborted) return;
+
+  /* Strictly non-blocking: if there is no room in the TX buffer, drop the rest
+     of this frame rather than wait. A stalled/absent USB-CDC host must never
+     stall loop() (any wait here starves the RX read loop and lets the TinyUSB
+     RX path overflow). Only write() when there is space, so write() can never
+     enter its internal busy-wait either. */
+  if (_serial.availableForWrite() <= 0) {
+    _tx_write_aborted = true;
+    return;
+  }
+  _serial.write(b);
+}
+
 void KissModem::writeByte(uint8_t b) {
   if (b == KISS_FEND) {
-    _serial.write(KISS_FESC);
-    _serial.write(KISS_TFEND);
+    rawWrite(KISS_FESC);
+    rawWrite(KISS_TFEND);
   } else if (b == KISS_FESC) {
-    _serial.write(KISS_FESC);
-    _serial.write(KISS_TFESC);
+    rawWrite(KISS_FESC);
+    rawWrite(KISS_TFESC);
   } else {
-    _serial.write(b);
+    rawWrite(b);
   }
 }
 
 void KissModem::writeFrame(uint8_t type, const uint8_t* data, uint16_t len) {
-  _serial.write(KISS_FEND);
+  beginFrameWrite();
+  rawWrite(KISS_FEND);
   writeByte(type);
   for (uint16_t i = 0; i < len; i++) {
     writeByte(data[i]);
   }
-  _serial.write(KISS_FEND);
+  rawWrite(KISS_FEND);
 }
 
 void KissModem::writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len) {
-  _serial.write(KISS_FEND);
+  beginFrameWrite();
+  rawWrite(KISS_FEND);
   writeByte(KISS_CMD_SETHARDWARE);
   writeByte(sub_cmd);
   for (uint16_t i = 0; i < len; i++) {
     writeByte(data[i]);
   }
-  _serial.write(KISS_FEND);
+  rawWrite(KISS_FEND);
 }
 
 void KissModem::writeHardwareError(uint8_t error_code) {

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -28,9 +28,9 @@
 #define KISS_DEFAULT_SLOTTIME    10
 #define KISS_TX_TIMEOUT_FACTOR   3/2   // 1.5x estimated airtime
 
-/* Max time (ms) to wait for serial TX buffer space before dropping a frame.
-   Prevents a stalled/absent USB-CDC host from blocking the single-threaded loop()
-   indefinitely (the ESP32 USB-CDC failure mode; UART transports never fill up). */
+/* Upper bound (ms) on how long a serial write may wait for the host to drain the
+   TX buffer. Keeps a stalled USB-CDC host from freezing the single-threaded loop();
+   UART transports drain via FIFO and never reach this. */
 #define KISS_WRITE_TIMEOUT_MS    50
 
 #define HW_CMD_GET_IDENTITY      0x01

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -28,6 +28,11 @@
 #define KISS_DEFAULT_SLOTTIME    10
 #define KISS_TX_TIMEOUT_FACTOR   3/2   // 1.5x estimated airtime
 
+/* Max time (ms) to wait for serial TX buffer space before dropping a frame.
+   Prevents a stalled/absent USB-CDC host from blocking the single-threaded loop()
+   indefinitely (the ESP32 USB-CDC failure mode; UART transports never fill up). */
+#define KISS_WRITE_TIMEOUT_MS    50
+
 #define HW_CMD_GET_IDENTITY      0x01
 #define HW_CMD_GET_RANDOM        0x02
 #define HW_CMD_VERIFY_SIGNATURE  0x03
@@ -131,6 +136,10 @@ class KissModem {
   RadioConfig _config;
   bool _signal_report_enabled;
 
+  bool _tx_write_aborted;       // set when the current frame is dropped (no TX buffer space)
+
+  void beginFrameWrite();       // reset per-frame abort state
+  void rawWrite(uint8_t b);     // non-blocking write: drops the frame rather than stalling loop()
   void writeByte(uint8_t b);
   void writeFrame(uint8_t type, const uint8_t* data, uint16_t len);
   void writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len);

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -28,10 +28,11 @@
 #define KISS_DEFAULT_SLOTTIME    10
 #define KISS_TX_TIMEOUT_FACTOR   3/2   // 1.5x estimated airtime
 
-/* Upper bound (ms) on how long a serial write may wait for the host to drain the
-   TX buffer. Keeps a stalled USB-CDC host from freezing the single-threaded loop();
-   UART transports drain via FIFO and never reach this. */
+// Max ms a USB-CDC write may block on a stalled host, so loop() never freezes (UART drains via FIFO, never hits this)
 #define KISS_WRITE_TIMEOUT_MS    50
+
+// Must fit a full escaped DATA frame (~514B) for all-or-nothing writes; 256B default drops max-size RX frames
+#define KISS_TX_BUFFER_SIZE      1024
 
 #define HW_CMD_GET_IDENTITY      0x01
 #define HW_CMD_GET_RANDOM        0x02
@@ -136,10 +137,10 @@ class KissModem {
   RadioConfig _config;
   bool _signal_report_enabled;
 
-  bool _tx_write_aborted;       // set when the current frame is dropped (no TX buffer space)
-
-  void beginFrameWrite();       // reset per-frame abort state
-  void rawWrite(uint8_t b);     // non-blocking write: drops the frame rather than stalling loop()
+  size_t escapedLength(uint8_t b) const;
+  size_t escapedLength(const uint8_t* data, size_t len) const;
+  bool canWriteFrame(size_t total_len) const;  // true only if the whole frame fits the TX buffer now
+  void writeEscapedFrame(const uint8_t* prefix, size_t prefix_len, const uint8_t* data, uint16_t len);
   void writeByte(uint8_t b);
   void writeFrame(uint8_t type, const uint8_t* data, uint16_t len);
   void writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len);

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -107,11 +107,11 @@ void setup() {
 #endif
   modem = new KissModem(Serial1, identity, rng, radio_driver, board, sensors);
 #else
+#if defined(ESP32) && (ARDUINO_USB_MODE == 1)
+  Serial.setTxBufferSize(KISS_TX_BUFFER_SIZE);  // HWCDC ring must fit a whole KISS frame; set before begin()
+#endif
   Serial.begin(115200);
 #if defined(ESP32)
-  /* Cap how long a USB-CDC write blocks waiting for the host to drain the TX
-     buffer. loop() is single-threaded, so an unbounded wait when the host stalls
-     would also freeze RX and radio servicing. */
   Serial.setTxTimeoutMs(KISS_WRITE_TIMEOUT_MS);
 #endif
   uint32_t start = millis();

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -108,6 +108,11 @@ void setup() {
   modem = new KissModem(Serial1, identity, rng, radio_driver, board, sensors);
 #else
   Serial.begin(115200);
+#if defined(ESP32)
+  /* Bound USB-CDC transmit so write() drops instead of blocking forever when the
+     host read side stalls; otherwise the single-threaded modem loop wedges. */
+  Serial.setTxTimeoutMs(KISS_WRITE_TIMEOUT_MS);
+#endif
   uint32_t start = millis();
   while (!Serial && millis() - start < 3000) delay(10);
   delay(100);

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -109,8 +109,9 @@ void setup() {
 #else
   Serial.begin(115200);
 #if defined(ESP32)
-  /* Bound USB-CDC transmit so write() drops instead of blocking forever when the
-     host read side stalls; otherwise the single-threaded modem loop wedges. */
+  /* Cap how long a USB-CDC write blocks waiting for the host to drain the TX
+     buffer. loop() is single-threaded, so an unbounded wait when the host stalls
+     would also freeze RX and radio servicing. */
   Serial.setTxTimeoutMs(KISS_WRITE_TIMEOUT_MS);
 #endif
   uint32_t start = millis();

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -434,3 +434,13 @@ lib_deps =
 extends = Heltec_lora32_v4
 build_src_filter = ${Heltec_lora32_v4.build_src_filter}
   +<../examples/kiss_modem/>
+; Use the USB-Serial-JTAG peripheral (HWCDC) instead of TinyUSB CDC. The TinyUSB
+; USBCDC path wedges permanently under TX backpressure on ESP32-S3 (write() busy-
+; spins while "connected", RX events post to a 5-deep queue with portMAX_DELAY),
+; leaving the modem unresponsive across host restarts. HWCDC bounds its writes and
+; posts RX from ISR, so it does not hang. build_unflags strips the board default
+; (=0); a bare -U is unreliable here because SCons reorders it after the -D defines.
+build_unflags = -DARDUINO_USB_MODE=0
+build_flags =
+  ${Heltec_lora32_v4.build_flags}
+  -DARDUINO_USB_MODE=1

--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -243,3 +243,13 @@ lib_deps =
 extends = Station_G2
 build_src_filter = ${Station_G2.build_src_filter}
   +<../examples/kiss_modem/>
+; Use the USB-Serial-JTAG peripheral (HWCDC) instead of TinyUSB CDC. The TinyUSB
+; USBCDC path wedges permanently under TX backpressure on ESP32-S3 (write() busy-
+; spins while "connected", RX events post to a 5-deep queue with portMAX_DELAY),
+; leaving the modem unresponsive across host restarts. HWCDC bounds its writes and
+; posts RX from ISR, so it does not hang. build_unflags strips the board default
+; (=0); a bare -U is unreliable here because SCons reorders it after the -D defines.
+build_unflags = -DARDUINO_USB_MODE=0
+build_flags =
+  ${Station_G2.build_flags}
+  -DARDUINO_USB_MODE=1


### PR DESCRIPTION
### Problem
On ESP32-S3 boards (Heltec V4, Station G2), the KISS modem would stop responding after a while and stay dead—`SetHardware` PING (`0x17`) timed out and the condition **survived a host service restart**, forcing the pyMC_repeater client into no-radio mode. nRF52 (RAK4361) on identical firmware was unaffected.

### Root cause
The ESP32 modem ran over Arduino **TinyUSB `USBCDC`** (`ARDUINO_USB_MODE=0`), which wedges under TX backpressure: `USBCDC::write()` busy-spins indefinitely while "connected" (its `tx_timeout_ms` only guards the lock acquire, not the send loop), and RX events post to a 5-deep queue with `portMAX_DELAY`. Since `loop()` is single-threaded and the ESP32-S3 has no DTR/RTS→EN reset, nothing recovers it. nRF52 is immune (hardware UART, non-blocking FIFO writes).

Confirmed by a deterministic repro (flood the modem while never reading replies → permanent wedge) and a heartbeat LED that kept blinking while the data path was frozen, isolating the hang to the TinyUSB layer, below app code.

### Fix
Switch the ESP32 KISS envs to the ESP32-S3 **USB-Serial-JTAG peripheral (`HWCDC`, `ARDUINO_USB_MODE=1`)**, whose `write()` is bounded (`tries`/timeout countdown, not an infinite spin) and which posts RX from ISR.

- `variants/{heltec_v4,station_g2}/platformio.ini`: `build_unflags` the board default `=0`, set `=1` (a bare `-U` is reordered after the `-D` by SCons).
- `examples/kiss_modem/`: transport-neutral hardening—non-blocking writes that drop a frame instead of stalling `loop()` when the TX buffer is full, plus `setTxTimeoutMs()`. A dropped reply is harmless; the host retries.

### Validation
- Builds clean for `heltec_v4_kiss_modem`, `Station_G2_kiss_modem`, `RAK_4631_kiss_modem`.
- `nm`: `HWCDC` linked, zero TinyUSB symbols.
- On hardware (Heltec V4): the flood that permanently wedged TinyUSB now recovers in a retry or two, which the host's continuous-read + ping-retry handles.

### A Wrinkle
`ARDUINO_USB_MODE=1` changes the USB descriptor, so the `/dev/serial/by-id/` path becomes `usb-Espressif_USB_JTAG_serial_debug_unit_<MAC>-if00`.