### PR TITLE
Disable auto-shutdown when externally powered, add auto-shutdown warning for OLED displays

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -832,22 +832,20 @@ void UITask::loop() {
   if (millis() > next_batt_chck) {
     uint16_t milliVolts = getBattMilliVolts();
     if (milliVolts > 0 && milliVolts < AUTO_SHUTDOWN_MILLIVOLTS) {
-
-      // show low battery shutdown alert
-      // we should only do this for eink displays, which will persist after power loss
-      #if defined(THINKNODE_M1) || defined(LILYGO_TECHO)
-      if (_display != NULL) {
-        _display->startFrame();
-        _display->setTextSize(2);
-        _display->setColor(DisplayDriver::RED);
-        _display->drawTextCentered(_display->width() / 2, 20, "Low Battery.");
-        _display->drawTextCentered(_display->width() / 2, 40, "Shutting Down!");
-        _display->endFrame();
+      if(!board.isExternalPowered()) {
+        if (_display != NULL) {
+          _display->startFrame();
+          _display->setTextSize(2);
+          _display->setColor(DisplayDriver::RED);
+          _display->drawTextCentered(_display->width() / 2, 20, "Low Battery.");
+          _display->drawTextCentered(_display->width() / 2, 40, "Shutting Down!");
+          _display->endFrame();
+          #if !defined(THINKNODE_M1) && !defined(LILYGO_TECHO) // TODO: refactor eink variants to use EINK_DISPLAY macros to gate this properly
+          delay(3000);
+          #endif
+        }
+        shutdown();
       }
-      #endif
-
-      shutdown();
-
     }
     next_batt_chck = millis() + 8000;
   }

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -840,9 +840,7 @@ void UITask::loop() {
           _display->drawTextCentered(_display->width() / 2, 20, "Low Battery.");
           _display->drawTextCentered(_display->width() / 2, 40, "Shutting Down!");
           _display->endFrame();
-          #if !defined(THINKNODE_M1) && !defined(LILYGO_TECHO) // TODO: refactor eink variants to use EINK_DISPLAY macros to gate this properly
-          delay(3000);
-          #endif
+          if (_display->isEink() == false) { delay(3000); }
         }
         shutdown();
       }

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -727,14 +727,23 @@ void UITask::loop() {
   if (millis() > next_batt_chck) {
     _cached_batt_mv = getBattMilliVolts();
     if (_cached_batt_mv > 0 && _cached_batt_mv < AUTO_SHUTDOWN_MILLIVOLTS) {
-
-      shutdown();
-
+      if(!board.isExternalPowered()) {
+        if (_display != NULL) {
+        _display->startFrame();
+        _display->setTextSize(2);
+        _display->drawTextCentered(_display->width() / 2, 6, "Low battery!");
+        _display->setTextSize(1);
+        _display->drawTextCentered(_display->width() / 2, 18, "Shutting down!");
+        _display->endFrame();
+        delay(3000); // TODO: refactor eink variants to use EINK_DISPLAY macros to gate this properly
+        }
+        shutdown();
+      }
     }
     next_batt_chck = millis() + 8000;
   }
 #else
-  if (_display != NULL && _display->isOn() && millis >= next_batt_chck) {
+  if (_display != NULL && _display->isOn() && millis() >= next_batt_chck) {
     _cached_batt_mv = getBattMilliVolts();
     next_batt_chck = millis() + 8000;
   }

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -735,7 +735,7 @@ void UITask::loop() {
         _display->setTextSize(1);
         _display->drawTextCentered(_display->width() / 2, 18, "Shutting down!");
         _display->endFrame();
-        delay(3000); // TODO: refactor eink variants to use EINK_DISPLAY macros to gate this properly
+        if (_display->isEink() == false) { delay(3000); }
         }
         shutdown();
       }

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -66,20 +66,6 @@ void NRF52Board::initPowerMgr() {
   }
 }
 
-bool NRF52Board::isExternalPowered() {
-  // Check if SoftDevice is enabled before using its API
-  uint8_t sd_enabled = 0;
-  sd_softdevice_is_enabled(&sd_enabled);
-
-  if (sd_enabled) {
-    uint32_t usb_status;
-    sd_power_usbregstatus_get(&usb_status);
-    return (usb_status & POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
-  } else {
-    return (NRF_POWER->USBREGSTATUS & POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
-  }
-}
-
 const char* NRF52Board::getResetReasonString(uint32_t reason) {
   if (reason & POWER_RESETREAS_RESETPIN_Msk) return "Reset Pin";
   if (reason & POWER_RESETREAS_DOG_Msk) return "Watchdog";
@@ -248,6 +234,20 @@ void NRF52BoardDCDC::begin() {
     sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
   } else {
     NRF_POWER->DCDCEN = 1;
+  }
+}
+
+bool NRF52Board::isExternalPowered() {
+  // Check if SoftDevice is enabled before using its API
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+
+  if (sd_enabled) {
+    uint32_t usb_status;
+    sd_power_usbregstatus_get(&usb_status);
+    return (usb_status & POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
+  } else {
+    return (NRF_POWER->USBREGSTATUS & POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
   }
 }
 

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -53,9 +53,9 @@ public:
   virtual bool getBootloaderVersion(char* version, size_t max_len) override;
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
   virtual void sleep(uint32_t secs) override;
+  bool isExternalPowered() override;
 
 #ifdef NRF52_POWER_MANAGEMENT
-  bool isExternalPowered() override;
   uint16_t getBootVoltage() override { return boot_voltage_mv; }
   virtual uint32_t getResetReason() const override { return reset_reason; }
   uint8_t getShutdownReason() const override { return shutdown_reason; }

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -14,6 +14,7 @@ public:
   int height() const { return _h; }
 
   virtual bool isOn() = 0;
+  virtual bool isEink() { return false; } // default to non-eink, override in eink drivers
   virtual void turnOn() = 0;
   virtual void turnOff() = 0;
   virtual void clear() = 0;

--- a/src/helpers/ui/E213Display.h
+++ b/src/helpers/ui/E213Display.h
@@ -26,6 +26,7 @@ public:
   }
   bool begin();
   bool isOn() override { return _isOn; }
+  bool isEink() override { return true; }
   void turnOn() override;
   void turnOff() override;
   void clear() override;

--- a/src/helpers/ui/E290Display.h
+++ b/src/helpers/ui/E290Display.h
@@ -22,6 +22,7 @@ public:
 
   bool begin();
   bool isOn() override { return _isOn; }
+  bool isEink() override { return true; }
   void turnOn() override;
   void turnOff() override;
   void clear() override;

--- a/src/helpers/ui/GxEPDDisplay.h
+++ b/src/helpers/ui/GxEPDDisplay.h
@@ -46,7 +46,8 @@ public:
 
   bool begin();
 
-  bool isOn() override {return _isOn;};
+  bool isOn() override { return _isOn; }
+  bool isEink() override { return true; }
   void turnOn() override;
   void turnOff() override;
   void clear() override;


### PR DESCRIPTION
This PR skips low battery auto-shutdown if isExternalPowered() returns true, and also introduces a 3 second warning for OLED displays before auto-shutdown.

Currently only works for NRF52 boards, ESP32 would probably need board-level overrides I think.