### PR TITLE
Added time keeping for NRF52 across resets

### DIFF
--- a/boards/nrf52840_s140_v6.ld
+++ b/boards/nrf52840_s140_v6.ld
@@ -7,6 +7,9 @@ MEMORY
 {
   FLASH (rx)     : ORIGIN = 0x26000, LENGTH = 0xED000 - 0x26000
 
+  /* To keep data in RAM across resets */
+  PERSISTENT_RAM (rwx) : ORIGIN = 0x20006000, LENGTH = 8
+
   /* SRAM required by Softdevice depend on
    * - Attribute Table Size (Number of Services and Characteristics)
    * - Vendor UUID count
@@ -14,11 +17,19 @@ MEMORY
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
    */ 
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+  RAM (rwx) :  ORIGIN = 0x20006000 + 8, LENGTH = 0x20040000 - 0x20006000 - 8
 }
 
 SECTIONS
 {
+  . = ALIGN(4);
+  .persistent (NOLOAD) :
+  {
+    KEEP(*(.persistent_magic))
+    KEEP(*(.persistent_data))
+    . = ALIGN(4);
+  } > PERSISTENT_RAM
+
   . = ALIGN(4);
   .svc_data :
   {
@@ -33,6 +44,6 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
-} INSERT AFTER .data;
+}
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v6_extrafs.ld
+++ b/boards/nrf52840_s140_v6_extrafs.ld
@@ -7,6 +7,9 @@ MEMORY
 {
   FLASH (rx)     : ORIGIN = 0x26000, LENGTH = 0xD4000 - 0x26000
 
+  /* To keep data in RAM across resets */
+  PERSISTENT_RAM (rwx) : ORIGIN = 0x20006000, LENGTH = 8
+
   /* SRAM required by Softdevice depend on
    * - Attribute Table Size (Number of Services and Characteristics)
    * - Vendor UUID count
@@ -14,11 +17,19 @@ MEMORY
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
    */ 
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+  RAM (rwx) :  ORIGIN = 0x20006000 + 8, LENGTH = 0x20040000 - 0x20006000 - 8
 }
 
 SECTIONS
 {
+  . = ALIGN(4);
+  .persistent (NOLOAD) :
+  {
+    KEEP(*(.persistent_magic))
+    KEEP(*(.persistent_data))
+    . = ALIGN(4);
+  } > PERSISTENT_RAM
+
   . = ALIGN(4);
   .svc_data :
   {
@@ -33,6 +44,6 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
-} INSERT AFTER .data;
+}
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7.ld
+++ b/boards/nrf52840_s140_v7.ld
@@ -7,6 +7,9 @@ MEMORY
 {
   FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0xED000 - 0x27000
 
+  /* To keep data in RAM across resets */
+  PERSISTENT_RAM (rwx) : ORIGIN = 0x20006000, LENGTH = 8
+
   /* SRAM required by Softdevice depend on
    * - Attribute Table Size (Number of Services and Characteristics)
    * - Vendor UUID count
@@ -14,11 +17,19 @@ MEMORY
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
    */ 
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+  RAM (rwx) :  ORIGIN = 0x20006000 + 8, LENGTH = 0x20040000 - 0x20006000 - 8
 }
 
 SECTIONS
 {
+  . = ALIGN(4);
+  .persistent (NOLOAD) :
+  {
+    KEEP(*(.persistent_magic))
+    KEEP(*(.persistent_data))
+    . = ALIGN(4);
+  } > PERSISTENT_RAM
+
   . = ALIGN(4);
   .svc_data :
   {
@@ -33,6 +44,6 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
-} INSERT AFTER .data;
+}
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7_extrafs.ld
+++ b/boards/nrf52840_s140_v7_extrafs.ld
@@ -7,6 +7,9 @@ MEMORY
 {
   FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0xD4000 - 0x27000
 
+  /* To keep data in RAM across resets */
+  PERSISTENT_RAM (rwx) : ORIGIN = 0x20006000, LENGTH = 8
+
   /* SRAM required by Softdevice depend on
    * - Attribute Table Size (Number of Services and Characteristics)
    * - Vendor UUID count

--- a/boards/nrf52840_s140_v7_extrafs.ld
+++ b/boards/nrf52840_s140_v7_extrafs.ld
@@ -14,11 +14,19 @@ MEMORY
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
    */ 
-  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+  RAM (rwx) :  ORIGIN = 0x20006000 + 8, LENGTH = 0x20040000 - 0x20006000 - 8
 }
 
 SECTIONS
 {
+  . = ALIGN(4);
+  .persistent (NOLOAD) :
+  {
+    KEEP(*(.persistent_magic))
+    KEEP(*(.persistent_data))
+    . = ALIGN(4);
+  } > PERSISTENT_RAM
+
   . = ALIGN(4);
   .svc_data :
   {
@@ -33,6 +41,6 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
-} INSERT AFTER .data;
+}
 
 INCLUDE "nrf52_common.ld"

--- a/src/helpers/ArduinoHelpers.cpp
+++ b/src/helpers/ArduinoHelpers.cpp
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+extern "C" {
+    __attribute__((section(".persistent_magic"))) uint32_t persistent_magic;
+    __attribute__((section(".persistent_data"))) uint32_t persistent_time;
+}

--- a/src/helpers/ArduinoHelpers.h
+++ b/src/helpers/ArduinoHelpers.h
@@ -3,19 +3,57 @@
 #include <Mesh.h>
 #include <Arduino.h>
 
+#ifdef NRF52_PLATFORM
+#define CLOCK_MAGIC_NUM        0xAA55CC33
+#define RTC_TIME_MIN           1772323200  // 1 Mar 2026
+
+extern uint32_t persistent_magic;
+extern uint32_t persistent_time;
+#endif
+
 class VolatileRTCClock : public mesh::RTCClock {
   uint32_t base_time;
   uint64_t accumulator;
   unsigned long prev_millis;
+
 public:
-  VolatileRTCClock() { base_time = 1715770351; accumulator = 0; prev_millis = millis(); }   // 15 May 2024, 8:50pm
+  VolatileRTCClock() {
+#ifdef NRF52_PLATFORM
+    if (persistent_magic == CLOCK_MAGIC_NUM && persistent_time >= RTC_TIME_MIN) {
+      base_time = persistent_time;
+    } else {
+      base_time = RTC_TIME_MIN;
+    }
+#else
+    base_time = 1715770351;
+#endif
+
+    accumulator = 0;
+    prev_millis = millis();
+  }
+
   uint32_t getCurrentTime() override { return base_time + accumulator/1000; }
-  void setCurrentTime(uint32_t time) override { base_time = time; accumulator = 0; prev_millis = millis(); }
+
+  void setCurrentTime(uint32_t time) override {
+    base_time = time;
+    accumulator = 0;
+    prev_millis = millis();
+
+#ifdef NRF52_PLATFORM
+    persistent_magic = CLOCK_MAGIC_NUM;
+    persistent_time = time;
+#endif
+  }
 
   void tick() override {
     unsigned long now = millis();
     accumulator += (now - prev_millis);
     prev_millis = now;
+
+#ifdef NRF52_PLATFORM
+    persistent_magic = CLOCK_MAGIC_NUM;
+    persistent_time = getCurrentTime();
+#endif
   }
 };
 

--- a/variants/gat562_30s_mesh_kit/platformio.ini
+++ b/variants/gat562_30s_mesh_kit/platformio.ini
@@ -2,6 +2,7 @@
 extends = nrf52_base
 board = rak4631
 board_check = true
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/gat562_30s_mesh_kit

--- a/variants/gat562_mesh_tracker_pro/platformio.ini
+++ b/variants/gat562_mesh_tracker_pro/platformio.ini
@@ -2,6 +2,7 @@
 extends = nrf52_base
 board = rak4631
 board_check = true
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/gat562_mesh_tracker_pro

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -1,6 +1,7 @@
 [Promicro]
 extends = nrf52_base
 board = promicro_nrf52840
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   -I variants/promicro
   -D PROMICRO

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -2,6 +2,7 @@
 extends = nrf52_base
 board = rak3401
 board_check = true
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -2,6 +2,7 @@
 extends = nrf52_base
 board = rak4631
 board_check = true
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 extra_scripts = ${nrf52_base.extra_scripts}
   post:variants/rak4631/fix_bsec_lib.py
 build_flags = ${nrf52_base.build_flags}

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -2,6 +2,7 @@
 extends = nrf52_base
 board = rak4631
 board_check = true
+board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak_wismesh_tag


### PR DESCRIPTION
Hi all,
This is to keep time for NRF52 especially NRF52 repeaters across reboot and reset.
So we can still receive adverts after reset due to reboot or software faults.
I "cut" 8 bytes from RAM to make persistent RAM to store 2 uint32_t for time keeping.

This will have same behaviour as this PR for ESP32: https://github.com/meshcore-dev/MeshCore/pull/1896

Test cases:
1. Sync time
2. Check time
3. Reboot by CLI
4. Login back to see if time is kept.

The default time is 1 Mar 2026 as same as https://github.com/meshcore-dev/MeshCore/pull/1896.

I have tested repeaters and BLE companions fine for RAK4631, Heltec T114, Heltec T096 and Xiao NRF52.
I added boards/nrf52840_s140_v6.ld for some of my comon built NRF52 boards too.
Please help to do more tests with your NRF52 boards.