### PR TITLE
companion_radio: wake display on USB connect 🤖🤖

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -558,6 +558,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _display = display;
   _sensors = sensors;
   _auto_off = millis() + AUTO_OFF_MILLIS;
+  _was_ext_powered = board.isExternalPowered();   // don't fire wake-on-connect if booted while powered
 
 #if defined(PIN_USER_BTN)
   user_btn.begin();
@@ -774,6 +775,15 @@ void UITask::loop() {
     next_backlight_btn_check = millis() + 300;
   }
 #endif
+
+  // Wake the display when external (USB) power is newly connected, as if a key
+  // was pressed. Only acts when the screen is currently off, so an already-lit
+  // display is left untouched (it still auto-offs unless KEEP_DISPLAY_ON_USB).
+  bool ext_powered = board.isExternalPowered();
+  if (ext_powered && !_was_ext_powered && _display != NULL && !_display->isOn()) {
+    c = checkDisplayOn(c);
+  }
+  _was_ext_powered = ext_powered;
 
   if (c != 0 && curr) {
     curr->handleInput(c);

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -38,6 +38,7 @@ class UITask : public AbstractUITask {
   int _msgcount;
   unsigned long ui_started_at, next_batt_chck;
   int next_backlight_btn_check = 0;
+  bool _was_ext_powered = false;   // tracks USB/external power edge for wake-on-connect
 #ifdef PIN_STATUS_LED
   int led_state = 0;
   int next_led_change = 0;

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -37,6 +37,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _display = display;
   _sensors = sensors;
   _auto_off = millis() + AUTO_OFF_MILLIS;
+  _was_ext_powered = board.isExternalPowered();   // don't fire wake-on-connect if booted while powered
   clearMsgPreview();
   _node_prefs = node_prefs;
   if (_display != NULL) {
@@ -328,6 +329,18 @@ void UITask::loop() {
 #ifdef PIN_BUZZER
   if (buzzer.isPlaying())  buzzer.loop();
 #endif
+
+  // Wake the display when external (USB) power is newly connected, as if a
+  // button was pressed. Only acts when the screen is currently off, so an
+  // already-lit display is left untouched (it still auto-offs unless
+  // KEEP_DISPLAY_ON_USB).
+  bool ext_powered = board.isExternalPowered();
+  if (ext_powered && !_was_ext_powered && _display != NULL && !_display->isOn()) {
+    _display->turnOn();
+    _auto_off = millis() + AUTO_OFF_MILLIS;
+    _need_refresh = true;
+  }
+  _was_ext_powered = ext_powered;
 
   if (_display != NULL && _display->isOn()) {
     static bool _firstBoot = true;

--- a/examples/companion_radio/ui-orig/UITask.h
+++ b/examples/companion_radio/ui-orig/UITask.h
@@ -29,6 +29,7 @@ class UITask : public AbstractUITask {
   int _msgcount;
   bool _need_refresh = true;
   bool _displayWasOn = false;  // Track display state before button press
+  bool _was_ext_powered = false;   // tracks USB/external power edge for wake-on-connect
   unsigned long ui_started_at;
 
   // Button handlers

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -428,6 +428,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _display = display;
   _sensors = sensors;
   _auto_off = millis() + AUTO_OFF_MILLIS;
+  _was_ext_powered = board.isExternalPowered();   // don't fire wake-on-connect if booted while powered
   _cached_batt_mv = getBattMilliVolts();
 
 #if defined(PIN_USER_BTN)
@@ -652,6 +653,15 @@ void UITask::loop() {
     c = 0;
   }
 #endif
+
+  // Wake the display when external (USB) power is newly connected, as if a key
+  // was pressed. Only acts when the screen is currently off, so an already-lit
+  // display is left untouched (it still auto-offs unless KEEP_DISPLAY_ON_USB).
+  bool ext_powered = board.isExternalPowered();
+  if (ext_powered && !_was_ext_powered && _display != NULL && !_display->isOn()) {
+    c = checkDisplayOn(c);
+  }
+  _was_ext_powered = ext_powered;
 
   if (c != 0 && curr) {
     curr->handleInput(c);

--- a/examples/companion_radio/ui-tiny/UITask.h
+++ b/examples/companion_radio/ui-tiny/UITask.h
@@ -42,6 +42,7 @@ class UITask : public AbstractUITask {
   int _msgcount;
   unsigned long ui_started_at, next_batt_chck;
   int next_backlight_btn_check = 0;
+  bool _was_ext_powered = false;   // tracks USB/external power edge for wake-on-connect
   uint16_t _cached_batt_mv;
 #ifdef PIN_STATUS_LED
   int led_state = 0;


### PR DESCRIPTION
## What

Light up the screen when external (USB) power is **newly connected**, as if a key had been pressed.

- A new `_was_ext_powered` member tracks the previous power state, so the wake only fires on the **rising edge** (`ext_powered && !_was_ext_powered`).
- It's seeded from the current state in `begin()`, so booting while already powered does **not** trigger a spurious wake.
- The wake only acts when the screen is currently **off** (`!_display->isOn()`), so an already-lit display is left untouched — no timer extension, no injected input.
- By default the screen auto-offs normally afterwards. The existing opt-in `KEEP_DISPLAY_ON_USB` is what keeps it lit while powered; the two compose cleanly.

Applied consistently across all three companion_radio UI variants: `ui-new`, `ui-orig`, `ui-tiny` (mirroring the existing `KEEP_DISPLAY_ON_USB` placement).

## Why

When a device is sitting with its screen off and you plug it into USB, it's natural to expect the display to wake so you can see status — without having to also press a button.

## Notes for reviewers

- `isExternalPowered()` is only implemented on **NRF52** (VBUS detect); it returns `false` on other platforms, so this feature is effectively NRF52-only and inert elsewhere — no behavior change on ESP32 targets.
- The wake is unconditional (not behind its own `#define`), unlike `KEEP_DISPLAY_ON_USB`: a momentary wake doesn't carry the OLED burn-in risk that gated the keep-on feature. Happy to gate it behind a flag if preferred.
- Build-verified on NRF52: `GAT562_30S_Mesh_Kit_companion_radio_usb` (ui-new) and `Xiao_nrf52_companion_radio_usb` (ui-orig). The `LilyGo_T-Echo_Card` env (ui-tiny) has a pre-existing `genericBuzzer` link error unrelated to this change (fails identically on the unmodified tree); the ui-tiny code is structurally identical to ui-new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)