### PR TITLE
nrf52: turn off BLE connection LED before SYSTEMOFF 🤖🤖

### DIFF
--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -156,6 +156,18 @@ void NRF52Board::enterSystemOff(uint8_t reason) {
     NRF_POWER->GPREGRET2 = reason;
   }
 
+  // Turn off the BLE connection LED before deep sleep. Bluefruit's autoConnLed
+  // (on by default) drives LED_CONN; nRF52 SYSTEMOFF only halts the core and
+  // leaves GPIO outputs latched in their last state, so the LED would otherwise
+  // stay lit through hibernation. Stop BLE re-driving the pin, then pull it low.
+  if (sd_enabled) {
+    Bluefruit.autoConnLed(false);   // stop BLE re-driving the LED
+    Bluefruit.Advertising.stop();   // stop advertising + its blink timer
+  }
+#if defined(LED_CONN) && (LED_CONN >= 0)
+  ledOff(LED_CONN);                 // polarity-aware (respects LED_STATE_ON)
+#endif
+
   // Flush serial buffers
   Serial.flush();
   delay(100);


### PR DESCRIPTION
## Problem

On nRF52 boards, the **BLE connection LED stays lit after entering hibernation** (SYSTEMOFF / deep sleep).

Bluefruit's `autoConnLed` defaults **on** and drives `LED_CONN` (the disable is commented out in [`SerialBLEInterface.cpp`](../blob/dev/src/helpers/nrf52/SerialBLEInterface.cpp)). nRF52 SYSTEMOFF only halts the core and leaves GPIO outputs **latched in their last drive state**, while `enterSystemOff()` never turns the LED off or stops BLE. So the LED stays on through deep sleep — solid when a companion app is connected, or caught mid-blink while advertising.

## Fix

In the shared `NRF52Board::enterSystemOff()` funnel, before entering SYSTEMOFF:
- disable `autoConnLed` and stop advertising so BLE no longer drives the pin,
- pull `LED_CONN` low with the **polarity-aware `ledOff()`** macro (respects each variant's `LED_STATE_ON` — boards differ: rak3401 is active-high, XIAO active-low).

The Bluefruit calls are gated on the SoftDevice being enabled, so the early low-voltage / boot-protect path (which runs before `Bluefruit.begin()`) is safe; `ledOff()` always runs. **Awake behavior is unchanged** — the LED still indicates BLE status during normal operation.

This is a general nRF52 issue, not board-specific. Fixing it in the shared funnel covers every board that hibernates through `enterSystemOff()` in one place: **rak3401, rak4631, xiao_nrf52**.

## Not covered

`promicro` and `rak_wismesh_tag` call `sd_power_system_off()` directly in their own `powerOff()` rather than routing through `enterSystemOff()`, so they are not fixed by this change. Left as a follow-up (either the same LED-off prep added to those paths, or routing them through `enterSystemOff()`).

## Testing

Builds clean for `RAK_3401_companion_radio_ble`, `RAK_4631_companion_radio_ble`, and `Xiao_nrf52_companion_radio_ble` (covers both LED polarities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)