### PR TITLE
Ignore prepended all-zero hops when calculating max flood hops

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -429,9 +429,10 @@ void MyMesh::sendFloodReply(mesh::Packet* packet, unsigned long delay_millis, ui
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
   if (packet->isRouteFlood()) {
-    if (packet->getPathHashCount() >= _prefs.flood_max) return false;
-    if (packet->getRouteType() == ROUTE_TYPE_FLOOD && packet->getPathHashCount() >= _prefs.flood_max_unscoped) return false;
-    if (packet->getPayloadType() == PAYLOAD_TYPE_ADVERT && packet->getPathHashCount() >= _prefs.flood_max_advert) return false;
+    uint8_t flood_hops = packet->getPathHashCountExcludingLeadingZeros();
+    if (flood_hops >= _prefs.flood_max) return false;
+    if (packet->getRouteType() == ROUTE_TYPE_FLOOD && flood_hops >= _prefs.flood_max_unscoped) return false;
+    if (packet->getPayloadType() == PAYLOAD_TYPE_ADVERT && flood_hops >= _prefs.flood_max_advert) return false;
   }
   if (packet->isRouteFlood() && recv_pkt_region == NULL) {
     MESH_DEBUG_PRINTLN("allowPacketForward: unknown transport code, or wildcard not allowed for FLOOD packet");

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -283,9 +283,10 @@ uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
   if (packet->isRouteFlood()) {
-    if (packet->getPathHashCount() >= _prefs.flood_max) return false;
-    if (packet->getRouteType() == ROUTE_TYPE_FLOOD && packet->getPathHashCount() >= _prefs.flood_max_unscoped) return false;
-    if (packet->getPayloadType() == PAYLOAD_TYPE_ADVERT && packet->getPathHashCount() >= _prefs.flood_max_advert) return false;
+    uint8_t flood_hops = packet->getPathHashCountExcludingLeadingZeros();
+    if (flood_hops >= _prefs.flood_max) return false;
+    if (packet->getRouteType() == ROUTE_TYPE_FLOOD && flood_hops >= _prefs.flood_max_unscoped) return false;
+    if (packet->getPayloadType() == PAYLOAD_TYPE_ADVERT && flood_hops >= _prefs.flood_max_advert) return false;
   }
   return true;
 }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -303,7 +303,7 @@ float SensorMesh::getAirtimeBudgetFactor() const {
 
 bool SensorMesh::allowPacketForward(const mesh::Packet* packet) {
   if (_prefs.disable_fwd) return false;
-  if (packet->isRouteFlood() && packet->getPathHashCount() >= _prefs.flood_max) return false;
+  if (packet->isRouteFlood() && packet->getPathHashCountExcludingLeadingZeros() >= _prefs.flood_max) return false;
   return true;
 }
 

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -34,6 +34,22 @@ uint8_t Packet::copyPath(uint8_t* dest, const uint8_t* src, uint8_t path_len) {
   return path_len;
 }
 
+uint8_t Packet::getPathHashCountExcludingLeadingZeros() const {
+  uint8_t hash_count = getPathHashCount();
+  uint8_t hash_size = getPathHashSize();
+  if (hash_size > 3) return hash_count;
+  if (hash_count == 0 || path[0] != 0) return hash_count;
+
+  uint8_t path_byte_len = hash_count * hash_size;
+  uint8_t zero_bytes = 1;
+  while (zero_bytes < path_byte_len && path[zero_bytes] == 0) {
+    zero_bytes++;
+  }
+
+  uint8_t padding_count = zero_bytes / hash_size;
+  return hash_count - padding_count;
+}
+
 int Packet::getRawLength() const {
   return 2 + getPathByteLen() + payload_len + (hasTransportCodes() ? 4 : 0);
 }

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -78,6 +78,7 @@ public:
 
   uint8_t getPathHashSize() const { return (path_len >> 6) + 1; }
   uint8_t getPathHashCount() const { return path_len & 63; }
+  uint8_t getPathHashCountExcludingLeadingZeros() const;
   uint8_t getPathByteLen() const { return getPathHashCount() * getPathHashSize(); }
   void setPathHashCount(uint8_t n) { path_len &= ~63; path_len |= n; }
   void setPathHashSizeAndCount(uint8_t sz, uint8_t n) { path_len = ((sz - 1) << 6) | (n & 63); }


### PR DESCRIPTION
# Summary

Adds `Packet::getPathHashCountExcludingLeadingZeros()` and uses it for flood forwarding policy checks. Leading all-zero path entries are treated as synthetic padding for all flood max decisions, while the existing raw `Packet::getPathHashCount()` behavior is left unchanged for path encoding, append position, priority, and the 64-byte path capacity check.

# Motivation
For sensor telemetry, I want to send flood-routed packets but limit how far they propagate. MeshCore does not have a TTL field, but flood routing already stops when another repeater hash no longer fits in `Packet::path` (64 bytes). So I am abusing this length limit by prefilling the route with reserved values (zeros). This already works without this PR.

With the new flood max config options (all, unscoped, adverts) it's expected that flood propagation will be limited by repeater admins by using these knobs to cut down on flood from lands far away. However this will completely kill the prepending zeros trick. Thus this PR to ignore prepended all-zero IDs in paths when counting for the max hop limiters.

## Other use cases
It's a generic TTL mechanism. Use it to limit all kinds of flood packets . This PR targets only the routing part, not actual applications in companions / sensors etc.

## Other solutions considered 
- Custom scope - cleanest but not always possible because you don't control all the routers along the path(s).
- Not doing anything and watching my solar node battery stats cross the continent.. 

# Example

Example with 3-byte path hashes:
- prefill 17 leading 000000 path entries;
- this consumes 51 of MAX_PATH_SIZE == 64 bytes;
- only 4 real 3-byte repeater hashes can still be appended;
- the 5th repeater cannot forward because (21 + 1) * 3 > 64.

# Behavior

## Patched firmware:
- uses Packet::getPathHashCountExcludingLeadingZeros() in allowPacketForward() checks for flood_max, flood_max_unscoped, and flood_max_advert;
- still uses Packet::getPathHashCount() in Mesh::routeRecvPacket() for raw append/capacity behavior;
- therefore repeaters with e.g. flood.max = 12 can still forward a packet with 17 synthetic leading-zero entries, while path capacity limits it to 4 real repeats.

## Existing 1.14.0+ firmware:
parses the multibyte path normally;
counts the synthetic entries as normal hops for flood.max;
still honors the raw path capacity limit;
may drop early if its configured flood.max is lower than the prefilled count.

# Adverse side-effects
- Packets will have a much longer path = more airtime. But weighed against unnecessary flooding it is acceptable.

# Scope of changes
This does not change the wire format, `Packet::readFrom()`, `Dispatcher::tryParsePacket()`, or direct routing. It only changes flood policy accounting in the repeater/room-server/sensor forwarding checks.