### PR TITLE
Fix wio-e5-mini_repeater build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ monitor_speed = 115200
 lib_deps =
   SPI
   Wire
-  jgromes/RadioLib @ ^7.6.0
+  jgromes/RadioLib @ 7.6.0
   rweather/Crypto @ ^0.4.0
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0


### PR DESCRIPTION
The `wio-e5-mini_repeater` build fails with:
```text
.pio/libdeps/wio-e5-mini_repeater/RadioLib/src/hal/Stm32duino/Stm32wlHal.cpp:15:10: fatal error: SubGhz.h: No such file or directory

   15 | #include <SubGhz.h>
      |          ^~~~~~~~~~
compilation terminated.
*** [.pio/build/wio-e5-mini_repeater/libe5e/RadioLib/hal/Stm32duino/Stm32wlHal.cpp.o] Error 1
========================= [FAILED] Took 75.80 seconds =========================
```

## Cause
`jgromes/RadioLib@^7.6.0` pulls the latest 7.7.x (7.7.1). Since 7.7.0, `Stm32wlHal.cpp` includes `#include <SubGhz.h>` - a header that is likely unavailable in the pinned STM32 core `2.10.1`.

## Fix
Pin to `7.6.0`.

```diff
- jgromes/RadioLib @ ^7.6.0
+ jgromes/RadioLib @ 7.6.0
```

## Verification
The full build **PASSED**.

|                                                  Before                                                   |                                                   After                                                   |
|:---------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------:|
| <img width="600" src="https://github.com/user-attachments/assets/9d8db853-dad9-447a-9895-985ac9db5c3a" /> | <img width="600" src="https://github.com/user-attachments/assets/197c7684-bb9e-4fe4-b47f-78c51799d6a1" /> |
