### PR TITLE
Fuzzy Paths: a new "wide" path mode for potentially better reliability on retries

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -450,6 +450,23 @@ bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   return true;
 }
 
+bool MyMesh::isNextHopNeighbor(const mesh::Packet* packet) {
+#if MAX_NEIGHBOURS
+  // TODO: check prefs to see if fuzzy pathing is enabled
+  // TODO: only consider neighbors that have been heard in a configurable amount of time
+  // TODO: make min SNR configurable
+  const int8_t min_snr = 0; // *4.f = actual snr value
+  for (int i = 0; i < MAX_NEIGHBOURS; ++i) {
+    auto neighbor = &neighbours[i];
+    if (neighbor->heard_timestamp > 0 && neighbor->snr >= min_snr && neighbor->id.isHashMatch(packet->path, packet->getPathHashSize())) {
+      return true;
+    }
+  }
+#endif
+
+return false;
+}
+
 const char *MyMesh::getLogDateTime() {
   static char tmp[32];
   uint32_t now = getRTCClock()->getCurrentTime();
@@ -480,7 +497,7 @@ void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": RX, len=%d (type=%d, route=%s, payload_len=%d) SNR=%d RSSI=%d score=%d", len,
-               pkt->getPayloadType(), pkt->isRouteDirect() ? "D" : "F", pkt->payload_len,
+               pkt->getPayloadType(), pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len,
                (int)_radio->getLastSNR(), (int)_radio->getLastRSSI(), (int)(score * 1000));
 
       if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH || pkt->getPayloadType() == PAYLOAD_TYPE_REQ ||
@@ -506,7 +523,7 @@ void MyMesh::logTx(mesh::Packet *pkt, int len) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": TX, len=%d (type=%d, route=%s, payload_len=%d)", len, pkt->getPayloadType(),
-               pkt->isRouteDirect() ? "D" : "F", pkt->payload_len);
+               pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len);
 
       if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH || pkt->getPayloadType() == PAYLOAD_TYPE_REQ ||
           pkt->getPayloadType() == PAYLOAD_TYPE_RESPONSE || pkt->getPayloadType() == PAYLOAD_TYPE_TXT_MSG) {
@@ -525,7 +542,7 @@ void MyMesh::logTxFail(mesh::Packet *pkt, int len) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": TX FAIL!, len=%d (type=%d, route=%s, payload_len=%d)\n", len, pkt->getPayloadType(),
-               pkt->isRouteDirect() ? "D" : "F", pkt->payload_len);
+               pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len);
       f.close();
     }
   }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -136,6 +136,7 @@ protected:
   }
 
   bool allowPacketForward(const mesh::Packet* packet) override;
+  bool isNextHopNeighbor(const mesh::Packet* packet) override;
   const char* getLogDateTime() override;
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -214,7 +214,7 @@ void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": RX, len=%d (type=%d, route=%s, payload_len=%d) SNR=%d RSSI=%d score=%d", len,
-               pkt->getPayloadType(), pkt->isRouteDirect() ? "D" : "F", pkt->payload_len,
+               pkt->getPayloadType(), pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len,
                (int)_radio->getLastSNR(), (int)_radio->getLastRSSI(), (int)(score * 1000));
 
       if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH || pkt->getPayloadType() == PAYLOAD_TYPE_REQ ||
@@ -233,7 +233,7 @@ void MyMesh::logTx(mesh::Packet *pkt, int len) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": TX, len=%d (type=%d, route=%s, payload_len=%d)", len, pkt->getPayloadType(),
-               pkt->isRouteDirect() ? "D" : "F", pkt->payload_len);
+               pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len);
 
       if (pkt->getPayloadType() == PAYLOAD_TYPE_PATH || pkt->getPayloadType() == PAYLOAD_TYPE_REQ ||
           pkt->getPayloadType() == PAYLOAD_TYPE_RESPONSE || pkt->getPayloadType() == PAYLOAD_TYPE_TXT_MSG) {
@@ -251,7 +251,7 @@ void MyMesh::logTxFail(mesh::Packet *pkt, int len) {
     if (f) {
       f.print(getLogDateTime());
       f.printf(": TX FAIL!, len=%d (type=%d, route=%s, payload_len=%d)\n", len, pkt->getPayloadType(),
-               pkt->isRouteDirect() ? "D" : "F", pkt->payload_len);
+               pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len);
       f.close();
     }
   }

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -219,7 +219,7 @@ void Dispatcher::checkRecv() {
     #if MESH_PACKET_LOGGING
     Serial.print(getLogDateTime());
     Serial.printf(": RX, len=%d (type=%d, route=%s, payload_len=%d) SNR=%d RSSI=%d score=%d time=%d", 
-            pkt->getRawLength(), pkt->getPayloadType(), pkt->isRouteDirect() ? "D" : "F", pkt->payload_len,
+            pkt->getRawLength(), pkt->getPayloadType(), pkt->isRouteDirect() ? (pkt->isRouteFuzzy() ? "Z" : "D") : "F", pkt->payload_len,
             (int)pkt->getSNR(), (int)_radio->getLastRSSI(), (int)(score*1000), air_time);
 
     static uint8_t packet_hash[MAX_HASH_SIZE];
@@ -340,7 +340,7 @@ void Dispatcher::checkSend() {
     #if MESH_PACKET_LOGGING
       Serial.print(getLogDateTime());
       Serial.printf(": TX, len=%d (type=%d, route=%s, payload_len=%d)", 
-            len, outbound->getPayloadType(), outbound->isRouteDirect() ? "D" : "F", outbound->payload_len);
+            len, outbound->getPayloadType(), outbound->isRouteDirect() ? (outbound->isRouteFuzzy() ? "Z" : "D") : "F", outbound->payload_len);
       if (outbound->getPayloadType() == PAYLOAD_TYPE_PATH || outbound->getPayloadType() == PAYLOAD_TYPE_REQ
         || outbound->getPayloadType() == PAYLOAD_TYPE_RESPONSE || outbound->getPayloadType() == PAYLOAD_TYPE_TXT_MSG) {
         Serial.printf(" [%02X -> %02X]\n", (uint32_t)outbound->payload[1], (uint32_t)outbound->payload[0]);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -14,6 +14,9 @@ void Mesh::loop() {
 bool Mesh::allowPacketForward(const mesh::Packet* packet) { 
   return false;  // by default, Transport NOT enabled
 }
+bool Mesh::isNextHopNeighbor(const mesh::Packet* packet) {
+  return false; // by default, neighbor tracking not enabled
+}
 uint32_t Mesh::getRetransmitDelay(const mesh::Packet* packet) { 
   uint32_t t = (_radio->getEstAirtimeFor(packet->getRawLength()) * 52 / 50) / 2;
 
@@ -72,7 +75,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
     return ACTION_RELEASE;
   }
 
-  if (pkt->isRouteDirect() && pkt->getPathHashCount() > 0) {
+  if (pkt->isRouteDirect() && pkt->getPathHashCount() > 0 && !pkt->isPathHashOnlyFuzzy()) {
     // check for 'early received' ACK
     if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) {
       int i = 0;
@@ -83,25 +86,35 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       }
     }
 
-    if (self_id.isHashMatch(pkt->path, pkt->getPathHashSize()) && allowPacketForward(pkt)) {
-      if (pkt->getPayloadType() == PAYLOAD_TYPE_MULTIPART) {
-        return forwardMultipartDirect(pkt);
-      } else if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) {
-        if (!_tables->hasSeen(pkt)) {  // don't retransmit!
-          removeSelfFromPath(pkt);
-          routeDirectRecvAcks(pkt, 0);
+    if (allowPacketForward(pkt)) {
+      bool is_next_hop = self_id.isHashMatch(pkt->path, pkt->getPathHashSize());
+      bool is_fuzzy_hop = !is_next_hop && pkt->isRouteFuzzy() && isNextHopNeighbor(pkt);
+      if (is_next_hop || is_fuzzy_hop) {
+        if (pkt->getPayloadType() == PAYLOAD_TYPE_MULTIPART) {
+          return forwardMultipartDirect(pkt);
+        } else if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) {
+          if (!_tables->hasSeen(pkt)) {  // don't retransmit!
+            removeSelfFromPath(pkt);
+            routeDirectRecvAcks(pkt, 0);
+          }
+          return ACTION_RELEASE;
         }
-        return ACTION_RELEASE;
-      }
 
-      if (!_tables->hasSeen(pkt)) {
-        removeSelfFromPath(pkt);
+        if (!_tables->hasSeen(pkt)) {
+          removeSelfFromPath(pkt);
 
-        uint32_t d = getDirectRetransmitDelay(pkt);
-        return ACTION_RETRANSMIT_DELAYED(0, d);  // Routed traffic is HIGHEST priority 
+          uint32_t d = getDirectRetransmitDelay(pkt);
+
+          if (is_next_hop) {
+            return ACTION_RETRANSMIT_DELAYED(0, d);  // Routed traffic is HIGHEST priority 
+          }
+          else {
+            return ACTION_RETRANSMIT_DELAYED(2, d); // Fuzzy traffic is high-ish priority
+          }
+        }
       }
+      return ACTION_RELEASE;   // this node is NOT the next hop (OR this packet has already been forwarded), so discard.
     }
-    return ACTION_RELEASE;   // this node is NOT the next hop (OR this packet has already been forwarded), so discard.
   }
 
   if (pkt->isRouteFlood() && filterRecvFloodPacket(pkt)) return ACTION_RELEASE;

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -56,6 +56,11 @@ protected:
   virtual bool allowPacketForward(const Packet* packet);
 
   /**
+   * \brief  Check whether this packet's next hop is a neighbor of ours.
+   */
+  virtual bool isNextHopNeighbor(const Packet* packet);
+
+  /**
    * \returns  number of milliseconds delay to apply to retransmitting the given packet.
    */
   virtual uint32_t getRetransmitDelay(const Packet* packet);

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -21,6 +21,10 @@
 #define MAX_PATH_SIZE        64
 #define MAX_TRANS_UNIT      255
 
+// Denotes that everything after this prefix can be used in a "fuzzy" repeat.
+// Repeated to match the path length (so 2-byte paths would use two of these, 3-byte would use 3).
+#define FUZZY_PATH_PREFIX 0xFF
+
 #if MESH_DEBUG && ARDUINO
   #include <Arduino.h>
   #define MESH_DEBUG_PRINT(F, ...) Serial.printf("DEBUG: " F, ##__VA_ARGS__)

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -49,6 +49,35 @@ void Packet::calculatePacketHash(uint8_t* hash) const {
   sha.finalize(hash, MAX_HASH_SIZE);
 }
 
+bool Packet::isRouteFuzzy() const {
+  // Only direct routes make sense for fuzzy use
+  if (!isRouteDirect()) {
+    return false;
+  }
+
+  // Trace is a weird situation to handle, not supported
+  if (getPayloadType() == PAYLOAD_TYPE_TRACE) {
+    return false;
+  }
+
+  if (!isValidPathLen(path_len)) {
+    return false;
+  }
+
+  uint8_t hash_size = getPathHashSize();
+  uint8_t hash_count = getPathHashCount();
+  
+  uint8_t fuzzy_prefix[3]; // TODO: is there a constant somewhere for the max # of prefix bytes?
+  memset(fuzzy_prefix, FUZZY_PATH_PREFIX, 3);
+
+  if (memcmp(fuzzy_prefix, &path[hash_size * (hash_count - 1)], hash_size) == 0)
+  {
+    return true;
+  }
+
+  return false;
+}
+
 uint8_t Packet::writeTo(uint8_t dest[]) const {
   uint8_t i = 0;
   dest[i++] = header;

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -63,6 +63,7 @@ public:
 
   bool isRouteFlood() const { return getRouteType() == ROUTE_TYPE_FLOOD || getRouteType() == ROUTE_TYPE_TRANSPORT_FLOOD; }
   bool isRouteDirect() const { return getRouteType() == ROUTE_TYPE_DIRECT || getRouteType() == ROUTE_TYPE_TRANSPORT_DIRECT; }
+  bool isRouteFuzzy() const;
 
   bool hasTransportCodes() const { return getRouteType() == ROUTE_TYPE_TRANSPORT_FLOOD || getRouteType() == ROUTE_TYPE_TRANSPORT_DIRECT; }
 
@@ -79,6 +80,7 @@ public:
   uint8_t getPathHashSize() const { return (path_len >> 6) + 1; }
   uint8_t getPathHashCount() const { return path_len & 63; }
   uint8_t getPathByteLen() const { return getPathHashCount() * getPathHashSize(); }
+  bool isPathHashOnlyFuzzy() const { return getPathHashCount() == 1 && isRouteFuzzy(); }
   void setPathHashCount(uint8_t n) { path_len &= ~63; path_len |= n; }
   void setPathHashSizeAndCount(uint8_t sz, uint8_t n) { path_len = ((sz - 1) << 6) | (n & 63); }
 


### PR DESCRIPTION
See https://github.com/meshcore-dev/MeshCore/discussions/2487 for my original proposal. I've gone back and forth on whether this should be called fuzzy/wide/thick or something else, happy to rename. Also, consider this a proof of concept as there's a bit of unfinished work and I'm not even entirely sure this is a good idea, but I wanted to try my hand at it nonetheless.

This implements a new method of pathing that is in-between a direct path and flood routing. If requested, updated repeaters can repeat a packet that was intended for a neighboring repeater, effectively "widening" the path. Flagging a path as "fuzzy" is done by appending an `FF` prefix (or `FFFF`, or `FFFFFF` depending on hash size) at the end of a path to signify that fuzzy repeating is allowed.

Some notes about compatibility, additional work, etc:

* Fuzzy paths are opt-in from the sender. This does not affect the behavior of normal direct-path packets or flood routing - it only affects packets that have explicitly added `FF` at the end of their path.
* I'm unsure if flagging a fuzzy path by appending `FF` to it is the best way to go - it was the easiest backwards-compatible method I could think of since as far as I can tell `FF` is reserved but not actually used, and the only downside is losing a single hop _if_ a fuzzy path is used.
* Old repeater firmware will continue to repeat packets with fuzzy paths the way they would normally, they just won't repeat for neighbors like the updated firmware will.
* The recipient of a packet with fuzzy pathing must be on updated firmware as recipients will otherwise ignore a packet meant for them, because they believe that repeater `FF` must first see the packet.
* The sender does *NOT* need to be on updated firmware since the flag for a fuzzy path looks like a normal repeater with an invalid prefix.
* I'm not sure if room servers have repeat logic (I didn't look into them too much) but they could automatically fall back to a fuzzy path as an attempt as well.
* For debugging/packet logging purposes I've changed the route type to `Z` for fuzzy paths since `F` already means flood.
* I have not done any work on making anything configurable yet, though I've left a few TODOs in `MyMesh::isNextHopNeighbor` about it. Right now any neighbor with an snr >= 0 will be considered when deciding whether to repeat for a fuzzy packet.
* I have done limited testing across a few devices (heltec v4 with updated firmware on the receiving end, an r1 neo without updated firmware as the sender, and a T1000e with updated firmware as a repeater).
* One downside of using a fuzzy path is that you can't know the true path that a packet took. Fixing that would require effectively rewriting how paths work for this mode and breaking any kind of compatibility for this type of path, which I did not want to do. As such, I would say that fuzzy paths are intended as a sort of last resort before the real last resort of flooding.

My idea is that this would be used as a fallback after attempting a couple of direct messages but before trying a flood message, since this should be much cheaper and potentially has a higher likelihood of reaching its destination if a repeater is busy. This will require app support since as far as I can tell the firmware does not decide how to handle retries, but I am not entirely sure the best way to go about adding that support. As things are with this PR now, an app would need to update the contact's path to have `FF` for the message it wants to retry, but ideally it'd be able to set a flag via the companion protocol. I was not comfortable changing that as I'm unsure how to handle that in a backwards compatible way, especially since no apps actually support this yet.