### PR TITLE
build fixes for LilyGo T-Echo Card

### DIFF
--- a/variants/lilygo_techo_card/TechoCardBoard.h
+++ b/variants/lilygo_techo_card/TechoCardBoard.h
@@ -3,7 +3,7 @@
 #include <MeshCore.h>
 #include <Arduino.h>
 #include <helpers/NRF52Board.h>
-#include <Adafruit_Neopixel.h>
+#include <Adafruit_NeoPixel.h>
 
 // built-ins
 #define VBAT_MV_PER_LSB   (0.73242188F)   // 3.0V ADC range and 12-bit ADC resolution = 3000mV/4096

--- a/variants/lilygo_techo_card/platformio.ini
+++ b/variants/lilygo_techo_card/platformio.ini
@@ -113,6 +113,7 @@ build_flags =
 build_src_filter = ${LilyGo_T-Echo_Card.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-tiny/*.cpp>
+  +<helpers/ui/buzzer.cpp>
 lib_deps =
   ${LilyGo_T-Echo_Card.lib_deps}
   end2endzone/NonBlockingRTTTL@^1.3.0


### PR DESCRIPTION
A couple of build fixes for LilyGo T-Echo Card.

Companion USB was failing due to buzzer.cpp missing from build_src_filter and linux was failing to build due to incorrect capitalisation of ``Adafruit_NeoPixel.h``