### PR TITLE
xiao_s3_wio: Allow connection of the L76 GPS module using its RX,TX and power pins.

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -6,7 +6,10 @@ board_build.mcu = esp32s3
 build_flags = ${esp32_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/xiao_s3_wio
-  -UENV_INCLUDE_GPS
+  -D ENV_INCLUDE_GPS=1
+  -D PIN_GPS_RX=D6
+  -D PIN_GPS_TX=D7
+  -D PIN_GPS_EN=D2
   -D SEEED_XIAO_S3
   -D P_LORA_DIO_1=39
   -D P_LORA_NSS=41

--- a/variants/xiao_s3_wio/target.cpp
+++ b/variants/xiao_s3_wio/target.cpp
@@ -14,7 +14,13 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 ESP32RTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
-EnvironmentSensorManager sensors;
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock, GPS_RESET, GPS_EN);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;


### PR DESCRIPTION
Add in support for GPS on this board.
Use the !RESET/ENABLE pin (D2) as the ENABLE pin in code. This is not wired into my circuit. (I will run a wire from D2 to the ENABLE pin on my module. They are side by side on veroboard in my buils so easy enough.)