### PR TITLE
Use `strtof` rather than `atof` for float values

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -869,7 +869,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
 
   // defaults
   memset(&_prefs, 0, sizeof(_prefs));
-  _prefs.airtime_factor = 1.0;
+  _prefs.airtime_factor = 1.0f;
   strcpy(_prefs.node_name, "NONAME");
   _prefs.freq = LORA_FREQ;
   _prefs.sf = LORA_SF;
@@ -1383,8 +1383,8 @@ void MyMesh::handleCmdFrame(size_t len) {
         bw <= 500000) {
       _prefs.sf = sf;
       _prefs.cr = cr;
-      _prefs.freq = (float)freq / 1000.0;
-      _prefs.bw = (float)bw / 1000.0;
+      _prefs.freq = (float)freq / 1000.0f;
+      _prefs.bw = (float)bw / 1000.0f;
       _prefs.client_repeat = repeat;
       savePrefs();
 

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -475,7 +475,7 @@ public:
     } else if (memcmp(command, "set ", 4) == 0) {
       const char* config = &command[4];
       if (memcmp(config, "af ", 3) == 0) {
-        _prefs.airtime_factor = atof(&config[3]);
+        _prefs.airtime_factor = strtof(&config[3], nullptr);
         savePrefs();
         Serial.println("  OK");
       } else if (memcmp(config, "name ", 5) == 0) {
@@ -495,7 +495,7 @@ public:
         savePrefs();
         Serial.println("  OK - reboot to apply");
       } else if (memcmp(config, "freq ", 5) == 0) {
-        _prefs.freq = atof(&config[5]);
+        _prefs.freq = strtof(&config[5], nullptr);
         savePrefs();
         Serial.println("  OK - reboot to apply");
       } else {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -481,7 +481,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
 void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* reply) {
   const char* config = &command[4];
   if (memcmp(config, "dutycycle ", 10) == 0) {
-    float dc = atof(&config[10]);
+    float dc = strtof(&config[10], nullptr);
     if (dc < 1 || dc > 100) {
       strcpy(reply, "ERROR: dutycycle must be 1-100");
     } else {
@@ -493,7 +493,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       sprintf(reply, "OK - %d.%d%%", a_int, a_frac);
     }
   } else if (memcmp(config, "af ", 3) == 0) {
-    _prefs->airtime_factor = atof(&config[3]);
+    _prefs->airtime_factor = strtof(&config[3], nullptr);
     savePrefs();
     strcpy(reply, "OK");
   } else if (memcmp(config, "int.thresh ", 11) == 0) {
@@ -595,7 +595,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     savePrefs();
     strcpy(reply, "OK");
   } else if (memcmp(config, "rxdelay ", 8) == 0) {
-    float db = atof(&config[8]);
+    float db = strtof(&config[8], nullptr);
     if (db >= 0 && db <= 20.0f) {
       _prefs->rx_delay_base = db;
       savePrefs();
@@ -604,7 +604,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       strcpy(reply, "Error, must be 0-20");
     }
   } else if (memcmp(config, "txdelay ", 8) == 0) {
-    float f = atof(&config[8]);
+    float f = strtof(&config[8], nullptr);
     if (f >= 0 && f <= 2.0f) {
       _prefs->tx_delay_factor = f;
       savePrefs();
@@ -640,7 +640,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       strcpy(reply, "Error, max 64");
     }
   } else if (memcmp(config, "direct.txdelay ", 15) == 0) {
-    float f = atof(&config[15]);
+    float f = strtof(&config[15], nullptr);
     if (f >= 0 && f <= 2.0f) {
       _prefs->direct_tx_delay_factor = f;
       savePrefs();
@@ -694,7 +694,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     _callbacks->setTxPower(_prefs->tx_power_dbm);
     strcpy(reply, "OK");
   } else if (sender_timestamp == 0 && memcmp(config, "freq ", 5) == 0) {
-    _prefs->freq = atof(&config[5]);
+    _prefs->freq = strtof(&config[5], nullptr);
     savePrefs();
     strcpy(reply, "OK - reboot to apply");
 #ifdef WITH_BRIDGE
@@ -747,7 +747,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(reply, "OK");
 #endif
   } else if (memcmp(config, "adc.multiplier ", 15) == 0) {
-    _prefs->adc_multiplier = atof(&config[15]);
+    _prefs->adc_multiplier = strtof(&config[15], nullptr);
     if (_board->setAdcMultiplier(_prefs->adc_multiplier)) {
       savePrefs();
       if (_prefs->adc_multiplier == 0.0f) {


### PR DESCRIPTION
`atof` produces a double value, which we immediately cast to a float in several cases. Like we already do elsewhere, e.g. in `tempradio`, use `strtof` to avoid using the double type at all. While unlikely, this should also avoid any double rounding precision isssues, as well as be a bit faster.

This is similar to #1104.