### PR TITLE
fix(nrf52): fix poweroff CLI command for T114 and RAK4631

### DIFF
--- a/variants/heltec_t114/T114Board.h
+++ b/variants/heltec_t114/T114Board.h
@@ -50,7 +50,10 @@ public:
 #ifdef LED_PIN
     digitalWrite(LED_PIN, HIGH);
 #endif
-
+#ifdef NRF52_POWER_MANAGEMENT
+    initiateShutdown(SHUTDOWN_REASON_USER);
+#else
     NRF52Board::powerOff();
+#endif
   }
 };

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -28,6 +28,9 @@ const PowerMgtConfig power_config = {
 void RAK4631Board::initiateShutdown(uint8_t reason) {
   // Disable LoRa module power before shutdown
   digitalWrite(SX126X_POWER_EN, LOW);
+  // RAK4631 has no buttons; clear DIO1 SENSE (set by RadioLib) so the
+  // floating pin doesn't trigger an immediate wakeup from SYSTEMOFF.
+  nrf_gpio_cfg_default(P_LORA_DIO_1);
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {

--- a/variants/rak4631/RAK4631Board.h
+++ b/variants/rak4631/RAK4631Board.h
@@ -35,4 +35,10 @@ public:
   const char* getManufacturerName() const override {
     return "RAK 4631";
   }
+
+#ifdef NRF52_POWER_MANAGEMENT
+  void powerOff() override {
+    initiateShutdown(SHUTDOWN_REASON_USER);
+  }
+#endif
 };


### PR DESCRIPTION
## Problem

T114 and RAK4631 repeater did not shutdown by command.

### T114
`T114Board::powerOff()` called `sd_power_system_off()` directly with no error handling. If the SoftDevice returns an error, execution silently returned and the device kept running.

Additionally, the SX1262 was left powered (`SX126X_POWER_EN` HIGH), leaving DIO1 SENSE active and risking an immediate GPIO wakeup from SYSTEMOFF.

### RAK4631
`RAK4631Board` had no `powerOff()` override at all. The CLI `poweroff` command called the base class no-op (`MainBoard::powerOff()`) and the device kept running.

Additionally, RAK4631 has no user buttons. After SX1262 is powered down, DIO1 (`P_LORA_DIO_1` = pin 47) is the only GPIO with SENSE configured (set by RadioLib's `attachInterrupt()`). The floating pin triggers an immediate GPIO wakeup from SYSTEMOFF, so the device restarts instead of staying off.

## Fix

### T114
Delegate `powerOff()` to `initiateShutdown(SHUTDOWN_REASON_USER)`, following the pattern used by R1NeoBoard and others with `NRF52_POWER_MANAGEMENT`. This powers down the SX1262 before SYSTEMOFF and goes through `enterSystemOff()` with proper error handling and fallback to `NRF_POWER->SYSTEMOFF`.

### RAK4631
- Add `powerOff()` override delegating to `initiateShutdown(SHUTDOWN_REASON_USER)`
- In `initiateShutdown()`, call `nrf_gpio_cfg_default(P_LORA_DIO_1)` immediately after powering down the SX1262 to clear the SENSE configuration and prevent immediate GPIO wakeup from SYSTEMOFF

## Test

- **T114** (nRF52840 + SX1262): `poweroff` CLI stopped ✅
- **RAK4631** (nRF52840 + SX1262): `poweroff` CLI stopped  ✅