### PR TITLE
HeltecV4: Fix battery ADC reading accuracy

### DIFF
--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -62,18 +62,18 @@ void HeltecV4Board::begin() {
   }
 
   uint16_t HeltecV4Board::getBattMilliVolts()  {
-    analogReadResolution(10);
+    analogReadResolution(12);
     digitalWrite(PIN_ADC_CTRL, HIGH);
     delay(10);
-    uint32_t raw = 0;
+    uint32_t raw_mv = 0;
     for (int i = 0; i < 8; i++) {
-      raw += analogRead(PIN_VBAT_READ);
+      raw_mv += analogReadMilliVolts(PIN_VBAT_READ);
     }
-    raw = raw / 8;
+    raw_mv /= 8;
 
     digitalWrite(PIN_ADC_CTRL, LOW);
 
-    return (adc_mult * (3.3 / 1024.0) * raw) * 1000;
+    return adc_mult * raw_mv;
   }
 
   const char* HeltecV4Board::getManufacturerName() const {

--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -63,6 +63,7 @@ void HeltecV4Board::begin() {
 
   uint16_t HeltecV4Board::getBattMilliVolts()  {
     analogReadResolution(12);
+    analogSetPinAttenuation(PIN_VBAT_READ, ADC_2_5db);  // divider puts pin at 0.61-0.86V so this attenuation should cover it with some room to spare
     digitalWrite(PIN_ADC_CTRL, HIGH);
     delay(10);
     uint32_t raw_mv = 0;

--- a/variants/heltec_v4/HeltecV4Board.h
+++ b/variants/heltec_v4/HeltecV4Board.h
@@ -7,7 +7,7 @@
 #include "LoRaFEMControl.h"
 
 #ifndef ADC_MULTIPLIER
-  #define ADC_MULTIPLIER 5.42
+  #define ADC_MULTIPLIER 4.9  // (R1+R2)/R2 = (390k+100k)/100k
 #endif
 
 class HeltecV4Board : public ESP32Board {


### PR DESCRIPTION
Correct `ADC_MULTIPLIER` from `5.42` to `4.9` to match the `R27/R28` resistor divider on the schematic `(390kΩ + 100kΩ) / 100kΩ = 4.9`.

Also switch from `analogRead()` with manual `3.3V/1024` conversion to `analogReadMilliVolts()` at 12-bit resolution, which uses the ESP32's built-in ADC calibration for improved accuracy.

Schematic reference: [https://resource.heltec.cn/download/WiFi_LoRa_32_V4](https://resource.heltec.cn/download/WiFi_LoRa_32_V4)