### PR TITLE
Change default power saving setting to 'off'

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -406,7 +406,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `on`: enable power saving
 - `off`: disable power saving
 
-**Default:** `on`
+**Default:** `off`
 
 **Note:** When enabled, device enters sleep mode between radio transmissions
 


### PR DESCRIPTION
The default powersaving value is off.
It is only on when entering "powersaving on".

Minimal change but hope to clear possible confussion.