### PR TITLE
fix(techo-lite): remove duplicate EXTERNAL_FLASH_DEVICES definition

### DIFF
--- a/variants/lilygo_techo_lite/variant.h
+++ b/variants/lilygo_techo_lite/variant.h
@@ -95,9 +95,6 @@
 #define PIN_BUTTON2             _PINNUM(0, 18)
 #define BUTTON_PIN2             PIN_BUTTON2
 
-#define EXTERNAL_FLASH_DEVICES MX25R1635F
-#define EXTERNAL_FLASH_USE_QSPI
-
 ////////////////////////////////////////////////////////////////////////////////
 // Lora
 

--- a/variants/lilygo_techo_lite/variant.h
+++ b/variants/lilygo_techo_lite/variant.h
@@ -70,9 +70,6 @@
 #define PIN_QSPI_IO2            _PINNUM(1, 9)
 #define PIN_QSPI_IO3            _PINNUM(0, 26)
 
-#define EXTERNAL_FLASH_DEVICES ZD25WQ32CEIGR
-#define EXTERNAL_FLASH_USE_QSPI
-
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin LEDs
 


### PR DESCRIPTION
## Problem

`variants/lilygo_techo_lite/variant.h` defines `EXTERNAL_FLASH_DEVICES` twice:

```c
// Line 73 (correct)
#define EXTERNAL_FLASH_DEVICES ZD25WQ32CEIGR  // 32Mbit = 4MB, actual hardware

// Line 98 (incorrect)
#define EXTERNAL_FLASH_DEVICES MX25R1635F     // 16Mbit = 2MB, used on T-Echo
                                               // (non-Lite) and Heltec T114
```

Both definitions were introduced simultaneously in the initial commit
adding T-Echo Lite support (b11f0842). Per LILYGO's official schematic,
`ZD25WQ32CEIGR` is the only flash chip used on T-Echo Lite hardware.

## Fix

Remove the erroneous second definition (lines 98–99) to avoid confusion
for anyone reading the variant file.

## Testing

Built `LilyGo_T-Echo-Lite_non_shell_companion_radio_ble` — Success.
Also fixes missing newline at end of file.