### PR TITLE
Fix: CMD_SEND_RAW_PACKET not freeing packet on parse failure

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1981,7 +1981,7 @@ void MyMesh::handleCmdFrame(size_t len) {
         sendPacket(pkt, priority, 0);
         writeOKFrame();
       } else {
-        _mgr->free(pkt);
+        releasePacket(pkt);
         writeErrFrame(ERR_CODE_ILLEGAL_ARG);
       }
     } else {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1981,6 +1981,7 @@ void MyMesh::handleCmdFrame(size_t len) {
         sendPacket(pkt, priority, 0);
         writeOKFrame();
       } else {
+        _mgr->free(pkt);
         writeErrFrame(ERR_CODE_ILLEGAL_ARG);
       }
     } else {


### PR DESCRIPTION
This PR fixes a bug where invalid packets passed to `CMD_SEND_RAW_PACKET` would result in the obtained packet not being freed leading to packet exhaustion. Fixes #2721