### PR TITLE
Use float and not double in calcRxDelay

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -264,7 +264,7 @@ int MyMesh::getInterferenceThreshold() const {
 
 int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
   if (_prefs.rx_delay_base <= 0.0f) return 0;
-  return (int)((pow(_prefs.rx_delay_base, 0.85f - score) - 1.0) * air_time);
+  return (int)((powf(_prefs.rx_delay_base, 0.85f - score) - 1.0f) * air_time);
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -537,7 +537,7 @@ void MyMesh::logTxFail(mesh::Packet *pkt, int len) {
 
 int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
   if (_prefs.rx_delay_base <= 0.0f) return 0;
-  return (int)((pow(_prefs.rx_delay_base, 0.85f - score) - 1.0) * air_time);
+  return (int)((powf(_prefs.rx_delay_base, 0.85f - score) - 1.0f) * air_time);
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -259,7 +259,7 @@ void MyMesh::logTxFail(mesh::Packet *pkt, int len) {
 
 int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
   if (_prefs.rx_delay_base <= 0.0f) return 0;
-  return (int)((pow(_prefs.rx_delay_base, 0.85f - score) - 1.0) * air_time);
+  return (int)((powf(_prefs.rx_delay_base, 0.85f - score) - 1.0f) * air_time);
 }
 
 const char *MyMesh::getLogDateTime() {

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -309,7 +309,7 @@ bool SensorMesh::allowPacketForward(const mesh::Packet* packet) {
 
 int SensorMesh::calcRxDelay(float score, uint32_t air_time) const {
   if (_prefs.rx_delay_base <= 0.0f) return 0;
-  return (int) ((pow(_prefs.rx_delay_base, 0.85f - score) - 1.0) * air_time);
+  return (int) ((powf(_prefs.rx_delay_base, 0.85f - score) - 1.0f) * air_time);
 }
 
 uint32_t SensorMesh::getRetransmitDelay(const mesh::Packet* packet) {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -53,7 +53,7 @@ void Dispatcher::updateTxBudget() {
 }
 
 int Dispatcher::calcRxDelay(float score, uint32_t air_time) const {
-  return (int) ((pow(10, 0.85f - score) - 1.0) * air_time);
+  return (int) ((powf(10, 0.85f - score) - 1.0f) * air_time);
 }
 
 uint32_t Dispatcher::getCADFailRetryDelay() const {


### PR DESCRIPTION
* Swaps constant double values for constant float values
* Use `powf` instead of `pow` for the calcualation

On an ESP32 platform, this eliminates several implicit calls to the soft floating point routines __extendsfdf2, __subdf3, __floatunsidf, __muldf3, and __fixdfsi. After making the change, only the `powf` call remains. The code size also shrinks by ~80 bytes in a companion radio build.

This is quite similar to #2723 in terms of eliminating unnecessary use of `double` when `float` is appropriate.