### PR TITLE
Fix: Heltec epaper nodes display draw colour

### DIFF
--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -8,7 +8,7 @@ class DisplayDriver {
 protected:
   DisplayDriver(int w, int h) { _w = w; _h = h; }
 public:
-  enum Color { DARK=0, LIGHT, RED, GREEN, BLUE, YELLOW, ORANGE }; // on b/w screen, colors will be !=0 synonym of light
+  enum Color { DARK=0, LIGHT, RED, GREEN, BLUE, YELLOW, ORANGE }; // on b/w screen, colors will be !=0 synonym of light (inverted on epaper)
 
   int width() const { return _w; }
   int height() const { return _h; }

--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -51,6 +51,7 @@ bool E213Display::begin() {
 
   _init = true;
   _isOn = true;
+  _color = WHITE;
 
   clear();
   display->fastmodeOn(); // Enable fast mode for quicker (partial) updates
@@ -123,23 +124,25 @@ void E213Display::startFrame(Color bkg) {
 void E213Display::setTextSize(int sz) {
   display_crc.update<int>(sz);
   // The library handles text size internally
-    display->setTextSize(sz);
+  display->setTextSize(sz);
 }
 
 void E213Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  // implemented in individual display methods
+  // keep in mind this is inverted on e-ink
+  _color = c == 0 ? WHITE : BLACK; // for rectangles and bitmaps
+  display->setTextColor(UINT16_MAX * _color); // for text
 }
 
 void E213Display::setCursor(int x, int y) {
   display_crc.update<int>(x);
   display_crc.update<int>(y);
-    display->setCursor(x, y);
+  display->setCursor(x, y);
 }
 
 void E213Display::print(const char *str) {
   display_crc.update<char>(str, strlen(str));
-    display->print(str);
+  display->print(str);
 }
 
 void E213Display::fillRect(int x, int y, int w, int h) {
@@ -147,7 +150,7 @@ void E213Display::fillRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-    display->fillRect(x, y, w, h, BLACK);
+  display->fillRect(x, y, w, h, _color);
 }
 
 void E213Display::drawRect(int x, int y, int w, int h) {
@@ -155,7 +158,7 @@ void E213Display::drawRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-    display->drawRect(x, y, w, h, BLACK);
+  display->drawRect(x, y, w, h, _color);
 }
 
 void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
@@ -179,7 +182,7 @@ void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 
       // If the bit is set, draw the pixel
       if (bitSet) {
-          display->drawPixel(x + bx, y + by, BLACK);
+          display->drawPixel(x + bx, y + by, _color);
       }
     }
   }

--- a/src/helpers/ui/E213Display.h
+++ b/src/helpers/ui/E213Display.h
@@ -13,6 +13,7 @@ class E213Display : public DisplayDriver {
   BaseDisplay* display=NULL;
   bool _init = false;
   bool _isOn = false;
+  uint8_t _color;
   RefCountedDigitalPin* _periph_power;
   CRC32 display_crc;
   uint32_t last_display_crc_value = 0;

--- a/src/helpers/ui/E290Display.cpp
+++ b/src/helpers/ui/E290Display.cpp
@@ -13,6 +13,7 @@ bool E290Display::begin() {
 
   _init = true;
   _isOn = true;
+  _color = WHITE;
 
   clear();
   display.fastmodeOn(); // Enable fast mode for quicker (partial) updates
@@ -81,7 +82,9 @@ void E290Display::setTextSize(int sz) {
 
 void E290Display::setColor(Color c) {
   display_crc.update<Color>(c);
-  // implemented in individual display methods
+  // keep in mind this is inverted on e-ink
+  _color = c == 0 ? WHITE : BLACK; // for rectangles and bitmaps
+  display.setTextColor(UINT16_MAX * _color); // for text
 }
 
 void E290Display::setCursor(int x, int y) {
@@ -100,7 +103,7 @@ void E290Display::fillRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-  display.fillRect(x, y, w, h, BLACK);
+  display.fillRect(x, y, w, h, _color);
 }
 
 void E290Display::drawRect(int x, int y, int w, int h) {
@@ -108,7 +111,7 @@ void E290Display::drawRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-  display.drawRect(x, y, w, h, BLACK);
+  display.drawRect(x, y, w, h, _color);
 }
 
 void E290Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
@@ -132,7 +135,7 @@ void E290Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 
       // If the bit is set, draw the pixel
       if (bitSet) {
-        display.drawPixel(x + bx, y + by, BLACK);
+        display.drawPixel(x + bx, y + by, _color);
       }
     }
   }

--- a/src/helpers/ui/E290Display.h
+++ b/src/helpers/ui/E290Display.h
@@ -13,6 +13,7 @@ class E290Display : public DisplayDriver {
   EInkDisplay_VisionMasterE290 display;
   bool _init = false;
   bool _isOn = false;
+  uint8_t _color;
   RefCountedDigitalPin* _periph_power;
   CRC32 display_crc;
   uint32_t last_display_crc_value = 0;


### PR DESCRIPTION
# Issue: 
The drawing functions in /src/helpers/ui/E213Display.cpp and /src/helpers/ui/E290Display.cpp did not implement any sort of colour changing on rectangles, text and bitmaps. This results in the following black rectangle appearing:

https://github.com/user-attachments/assets/46b02eaf-1d76-4f61-9735-265558ced54e

# How to replicate:
Simply install the official meshcore firmware on any of the Heltec e-paper boards. The black bar will appear on the recent contacts page when cycling through the pages in forward order (not in reverse order but that's a different issue, it shouldn't try to do a popup at all there imo) and when sending an advert via the companion itself (not when triggering an advert through the app).


# Fix:
The display.setColor() function was implemented properly. A variable for the colour was added like in the implementation of all the other displays. The fix is fully functional. Changing text and bitmap colour is also supported now although it is not used so far. The comment about text colours on monochrome screens was updated to note that the colours on epaper screens are inverted compared to other monochrome displays.

https://github.com/user-attachments/assets/7a9b50cc-391f-47e6-9ae5-c6f6af43b516


### This PR is a reworked version of [PR #2554](https://github.com/meshcore-dev/MeshCore/pull/2554)
I cleaned up the code a little bit more and am not trying to PR to main branch anymore