### PR TITLE
Issue #2668 [Fix] Heltec t096 RTC option

### DIFF
--- a/src/helpers/AutoDiscoverRTCClock.cpp
+++ b/src/helpers/AutoDiscoverRTCClock.cpp
@@ -43,6 +43,13 @@ void AutoDiscoverRTCClock::begin(TwoWire& wire) {
 
   if (i2c_probe(wire, PCF8563_ADDRESS)) {
     rtc_8563_success = rtc_8563.begin(&wire);
+    if (rtc_8563_success) {
+      if (rtc_8563.lostPower()) {
+        // only set time if RTC lost power, otherwise leave it alone
+        // (e.g. if battery is dead but still keeping time, or if user has set to a specific time)
+        rtc_8563.adjust(DateTime(2024, 5, 15, 20, 50, 0)); // set date and time as with CMD clkreboot: (15 May 2024, 8:50pm)
+      }
+    }
   }
 
   if (i2c_probe(wire, RX8130CE_ADDRESS)) {
@@ -81,7 +88,7 @@ uint32_t AutoDiscoverRTCClock::getCurrentTime() {
   return _fallback->getCurrentTime();
 }
 
-void AutoDiscoverRTCClock::setCurrentTime(uint32_t time) { 
+void AutoDiscoverRTCClock::setCurrentTime(uint32_t time) {
   if (ds3231_success) {
     rtc_3231.adjust(DateTime(time));
   } else if (rv3028_success) {

--- a/variants/heltec_t096/variant.h
+++ b/variants/heltec_t096/variant.h
@@ -14,7 +14,7 @@
 #define USE_LFXO    // 32.768 kHz crystal oscillator
 #define VARIANT_MCK (64000000ul)
 
-#define WIRE_INTERFACES_COUNT 	(2)
+#define WIRE_INTERFACES_COUNT 	(1) // #define WIRE_INTERFACES_COUNT 	(2) // Enable if using I2C bus 1
 
 ////////////////////////////////////////////////////////////////////////////////
 // Power
@@ -49,14 +49,14 @@
 
 
 // I2C pin definition
-
-#define PIN_WIRE_SDA (0 + 7)
-#define PIN_WIRE_SCL (0 + 8)
+// I2C bus 0 (default)
+#define PIN_WIRE_SDA            (32 + 4) // P1.04 RTC_SDA
+#define PIN_WIRE_SCL            (32 + 2) // P1.02 RTC_SCL
 
 // I2C bus 1
-// Available on header pins, for general use
-#define PIN_WIRE1_SDA (0 + 4)
-#define PIN_WIRE1_SCL (0 + 27)
+// not used by default, but can be used if I2C bus 1 is enabled.
+// #define PIN_WIRE1_SDA           (0 + 4)
+// #define PIN_WIRE1_SCL           (0 + 27)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin LEDs


### PR DESCRIPTION
Fixes to support RTC PCF8563 option with Heltec T096 board.
Only 1 I2C bus enabled to reduce unused resources.