### PR TITLE
feat: rak12047 sgp40 voc sensor support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -152,6 +152,8 @@ lib_deps =
   stevemarple/MicroNMEA @ ^2.0.6
   adafruit/Adafruit BME680 Library @ ^2.0.4
   adafruit/Adafruit BMP085 Library @ ^1.2.4
+  sensirion/Sensirion I2C SGP40 @ ^0.1.0
+  sensirion/Sensirion Gas Index Algorithm @ ^3.2.3
 
 ; ----------------- TESTING ---------------------
 

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -160,6 +160,19 @@ static Adafruit_VL53L0X VL53L0X;
 static RAK12035_SoilMoisture RAK12035;
 #endif
 
+#if ENV_INCLUDE_RAK12047
+#ifndef TELEM_RAK12047_ADDRESS
+#define TELEM_RAK12047_ADDRESS  0x59
+#endif
+#include <SensirionI2CSgp40.h>
+#include <SensirionGasIndexAlgorithm.h>
+static SensirionI2CSgp40       sgp40;
+static GasIndexAlgorithmParams sgp40_voc_params;
+static int32_t                 sgp40_voc_index = 0;
+static bool                    sgp40_active    = false;
+static uint32_t                sgp40_last_ms   = 0;
+#endif
+
 #if ENV_INCLUDE_GPS && defined(RAK_BOARD) && !defined(RAK_WISMESH_TAG)
 #define RAK_WISBLOCK_GPS
 #endif
@@ -475,6 +488,21 @@ static void query_rak12035(uint8_t ch, uint8_t sub_ch, CayenneLPP& lpp) {
 }
 #endif
 
+#if ENV_INCLUDE_RAK12047
+static uint8_t init_rak12047(TwoWire* wire, uint8_t addr) {
+  sgp40.begin(*wire);
+  uint16_t serial[3];
+  if (sgp40.getSerialNumber(serial, 3) != 0) return 0;
+  GasIndexAlgorithm_init(&sgp40_voc_params, GasIndexAlgorithm_ALGORITHM_TYPE_VOC);
+  sgp40_active = true;
+  return 1;
+}
+static void query_rak12047(uint8_t ch, uint8_t, CayenneLPP& lpp) {
+  if (sgp40_voc_index > 0)
+    lpp.addGenericSensor(ch, (uint32_t)sgp40_voc_index);
+}
+#endif
+
 #if ENV_INCLUDE_BME680_BSEC
 static void bsec_load_state() {
   using namespace Adafruit_LittleFS_Namespace;
@@ -599,6 +627,9 @@ static const SensorDef SENSOR_TABLE[] = {
 #endif
 #if ENV_INCLUDE_RAK12035
   { TELEM_RAK12035_ADDRESS,"RAK12035",     init_rak12035, query_rak12035 },
+#endif
+#if ENV_INCLUDE_RAK12047
+  { TELEM_RAK12047_ADDRESS,"RAK12047/SGP40", init_rak12047, query_rak12047 },
 #endif
   { 0, nullptr, nullptr, nullptr }  // sentinel — keeps the array non-empty
 };
@@ -885,7 +916,7 @@ void EnvironmentSensorManager::stop_gps() {
 }
 #endif // ENV_INCLUDE_GPS
 
-#if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC)
+#if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC) || defined(ENV_INCLUDE_RAK12047)
 void EnvironmentSensorManager::loop() {
 
   #if ENV_INCLUDE_GPS
@@ -939,5 +970,16 @@ void EnvironmentSensorManager::loop() {
     }
   }
   #endif  // ENV_INCLUDE_BME680_BSEC
+
+  #if ENV_INCLUDE_RAK12047
+  if (sgp40_active && (millis() - sgp40_last_ms >= 1000)) {
+    uint16_t sraw;
+    if (sgp40.measureRawSignal(0x8000, 0x6666, sraw) == 0) {
+      GasIndexAlgorithm_process(&sgp40_voc_params, (int32_t)sraw, &sgp40_voc_index);
+    }
+    sgp40_last_ms = millis();
+  }
+  #endif  // ENV_INCLUDE_RAK12047
+
 }
 #endif // ENV_INCLUDE_GPS || ENV_INCLUDE_BME680_BSEC

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -43,7 +43,7 @@ public:
   #endif
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
-  #if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC)
+  #if ENV_INCLUDE_GPS || defined(ENV_INCLUDE_BME680_BSEC) || defined(ENV_INCLUDE_RAK12047)
   void loop() override;
   #endif
   int getNumSettings() const override;

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -25,6 +25,7 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_RAK12035=1
   -UENV_INCLUDE_BME680
   -D ENV_INCLUDE_BME680_BSEC=1
+  -D ENV_INCLUDE_RAK12047=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak4631>
   +<helpers/sensors>


### PR DESCRIPTION
This short feature adds the RAK12407 SGP40 sensor support for RAK nodes.

Follows the current sensor implementation.

Does a serial number check to bootstrap and the sensiron lib for VOC calculations.

Query reports as addGenericSensor.

I've had this one running for a few months now, so yanked the code out to put in a PR in case others want to be able to use this.

Tested on RAK19001, compiled against several other board types and compile didn't break.