### PR TITLE
feat(techo-lite): add non-shell repeater and room server environments

### DIFF
--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -98,6 +98,38 @@ lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:LilyGo_T-Echo-Lite_kiss_modem]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/kiss_modem/>
+
+[env:LilyGo_T-Echo-Lite_non_shell_repeater]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -D ADVERT_NAME='"T-Echo-Lite-NS Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+
+[env:LilyGo_T-Echo-Lite_non_shell_room_server]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -D ADVERT_NAME='"T-Echo-Lite-NS Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+
 [env:LilyGo_T-Echo-Lite_non_shell_companion_radio_ble]
 extends = LilyGo_T-Echo-Lite
 upload_protocol = nrfutil
@@ -161,6 +193,7 @@ build_flags =
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
   -D SX126X_POWER_EN=30
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D P_LORA_TX_LED=LED_GREEN
@@ -185,8 +218,3 @@ build_src_filter = ${nrf52_base.build_src_filter}
 lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
-
-[env:LilyGo_T-Echo-Lite_kiss_modem]
-extends = LilyGo_T-Echo-Lite
-build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
-  +<../examples/kiss_modem/>

--- a/variants/lilygo_techo_lite/platformio.ini
+++ b/variants/lilygo_techo_lite/platformio.ini
@@ -98,6 +98,38 @@ lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:LilyGo_T-Echo-Lite_kiss_modem]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/kiss_modem/>
+
+[env:LilyGo_T-Echo-Lite_non_shell_repeater]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -D ADVERT_NAME='"T-Echo-Lite-NS Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+
+[env:LilyGo_T-Echo-Lite_non_shell_room_server]
+extends = LilyGo_T-Echo-Lite
+build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${LilyGo_T-Echo-Lite.build_flags}
+  -D ADVERT_NAME='"T-Echo-Lite-NS Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+
 [env:LilyGo_T-Echo-Lite_non_shell_companion_radio_ble]
 extends = LilyGo_T-Echo-Lite
 upload_protocol = nrfutil
@@ -187,8 +219,3 @@ build_src_filter = ${nrf52_base.build_src_filter}
 lib_deps =
   ${LilyGo_T-Echo-Lite.lib_deps}
   densaugeo/base64 @ ~1.4.0
-
-[env:LilyGo_T-Echo-Lite_kiss_modem]
-extends = LilyGo_T-Echo-Lite
-build_src_filter = ${LilyGo_T-Echo-Lite.build_src_filter}
-  +<../examples/kiss_modem/>


### PR DESCRIPTION
## Summary

Adds missing build environments for LilyGo T-Echo Lite Without Shell (H747-01/H747-02/H747-04), and fixes a missing TCXO voltage flag in the existing non-shell USB companion environment.

## Changes

### New environments
- `LilyGo_T-Echo-Lite_non_shell_repeater`
- `LilyGo_T-Echo-Lite_non_shell_room_server`

The standard `LilyGo_T-Echo-Lite_*` envs work correctly on non-shell hardware (confirmed on H747-02), but dedicated `non_shell_*` envs make the intent explicit and allow the web flasher to surface these roles as a distinct device entry. ADVERT_NAME uses `-NS` suffix to distinguish non-shell nodes on the network from display-equipped units.

### Bug fix
- `LilyGo_T-Echo-Lite_non_shell_companion_radio_usb`: added missing `-D SX126X_DIO3_TCXO_VOLTAGE=1.8`. All other non-shell envs had this flag; the USB variant was the only one missing it, causing the TCXO to fall back to 1.6V and potentially preventing radio init.

### Housekeeping
- Moved `LilyGo_T-Echo-Lite_kiss_modem` entry before the non-shell block for readability.

## Hardware tested
- H747-02 (T-Echo Lite Without Shell, 915MHz)
- `non_shell_repeater`: build + hardware verified ✅
- `non_shell_room_server`: build + hardware verified ✅
- `non_shell_companion_radio_usb`: build + hardware verified ✅ (after TCXO fix)