### PR TITLE
Early receives: allow nodes to process most incoming direct packets ASAP

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -73,16 +73,6 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
   }
 
   if (pkt->isRouteDirect() && pkt->getPathHashCount() > 0) {
-    // check for 'early received' ACK
-    if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) {
-      int i = 0;
-      uint32_t ack_crc;
-      memcpy(&ack_crc, &pkt->payload[i], 4); i += 4;
-      if (i <= pkt->payload_len) {
-        onAckRecv(pkt, ack_crc);
-      }
-    }
-
     if (self_id.isHashMatch(pkt->path, pkt->getPathHashSize()) && allowPacketForward(pkt)) {
       if (pkt->getPayloadType() == PAYLOAD_TYPE_MULTIPART) {
         return forwardMultipartDirect(pkt);
@@ -101,7 +91,36 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         return ACTION_RETRANSMIT_DELAYED(0, d);  // Routed traffic is HIGHEST priority 
       }
     }
-    return ACTION_RELEASE;   // this node is NOT the next hop (OR this packet has already been forwarded), so discard.
+
+    // check if we're the destination or can otherwise receive this packet early - before the full path has been consumed
+    bool can_early_receive = false;
+    switch (pkt->getPayloadType()) {
+      case PAYLOAD_TYPE_ACK: {
+        int i = 0;
+        uint32_t ack_crc;
+        memcpy(&ack_crc, &pkt->payload[i], 4); i += 4;
+        if (i <= pkt->payload_len) {
+          can_early_receive = true;
+        }
+        break;
+      }
+      
+      case PAYLOAD_TYPE_PATH:
+      case PAYLOAD_TYPE_REQ:
+      case PAYLOAD_TYPE_RESPONSE:
+      case PAYLOAD_TYPE_TXT_MSG:
+      case PAYLOAD_TYPE_ANON_REQ: {
+        // all of these payloads have the destination hash in the first byte
+        if (self_id.isHashMatch(pkt->payload, 1)) {
+          can_early_receive = true;
+        }
+        break;
+      }
+    }
+
+    if (!can_early_receive) {
+      return ACTION_RELEASE;   // this node is NOT the next hop (OR this packet has already been forwarded), so discard.
+    }
   }
 
   if (pkt->isRouteFlood() && filterRecvFloodPacket(pkt)) return ACTION_RELEASE;


### PR DESCRIPTION
Right now a node can only process a direct packet if it is receiving the final hop (i.e. the entire path has been consumed), but this seems like it is unnecessary for payload types that are easy to check destination hashes on.

For example, consider a packet with path A,B,C with a destination of D. If node D can hear A directly, there's no reason for it to wait for C to repeat the packet before replying.

There was already an exception for ACKs that worked this way, so this change extends that to a few other payload types that all have easy access to the destination hash.