### PR TITLE
Add Companion Selective Repeat Ability (CSRA)

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -520,17 +520,24 @@ bool MyMesh::allowPacketForward(const mesh::Packet* packet) {
 bool MyMesh::shouldSelectivelyRelay(const mesh::Packet* packet) {
   uint8_t pt = packet->getPayloadType();
 
-  // Chat-type flood packets carry src_hash at payload[1].
+  // Chat-type flood layout: payload[0]=dest_hash, payload[1]=src_hash.
+  // Match a favourite at either endpoint so both directions of its conversation relay:
+  // outbound floods it sends (src), and floods headed back to it (dest). When the
+  // favourite is shielded behind this relayer, its peer has no path home yet, so the
+  // returns come back as floods rather than direct routes. Without the dest match the
+  // return leg is dropped and the message is never ACKed.
   if (pt == PAYLOAD_TYPE_TXT_MSG || pt == PAYLOAD_TYPE_REQ ||
       pt == PAYLOAD_TYPE_RESPONSE || pt == PAYLOAD_TYPE_PATH) {
     if (packet->payload_len < 2) return false;
+    uint8_t dst_hash = packet->payload[0];
     uint8_t src_hash = packet->payload[1];
     int n = getNumContacts();
     for (int i = 0; i < n; i++) {
       ContactInfo ci;
       if (!getContactByIdx(i, ci)) continue;
-      // 1-byte hash collisions (~favourite_count/256) are intrinsic to the on-wire src_hash.
-      if (ci.id.isHashMatch(&src_hash, 1) && (ci.flags & FLAG_FAVOURITE)) return true;
+      // 1-byte hash collisions (~favourite_count/256) are intrinsic to the on-wire hash.
+      if ((ci.id.isHashMatch(&src_hash, 1) || ci.id.isHashMatch(&dst_hash, 1))
+           && (ci.flags & FLAG_FAVOURITE)) return true;
     }
     return false;
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -62,6 +62,14 @@
 #define CMD_SET_DEFAULT_FLOOD_SCOPE   63
 #define CMD_GET_DEFAULT_FLOOD_SCOPE   64
 #define CMD_SEND_RAW_PACKET           65
+#define CMD_SET_CLIENT_REPEAT_MODE    66  // non-radio-params variant; SELECTIVE bypasses isValidClientRepeatFreq
+
+#define CLIENT_REPEAT_OFF        0
+#define CLIENT_REPEAT_ALL        1
+#define CLIENT_REPEAT_SELECTIVE  2
+
+// Existing ContactInfo.flags bit; doubles as the SELECTIVE allowlist gate.
+#define FLAG_FAVOURITE           0x01
 
 // Stats sub-types for CMD_GET_STATS
 #define STATS_TYPE_CORE               0
@@ -480,7 +488,71 @@ bool MyMesh::filterRecvFloodPacket(mesh::Packet* packet) {
 }
 
 bool MyMesh::allowPacketForward(const mesh::Packet* packet) {
-  return _prefs.client_repeat != 0;
+  switch (_prefs.client_repeat) {
+    case CLIENT_REPEAT_OFF:
+      return false;
+    case CLIENT_REPEAT_ALL:
+      return true;
+    case CLIENT_REPEAT_SELECTIVE:
+      // A DIRECT-routed packet only reaches allowPacketForward() after the core
+      // (Mesh::routeRecvPacket) has confirmed this node is the recorded next hop on its
+      // path: ACK / PATH-return / response packets travelling back along a path this node was
+      // inserted into while flood-relaying the outbound. Forward them unconditionally --
+      // filtering by source here would black-hole the route, since the return's source is
+      // the far contact rather than the allowlisted node.
+      if (packet->isRouteDirect()) return true;
+
+      // Re-flood (full-hop) when an outbound flood matches the allowlist. Returning true
+      // lets Mesh::routeRecvPacket() append this node's hash to the path and retransmit,
+      // which propagates the packet to its destination and places this node on the path so
+      // the destination's reverse-routed ACK comes back through it. Selectivity (the
+      // allowlist gate below) is what keeps this node from becoming a next-hop for
+      // unrelated mesh traffic.
+      if (shouldSelectivelyRelay(packet)) {
+        _selective_relays++;
+        return true;
+      }
+      return false;
+  }
+  return false;
+}
+
+bool MyMesh::shouldSelectivelyRelay(const mesh::Packet* packet) {
+  uint8_t pt = packet->getPayloadType();
+
+  // Chat-type flood packets carry src_hash at payload[1].
+  if (pt == PAYLOAD_TYPE_TXT_MSG || pt == PAYLOAD_TYPE_REQ ||
+      pt == PAYLOAD_TYPE_RESPONSE || pt == PAYLOAD_TYPE_PATH) {
+    if (packet->payload_len < 2) return false;
+    uint8_t src_hash = packet->payload[1];
+    int n = getNumContacts();
+    for (int i = 0; i < n; i++) {
+      ContactInfo ci;
+      if (!getContactByIdx(i, ci)) continue;
+      // 1-byte hash collisions (~favourite_count/256) are intrinsic to the on-wire src_hash.
+      if (ci.id.isHashMatch(&src_hash, 1) && (ci.flags & FLAG_FAVOURITE)) return true;
+    }
+    return false;
+  }
+
+#ifdef MAX_GROUP_CHANNELS
+  // Group packets carry the channel_hash at payload[0] (matches the core's group dedup key).
+  if (pt == PAYLOAD_TYPE_GRP_TXT || pt == PAYLOAD_TYPE_GRP_DATA) {
+    if (packet->payload_len < 1) return false;
+    uint8_t ch_hash = packet->payload[0];
+    for (int i = 0; i < MAX_GROUP_CHANNELS; i++) {
+      ChannelDetails cd;
+      if (!getChannel(i, cd)) continue;
+      // After remove_channel, the slot's name is empty but hash is sha256(zeros),
+      // which would otherwise produce a 1-in-256 false positive.
+      if (cd.name[0] == '\0') continue;
+      if (cd.channel.hash[0] == ch_hash) return true;
+    }
+    return false;
+  }
+#endif
+
+  return false;
 }
 
 void MyMesh::sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis) {
@@ -863,6 +935,8 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   next_ack_idx = 0;
   sign_data = NULL;
   dirty_contacts_expiry = 0;
+  _selective_relays = 0;
+  _selective_drops = 0;
   memset(advert_paths, 0, sizeof(advert_paths));
   memset(send_scope.key, 0, sizeof(send_scope.key));
   send_unscoped = false;
@@ -1889,6 +1963,9 @@ void MyMesh::handleCmdFrame(size_t len) {
       memcpy(&out_frame[i], &n_recv_flood, 4); i += 4;
       memcpy(&out_frame[i], &n_recv_direct, 4); i += 4;
       memcpy(&out_frame[i], &n_recv_errors, 4); i += 4;
+      // Extra 8 bytes; parsers that don't know about these stop at recv_errors.
+      memcpy(&out_frame[i], &_selective_relays, 4); i += 4;
+      memcpy(&out_frame[i], &_selective_drops, 4); i += 4;
       _serial->writeFrame(out_frame, i);
     } else {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG); // invalid stats sub-type
@@ -1985,6 +2062,18 @@ void MyMesh::handleCmdFrame(size_t len) {
       }
     } else {
       writeErrFrame(ERR_CODE_TABLE_FULL);
+    }
+  } else if (cmd_frame[0] == CMD_SET_CLIENT_REPEAT_MODE && len >= 2) {
+    uint8_t mode = cmd_frame[1];
+    if (mode > CLIENT_REPEAT_SELECTIVE) {
+      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
+    } else if (mode == CLIENT_REPEAT_ALL && !isValidClientRepeatFreq((uint32_t)(_prefs.freq * 1000))) {
+      // ALL mode still requires a designated repeater freq; SELECTIVE bypasses the gate
+      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
+    } else {
+      _prefs.client_repeat = mode;
+      savePrefs();
+      writeOKFrame();
     }
   } else {
     writeErrFrame(ERR_CODE_UNSUPPORTED_CMD);

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -526,11 +526,13 @@ bool MyMesh::shouldSelectivelyRelay(const mesh::Packet* packet) {
   // favourite is shielded behind this relayer, its peer has no path home yet, so the
   // returns come back as floods rather than direct routes. Without the dest match the
   // return leg is dropped and the message is never ACKed.
-  if (pt == PAYLOAD_TYPE_TXT_MSG || pt == PAYLOAD_TYPE_REQ ||
-      pt == PAYLOAD_TYPE_RESPONSE || pt == PAYLOAD_TYPE_PATH) {
-    if (packet->payload_len < 2) return false;
+  bool chat = (pt == PAYLOAD_TYPE_TXT_MSG || pt == PAYLOAD_TYPE_REQ ||
+               pt == PAYLOAD_TYPE_RESPONSE || pt == PAYLOAD_TYPE_PATH);
+  // ANON_REQ (e.g. first contact / room login to a shielded favourite) is dest_hash at
+  // payload[0] then the sender's full pubkey -- no 1-byte src_hash -- so dest-match only.
+  if (chat || pt == PAYLOAD_TYPE_ANON_REQ) {
+    if (packet->payload_len < (chat ? 2 : 1)) return false;
     uint8_t dst_hash = packet->payload[0];
-    uint8_t src_hash = packet->payload[1];
     int n = getNumContacts();
     for (int i = 0; i < n; i++) {
       ContactInfo ci;
@@ -540,7 +542,8 @@ bool MyMesh::shouldSelectivelyRelay(const mesh::Packet* packet) {
       // convenience and shouldn't pull their traffic (or their hash) into the allowlist.
       if (ci.type != ADV_TYPE_CHAT && ci.type != ADV_TYPE_ROOM) continue;
       // 1-byte hash collisions (~favourite_count/256) are intrinsic to the on-wire hash.
-      if (ci.id.isHashMatch(&src_hash, 1) || ci.id.isHashMatch(&dst_hash, 1)) return true;
+      if (ci.id.isHashMatch(&dst_hash, 1)) return true;
+      if (chat && ci.id.isHashMatch(&packet->payload[1], 1)) return true;
     }
     return false;
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -535,9 +535,12 @@ bool MyMesh::shouldSelectivelyRelay(const mesh::Packet* packet) {
     for (int i = 0; i < n; i++) {
       ContactInfo ci;
       if (!getContactByIdx(i, ci)) continue;
+      if (!(ci.flags & FLAG_FAVOURITE)) continue;
+      // Only relay for conversational peers; repeaters/sensors get starred for
+      // convenience and shouldn't pull their traffic (or their hash) into the allowlist.
+      if (ci.type != ADV_TYPE_CHAT && ci.type != ADV_TYPE_ROOM) continue;
       // 1-byte hash collisions (~favourite_count/256) are intrinsic to the on-wire hash.
-      if ((ci.id.isHashMatch(&src_hash, 1) || ci.id.isHashMatch(&dst_hash, 1))
-           && (ci.flags & FLAG_FAVOURITE)) return true;
+      if (ci.id.isHashMatch(&src_hash, 1) || ci.id.isHashMatch(&dst_hash, 1)) return true;
     }
     return false;
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1461,7 +1461,11 @@ void MyMesh::handleCmdFrame(size_t len) {
       repeat = cmd_frame[i++];   // FIRMWARE_VER_CODE  9+
     }
 
-    if (repeat && !isValidClientRepeatFreq(freq)) {
+    // Only CLIENT_REPEAT_ALL is tied to a designated repeater freq; SELECTIVE is
+    // exempt here too, matching CMD_SET_CLIENT_REPEAT_MODE.
+    if (repeat > CLIENT_REPEAT_SELECTIVE) {
+      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
+    } else if (repeat == CLIENT_REPEAT_ALL && !isValidClientRepeatFreq(freq)) {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
     } else if (freq >= 150000 && freq <= 2500000 && sf >= 5 && sf <= 12 && cr >= 5 && cr <= 8 && bw >= 7000 &&
         bw <= 500000) {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -111,6 +111,7 @@ protected:
   uint8_t getExtraAckTransmitCount() const override;
   bool filterRecvFloodPacket(mesh::Packet* packet) override;
   bool allowPacketForward(const mesh::Packet* packet) override;
+  bool shouldSelectivelyRelay(const mesh::Packet* packet);
 
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis);
   void sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis=0) override;
@@ -209,6 +210,9 @@ private:
   uint32_t pending_status;
   uint32_t pending_telemetry, pending_discovery;   // pending _TELEMETRY_REQ
   uint32_t pending_req;   // pending _BINARY_REQ
+  uint32_t _selective_relays;        // count of allowlisted floods relayed
+  uint32_t _selective_drops;         // reserved; kept for STATS wire compat
+
   BaseSerialInterface *_serial;
   AbstractUITask* _ui;
 


### PR DESCRIPTION
## Background

There are plenty of situations where you want a well-positioned companion (always powered, good antenna) to extend the reach of another device stuck in poor coverage, but only for your own traffic. A roof-mounted companion covering a pocket device that ducks into a store is one example.

The existing options don't fit. The built-in `client_repeat` mode repeats everything for everybody, and critically, it requires moving off your normal companion frequency onto a dedicated repeater band. The common community workaround, a "car-peater" or mobile repeater, also introduces trouble in that it isn't selective and thus can create known paths that are transient and unstable for many users.

## Proposed Solution

This PR adds a third option alongside the two that exist today. `off` repeats nothing and `all` repeats everything on a dedicated repeater frequency, both unchanged. The new `selective` mode **repeats only traffic on your allowlist** and stays on your normal companion frequency. I'm calling the capability CSRA, Companion Selective Repeat Ability, a nod to the [CSRA mesh region](https://meshcore.csramsh.org) (Central Savannah River Area) I'm building out near Augusta GA, USA. I'm definitely open to alternate methods of indicating allowlist should the community decide that is a good path to not overload use of favorites.

As implemented, the allowlist reuses the existing `favorite` flag on contacts, so there's no new setting to manage and the capability works without companion app updates. You mark the contacts you want selectively repeated, and it also repeats the specific group channels you already carry.

## Limiting impact on the larger mesh

This was the central design consideration, so I want to address it head on. A repeater that isn't selective is a burden on the mesh. Every flood it hears it rebroadcasts, and that retransmission consumes airtime every nearby node has to wait through. CSRA is built specifically to avoid that. It rebroadcasts a message only when the source contact is on your allowlist, or the message is on a channel you carry. Everything else is dropped with no retransmission at all. The practical result is that a CSRA node adds essentially no flood traffic to the mesh beyond the specific conversations its owner has opted into. That is a real improvement over an `all`-mode car-peater sitting in the same location and rebroadcasting indiscriminately.

The same selectivity keeps the node from quietly turning into a general next-hop for unrelated routed traffic. It will only relay along paths it created for allowlisted conversations, and it forwards nothing else.

## What gets repeated

Traffic moves in two directions. Outbound is a message leaving your device toward the wider mesh. Inbound is the reply coming back.

On the outbound side, a direct message involving a favorited contact gets repeated, and so does a group message on a channel you carry on the CSRA enabled companion. Anything else, meaning a message from a contact you haven't favorited or on a channel you don't carry, is ignored and not repeated.

On the inbound side, the reply or acknowledgement heading back to you is forwarded even though the far party is not on your allowlist. The return arrives in one of two ways. Once the node has built a path, the reply comes back along that path, and dropping it would break the route the node created. Before any path exists, which is the usual case while your device is shielded behind the node, the reply arrives as a flood addressed to your device. **The node recognizes your device as the destination and repeats it**, and that repeated flood is what lets the return path be found so the acknowledgement gets home. Traffic that is not part of one of your conversations is ignored here as well.

Three implementation points for reviewers. First, when the node repeats one of your messages it inserts itself into the message path. That is what gives the reply a way back. Without it the message goes out but the acknowledgement has nowhere to return, and the DM looks like it silently failed. Second, the allowlist check looks at both ends of a message, the sender and the recipient, rather than the sender alone. A favorited device is amplified whether it is sending a flood out or receiving one back, and that second case is what carries the first acknowledgement home before any path exists. Third, the node only steps in when a message is actually flooding. If your device already knows a direct route to a contact, that message does not need help and the node leaves it untouched. CSRA engages precisely when coverage is poor and the device has fallen back to flooding.

## Testing

I verified all cases DM/flood worked (and didn't work) as expected by flashing KISS on a device and watching all the raw OTA packets traversing through the various cases in a "bench test" scenario. I and other have also field tested the firmware and found the capability works as intended (see "test yourself! section below).

## Companion tooling

There is a companion-side piece, a new command to set the repeat mode, that I have ready in `meshcore_py` and `meshcore-cli`. I am holding those until there is intent to merge this firmware change, and they will need to be coordinated with a client app update as well.

## Test yourself!

Given there is no current client app support, I've gone ahead and built CSRA auto-enabled companion firmware for all supported devices available here: https://github.com/copelaje/MeshCore/releases  If you flash these, these your companion will behave in the manner described above for personal testing purposes. Long term my intent is that this mode be selectable within client apps (see "Companion tooling" above.  I'm happy to provide MRs and coordinate in this regard.