### PR TITLE
Sensor improvement: try BME280 addresses

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -563,6 +563,9 @@ static const SensorDef SENSOR_TABLE[] = {
 #endif
 #if ENV_INCLUDE_BME280
   { TELEM_BME280_ADDRESS,  "BME280",       init_bme280,   query_bme280   },
+#if TELEM_BME280_ADDRESS != 0x77
+  { 0x77,                  "BME280@77",    init_bme280,   query_bme280   },
+#endif
 #endif
 #if ENV_INCLUDE_BMP280
   { TELEM_BMP280_ADDRESS,  "BMP280",       init_bmp280,   query_bmp280   },


### PR DESCRIPTION
The meshcore-default 0x76 address is actually not the default on the chip. Try both addresses.

Replaces #2607, which did it in the v1.15 architecture. It's much easier in v1.16!