### PR TITLE
Implement flood.max.unscoped to allow selective repeating of unscoped messages

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -619,6 +619,21 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+#### Limit the number of hops for an unscoped flood message
+**Usage:**
+- `get flood.max.unscoped`
+- `set flood.max.unscoped <value>`
+
+**Parameters:**
+- `value`: Maximum flood hop count (0-64) for a packet without a scope (no region set)
+
+**Default:** `0xFF` - indicates it hasn't been set, will track flood.max until it is.
+
+**Note:** An alternative to `region denyf *`, setting `flood.max.unscoped` to a lower value such as `3` would allow for local unscoped messages to propagate, while preventing noisy neighbors from flooding a local region.
+
+
+---
+
 ### ACL
 
 #### Add, update or remove permissions for a companion

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -428,7 +428,14 @@ void MyMesh::sendFloodReply(mesh::Packet* packet, unsigned long delay_millis, ui
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
-  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
+  if (packet->isRouteFlood()) {
+    uint8_t limit = _prefs.flood_max;
+    if (packet->getRouteType() == ROUTE_TYPE_FLOOD
+        && _prefs.flood_max_unscoped != FLOOD_MAX_UNSCOPED_UNSET) {
+      limit = _prefs.flood_max_unscoped;
+    }
+    if (packet->getPathHashCount() >= limit) return false;
+  }
   if (packet->isRouteFlood() && recv_pkt_region == NULL) {
     MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");
     return false;
@@ -886,6 +893,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.advert_interval = 1;        // default to 2 minutes for NEW installs
   _prefs.flood_advert_interval = 47; // 47 hours
   _prefs.flood_max = 64;
+  _prefs.flood_max_unscoped = FLOOD_MAX_UNSCOPED_UNSET;
   _prefs.interference_threshold = 0; // disabled
 
   // bridge defaults

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -282,7 +282,14 @@ uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
-  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
+  if (packet->isRouteFlood()) {
+    uint8_t limit = _prefs.flood_max;
+    if (packet->getRouteType() == ROUTE_TYPE_FLOOD
+        && _prefs.flood_max_unscoped != FLOOD_MAX_UNSCOPED_UNSET) {
+      limit = _prefs.flood_max_unscoped;
+    }
+    if (packet->getPathHashCount() >= limit) return false;
+  }
   return true;
 }
 
@@ -643,6 +650,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.advert_interval = 1;        // default to 2 minutes for NEW installs
   _prefs.flood_advert_interval = 47; // 47 hours
   _prefs.flood_max = 64;
+  _prefs.flood_max_unscoped = FLOOD_MAX_UNSCOPED_UNSET;
   _prefs.interference_threshold = 0; // disabled
 #ifdef ROOM_PASSWORD
   StrHelper::strncpy(_prefs.guest_password, ROOM_PASSWORD, sizeof(_prefs.guest_password));

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -89,7 +89,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.read((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.read((uint8_t *)&_prefs->flood_max_unscoped, sizeof(_prefs->flood_max_unscoped));   // 291
+    // next: 292
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -119,6 +120,11 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
 
     // sanitise settings
     _prefs->rx_boosted_gain = constrain(_prefs->rx_boosted_gain, 0, 1); // boolean
+
+    // sanitise only if user sets unscoped max
+    if (_prefs->flood_max_unscoped != FLOOD_MAX_UNSCOPED_UNSET) {
+      _prefs->flood_max_unscoped = constrain(_prefs->flood_max_unscoped, 0, 64);
+    }
 
     file.close();
   }
@@ -180,7 +186,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));                          // 170
     file.write((uint8_t *)&_prefs->rx_boosted_gain, sizeof(_prefs->rx_boosted_gain));              // 290
-    // next: 291
+    file.write((uint8_t *)&_prefs->flood_max_unscoped, sizeof(_prefs->flood_max_unscoped));   // 291
+    // next: 292
 
     file.close();
   }
@@ -607,6 +614,15 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     } else {
       strcpy(reply, "Error, max 64");
     }
+  } else if (memcmp(config, "flood.max.unscoped ", 19) == 0) {
+    uint8_t m = atoi(&config[19]);
+    if (m <= 64) {
+      _prefs->flood_max_unscoped = m;
+      savePrefs();
+      strcpy(reply, "OK");
+    } else {
+      strcpy(reply, "Error, max 64");
+    } 
   } else if (memcmp(config, "direct.txdelay ", 15) == 0) {
     float f = atof(&config[15]);
     if (f >= 0 && f <= 2.0f) {
@@ -782,6 +798,12 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->rx_delay_base));
   } else if (memcmp(config, "txdelay", 7) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->tx_delay_factor));
+  } else if (memcmp(config, "flood.max.unscoped", 18) == 0) {
+    if (_prefs->flood_max_unscoped == FLOOD_MAX_UNSCOPED_UNSET) {
+      sprintf(reply, "> default (tracks flood.max=%u)", (unsigned)_prefs->flood_max);
+    } else {
+      sprintf(reply, "> %d", (uint32_t)_prefs->flood_max_unscoped);
+    }
   } else if (memcmp(config, "flood.max", 9) == 0) {
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
   } else if (memcmp(config, "direct.txdelay", 14) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -14,6 +14,8 @@
 #define ADVERT_LOC_SHARE      1
 #define ADVERT_LOC_PREFS      2
 
+#define FLOOD_MAX_UNSCOPED_UNSET 0xFF
+
 #define LOOP_DETECT_OFF       0
 #define LOOP_DETECT_MINIMAL   1
 #define LOOP_DETECT_MODERATE  2
@@ -40,6 +42,7 @@ struct NodePrefs { // persisted to file
   uint8_t multi_acks;
   float bw;
   uint8_t flood_max;
+  uint8_t flood_max_unscoped;
   uint8_t interference_threshold;
   uint8_t agc_reset_interval; // secs / 4
   // Bridge settings


### PR DESCRIPTION
As mentioned in https://github.com/meshcore-dev/MeshCore/issues/2555 this, having flood.max.unscoped as an alternative to `region denyf *` would address most peoples primary fear of blocking all unscoped messages - mostly that nearby users new to the mesh won't be able to contact or communicate with _anyone_ until they have the correct regions set.

This fix implements `flood.max.unscoped` as an additional setting, with the following design considerations:
- If unset, default value is 0xFF, and the check falls back to the flood.max value (and reports the flood.max.unscoped value as the same as the flood.max value - because it is handled the same way).
- Once set, packets with ROUTE\_TYPE\_FLOOD will be checked against this value, while all other packets will be evaluated against the max.flood value. There is currently no way to _unset_ this value, so users will have to change flood.max.unscoped independently of flood.max in the future.

Preliminary testing has been done with repeater firmware, and have verified that both unscoped of <= flood.max.unscoped have passed through, while > flood.max.unscoped were dropped. Scoped messages continued to pass without issue at the same time.

Compiled firmware, based off dev snapshot from the afternoon of 2026-06-01, is available here: https://static.loraproject.org/unscoped/

