### PR TITLE
Optimize packetScoreInt by using only float, not double

### DIFF
--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -202,12 +202,12 @@ static float snr_threshold[] = {
 };
   
 float RadioLibWrapper::packetScoreInt(float snr, int sf, int packet_len) {
-  if (sf < 7) return 0.0f;
+  if (sf < 7 || sf > 12) return 0.0f;
   
   if (snr < snr_threshold[sf - 7]) return 0.0f;    // Below threshold, no chance of success
 
-  auto success_rate_based_on_snr = (snr - snr_threshold[sf - 7]) / 10.0;
-  auto collision_penalty = 1 - (packet_len / 256.0);   // Assuming max packet of 256 bytes
+  auto success_rate_based_on_snr = (snr - snr_threshold[sf - 7]) * 0.1f;
+  auto collision_penalty = 1 - (packet_len / 256.0f);   // Assuming max packet of 256 bytes
 
-  return max(0.0, min(1.0, success_rate_based_on_snr * collision_penalty));
+  return max(0.0f, min(1.0f, success_rate_based_on_snr * collision_penalty));
 }


### PR DESCRIPTION
On ESP32, this eliminates calls to 9 soft-float operations: __floatsidf, __divdf3, __divsf3, __subdf3, __extendsfdf2, __muldf3, __ledf2, __gedf2, and __truncdfsf2.

All operations can now be done in hardware floating point, and the code size is ~100 bytes smaller, as well as likely much faster.

Changing to `* 0.1f` rather than `/ 10.0f` allows using hardware floating point multiply, since there is no hardware divide instruction.