### PR TITLE
room_server: add room.post command for server-originated posts

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -45,9 +45,7 @@ void MyMesh::addPost(ClientInfo *client, const char *postData) {
 void MyMesh::addSystemPost(const char *postData) {
   if (!postData || postData[0] == 0) return;
 
-#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
-  Serial.print("room.post: addSystemPost: "); Serial.println(postData);
-#endif
+  MESH_DEBUG_PRINTLN("room.post: addSystemPost: %s", postData);
 
   storePost(self_id, postData);
 }
@@ -59,23 +57,17 @@ void MyMesh::storePost(const mesh::Identity &author, const char *postData) {
   StrHelper::strncpy(posts[idx].text, postData, MAX_POST_TEXT_LEN);
 
   posts[idx].post_timestamp = getRTCClock()->getCurrentTimeUnique();
-#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
-  Serial.printf("room.post: storePost idx=%d text=%s\n", idx, posts[idx].text);
-  Serial.printf("room.post: timestamp=%u\n", posts[idx].post_timestamp);
-#endif
+  MESH_DEBUG_PRINTLN("room.post: storePost idx=%d text=%s", idx, posts[idx].text);
+  MESH_DEBUG_PRINTLN("room.post: timestamp=%u", posts[idx].post_timestamp);
   next_post_idx = (next_post_idx + 1) % MAX_UNSYNCED_POSTS;
 
   next_push = futureMillis(PUSH_NOTIFY_DELAY_MILLIS);
   _num_posted++; // stats
-#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
-  Serial.printf("room.post: next_post_idx=%d num_posted=%d push scheduled\n", next_post_idx, _num_posted);
-#endif
+  MESH_DEBUG_PRINTLN("room.post: next_post_idx=%d num_posted=%d push scheduled", next_post_idx, _num_posted);
 }
 
 void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
-#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
-  Serial.print("room.post: pushPostToClient text="); Serial.println(post.text);
-#endif
+  MESH_DEBUG_PRINTLN("room.post: pushPostToClient text=%s", post.text);
   int len = 0;
   memcpy(&reply_data[len], &post.post_timestamp, 4);
   len += 4; // this is a PAST timestamp... but should be accepted by client

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -39,18 +39,43 @@ struct ServerStats {
 };
 
 void MyMesh::addPost(ClientInfo *client, const char *postData) {
-  // TODO: suggested postData format: <title>/<descrption>
-  posts[next_post_idx].author = client->id; // add to cyclic queue
-  StrHelper::strncpy(posts[next_post_idx].text, postData, MAX_POST_TEXT_LEN);
+  storePost(client->id, postData);
+}
 
-  posts[next_post_idx].post_timestamp = getRTCClock()->getCurrentTimeUnique();
+void MyMesh::addSystemPost(const char *postData) {
+  if (!postData || postData[0] == 0) return;
+
+#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
+  Serial.print("room.post: addSystemPost: "); Serial.println(postData);
+#endif
+
+  storePost(self_id, postData);
+}
+
+void MyMesh::storePost(const mesh::Identity &author, const char *postData) {
+  int idx = next_post_idx;
+  // TODO: suggested postData format: <title>/<descrption>
+  posts[idx].author = author; // add to cyclic queue
+  StrHelper::strncpy(posts[idx].text, postData, MAX_POST_TEXT_LEN);
+
+  posts[idx].post_timestamp = getRTCClock()->getCurrentTimeUnique();
+#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
+  Serial.printf("room.post: storePost idx=%d text=%s\n", idx, posts[idx].text);
+  Serial.printf("room.post: timestamp=%u\n", posts[idx].post_timestamp);
+#endif
   next_post_idx = (next_post_idx + 1) % MAX_UNSYNCED_POSTS;
 
   next_push = futureMillis(PUSH_NOTIFY_DELAY_MILLIS);
   _num_posted++; // stats
+#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
+  Serial.printf("room.post: next_post_idx=%d num_posted=%d push scheduled\n", next_post_idx, _num_posted);
+#endif
 }
 
 void MyMesh::pushPostToClient(ClientInfo *client, PostInfo &post) {
+#if defined(ENABLE_ROOM_POST_DEBUG) && ENABLE_ROOM_POST_DEBUG == 1
+  Serial.print("room.post: pushPostToClient text="); Serial.println(post.text);
+#endif
   int len = 0;
   memcpy(&reply_data[len], &post.post_timestamp, 4);
   len += 4; // this is a PAST timestamp... but should be accepted by client
@@ -948,6 +973,15 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
       Serial.printf("\n");
     }
     reply[0] = 0;
+  } else if (strncmp(command, "room.post", 9) == 0) {
+    char* msg = command + 9;
+    while (*msg == ' ') msg++;
+    if (*msg == 0) {
+      snprintf(reply, MAX_POST_TEXT_LEN, "ERR empty message");
+    } else {
+      addSystemPost(msg);
+      snprintf(reply, MAX_POST_TEXT_LEN, "OK");
+    }
   } else{
     _cli.handleCommand(sender_timestamp, command, reply);  // common CLI commands
   }

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -119,6 +119,7 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   int  matching_peer_indexes[MAX_CLIENTS];
 
   void addPost(ClientInfo* client, const char* postData);
+  void storePost(const mesh::Identity& author, const char* postData);
   void pushPostToClient(ClientInfo* client, PostInfo& post);
   uint8_t getUnsyncedCount(ClientInfo* client);
   bool processAck(const uint8_t *data);
@@ -176,6 +177,7 @@ public:
   MyMesh(mesh::MainBoard& board, mesh::Radio& radio, mesh::MillisecondClock& ms, mesh::RNG& rng, mesh::RTCClock& rtc, mesh::MeshTables& tables);
 
   void begin(FILESYSTEM* fs);
+  void addSystemPost(const char* postData);
 
   const char* getFirmwareVer() override { return FIRMWARE_VERSION; }
   const char* getBuildDate() override { return FIRMWARE_BUILD_DATE; }


### PR DESCRIPTION
Based on #2686.

## Summary

This PR adds support for room-server-originated posts to `simple_room_server`.

It introduces:

```cpp
MyMesh::addSystemPost(const char* postData)
```

and exposes it through the serial console command:

```text
room.post <message>
```

## Motivation

The room server currently stores posts received from clients, but it has no simple API for creating a post using its own identity.

This change provides a reusable path for local room-server code to publish messages without duplicating the existing post storage and notification logic.

## Implementation

This PR:

- adds `MyMesh::addSystemPost(const char* postData)`
- stores system posts using the room server's own identity
- refactors the existing post logic into a shared `storePost()` method
- preserves the existing timestamp, cyclic queue, push scheduling, and synchronization behavior
- adds the `room.post <message>` serial console command
- rejects empty messages with `ERR empty message`
- introduces no protocol changes or new dependencies

## Usage

From the room server's serial console:

```text
room.post Equipment box opened
```

Successful commands return:

```text
OK
```

## Testing

Built successfully with:

```text
pio run -e LilyGo_TLora_V2_1_1_6_room_server
```

## Scope

This PR only adds the system-post helper and the `room.post` command. It does not include GPIO handling, sensor examples, or board-specific configuration.
