### PR TITLE
fix(heltec_t114): correct swapped P0.X comments on Wire1 I2C pins

### DIFF
--- a/variants/heltec_t114/variant.h
+++ b/variants/heltec_t114/variant.h
@@ -61,8 +61,8 @@
 #define PIN_WIRE_SDA            (26) // P0.26
 #define PIN_WIRE_SCL            (27) // P0.27
 
-#define PIN_WIRE1_SDA            (7) // P0.8
-#define PIN_WIRE1_SCL            (8) // P0.7
+#define PIN_WIRE1_SDA            (7) // P0.07
+#define PIN_WIRE1_SCL            (8) // P0.08
 
 ////////////////////////////////////////////////////////////////////////////////
 // SPI pin definition


### PR DESCRIPTION
## What

Corrects the `// P0.X` comments on the T114 `Wire1` I2C pins in `variants/heltec_t114/variant.h`. They were swapped and wrong:

```c
// before
#define PIN_WIRE1_SDA  (7) // P0.8
#define PIN_WIRE1_SCL  (8) // P0.7
// after
#define PIN_WIRE1_SDA  (7) // P0.07
#define PIN_WIRE1_SCL  (8) // P0.08
```

Per `g_ADigitalPinMap` in `variant.cpp` (1:1 for pins ≥ 2), Arduino pin 7 = **P0.07** and pin 8 = **P0.08**. The old comments labelled pin 7 as P0.8 and pin 8 as P0.7 — both wrong, and swapped relative to each other.

## Why it matters

`Wire1` is the environment-sensor bus (`ENV_PIN_SDA`/`ENV_PIN_SCL` in the T114 `platformio.ini`). The misleading comments lead users to wire INA219 / other I2C sensors with **SDA and SCL reversed**. A reversed bus means the sensor never ACKs, and on the nRF52 TWIM a stuck/miswired bus can block inside the I2C scan in `EnvironmentSensorManager::begin()`, which runs in `setup()` before the USB CLI is serviced — so the device appears to "lock up" / stop responding to USB configuration whenever the sensor is plugged in.

The wrong comments date back to the sensor-management refactor (commit `5cb26b91`) and have never been corrected.

## Scope

Comment-only change. No electrical or behavioral change to the firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)