### PR TITLE
fix: update wio-e5-mini pio config to address SubGhz dependency issue

### DIFF
--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -12,10 +12,14 @@ build_flags = ${stm32_base.build_flags}
   -D P_LORA_TX_LED=LED_RED
   -D PIN_USER_BTN=USER_BTN
   -I variants/wio-e5-mini
+  ; HACK: why this is needed, I don't know. But if I remove it, everything breaks.
+  ;       until such a time as this un-breaks itself, I'd suggest leaving it in.
+  -I $PROJECT_PACKAGES_DIR/framework-arduinoststm32/libraries/SubGhz/src
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-mini>
 lib_deps = ${stm32_base.lib_deps}
   finitespace/BME280 @ ^3.0.0
+  SubGhz
 
 [env:wio-e5-mini_repeater]
 extends = lora_e5_mini


### PR DESCRIPTION
Title is self-explanatory, should fix an issue with the `wio-e5-mini` variants failing to build due to a failure in resolving the `SubGhz` library of `framework-arduinostm32` - builds no longer fail locally, though may require testing on hardware to confirm functionality.