### PR TITLE
Build fixes for some RP2040 targets

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -99,7 +99,7 @@ lib_deps =
 extends = arduino_base
 upload_protocol = picotool
 board_build.core = earlephilhower
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#4e22a0d ; framework-arduinopico @ 1.50600.0+sha.6a1d13e9
 build_flags = ${arduino_base.build_flags}
   -D RP2040_PLATFORM
 

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -91,6 +91,7 @@ build_src_filter = ${rak11310.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 lib_deps = ${rak11310.lib_deps}
   densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
 
 ; [env:RAK_11310_companion_radio_ble]
 ; extends = rak11310

--- a/variants/rak11310/target.cpp
+++ b/variants/rak11310/target.cpp
@@ -12,6 +12,12 @@ VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
 SensorManager sensors;
 
+bool radio_init() {
+  rtc_clock.begin(Wire);
+  
+  return radio.std_init(&SPI1);
+}
+
 void radio_set_tx_power(int8_t dbm) {
   radio.setOutputPower(dbm);
 }

--- a/variants/rpi_picow/platformio.ini
+++ b/variants/rpi_picow/platformio.ini
@@ -64,6 +64,7 @@ build_src_filter = ${rpi_picow.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 lib_deps = ${rpi_picow.lib_deps}
   densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
 
 ; [env:PicoW_companion_radio_ble]
 ; extends = rpi_picow

--- a/variants/rpi_picow/platformio.ini
+++ b/variants/rpi_picow/platformio.ini
@@ -1,6 +1,5 @@
 [rpi_picow]
 extends = rp2040_base
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = rpipicow
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m

--- a/variants/waveshare_rp2040_lora/platformio.ini
+++ b/variants/waveshare_rp2040_lora/platformio.ini
@@ -90,6 +90,7 @@ build_src_filter = ${waveshare_rp2040_lora.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 lib_deps = ${waveshare_rp2040_lora.lib_deps}
   densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
 
 ; [env:waveshare_rp2040_lora_companion_radio_ble]
 ; extends = waveshare_rp2040_lora

--- a/variants/xiao_rp2040/platformio.ini
+++ b/variants/xiao_rp2040/platformio.ini
@@ -67,6 +67,7 @@ build_src_filter = ${Xiao_rp2040.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 lib_deps = ${Xiao_rp2040.lib_deps}
   densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
 
 ; [env:Xiao_rp2040_companion_radio_ble]
 ; extends = Xiao_rp2040


### PR DESCRIPTION
This PR fixes a few RP2040 targets that were failing build and pins the platform so that we don't get caught out by upstream changes again and builds become reproducible.

The RP2040 framework-arduinopico [made a change](https://github.com/earlephilhower/arduino-pico/pull/3397) that causes an assert if you compile the BLE library without enabling bluetooth in the framework.  Companion firmware has code in it which causes the platformio dependency checker to pull in BLE and then the build fails.

Adding ``lib_ignore = BLE`` for the USB targets fixes it.