### PR TITLE
stm32: make subghz dep fix global and update framework

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -107,17 +107,17 @@ build_flags = ${arduino_base.build_flags}
 
 [stm32_base]
 extends = arduino_base
-platform = platformio/ststm32@19.1.0
-platform_packages = platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.10.1.zip
+platform = ststm32
 extra_scripts = post:arch/stm32/build_hex.py
 build_flags = ${arduino_base.build_flags}
   -D STM32_PLATFORM
   -I src/helpers/stm32
+  -I $PROJECT_PACKAGES_DIR/framework-arduinoststm32/libraries/SubGhz/src
 build_src_filter = ${arduino_base.build_src_filter}
   +<helpers/stm32>
 lib_deps = ${arduino_base.lib_deps}
   file://arch/stm32/Adafruit_LittleFS_stm32
-  adafruit/Adafruit BusIO @ 1.17.2
+  SubGhz
 
 [sensor_base]
 build_flags =

--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -12,14 +12,10 @@ build_flags = ${stm32_base.build_flags}
   -D P_LORA_TX_LED=LED_RED
   -D PIN_USER_BTN=USER_BTN
   -I variants/wio-e5-mini
-  ; HACK: why this is needed, I don't know. But if I remove it, everything breaks.
-  ;       until such a time as this un-breaks itself, I'd suggest leaving it in.
-  -I $PROJECT_PACKAGES_DIR/framework-arduinoststm32/libraries/SubGhz/src
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-mini>
 lib_deps = ${stm32_base.lib_deps}
   finitespace/BME280 @ ^3.0.0
-  SubGhz
 
 [env:wio-e5-mini_repeater]
 extends = lora_e5_mini


### PR DESCRIPTION
This makes the #2650 fix by @LeoCatsune global to all stm32 ports

Also updates the platform deps and removes the fix for adafruit busio (that has been solved upstream long ago)