### PR TITLE
Add ESP32 Reset Reason to existing pwrmgt.bootreason cli command

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -944,13 +944,9 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(reply, "ERROR: Power management not supported");
 #endif
   } else if (memcmp(config, "pwrmgt.bootreason", 17) == 0) {
-#ifdef NRF52_POWER_MANAGEMENT
     sprintf(reply, "> Reset: %s; Shutdown: %s",
       _board->getResetReasonString(_board->getResetReason()),
       _board->getShutdownReasonString(_board->getShutdownReason()));
-#else
-    strcpy(reply, "ERROR: Power management not supported");
-#endif
   } else if (memcmp(config, "pwrmgt.bootmv", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
     sprintf(reply, "> %u mV", _board->getBootVoltage());

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -155,6 +155,42 @@ public:
   void setInhibitSleep(bool inhibit) {
     inhibit_sleep = inhibit;
   }
+
+  uint32_t getResetReason() const override {
+    return esp_reset_reason();
+  }
+
+  // https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/api-reference/system/system.html
+  const char* getResetReasonString(uint32_t reason) {
+    switch (reason) {
+      case ESP_RST_UNKNOWN:
+        return "Unknown or first boot";
+      case ESP_RST_POWERON:
+        return "Power-on reset";
+      case ESP_RST_EXT:
+        return "External reset";
+      case ESP_RST_SW:
+        return "Software reset";
+      case ESP_RST_PANIC:
+        return "Panic / exception reset";
+      case ESP_RST_INT_WDT:
+        return "Interrupt watchdog reset";
+      case ESP_RST_TASK_WDT:
+        return "Task watchdog reset";
+      case ESP_RST_WDT:
+        return "Other watchdog reset";
+      case ESP_RST_DEEPSLEEP:
+        return "Wake from deep sleep";
+      case ESP_RST_BROWNOUT:
+        return "Brownout (low voltage)";
+      case ESP_RST_SDIO:
+        return "SDIO reset";
+      default:
+        static char buf[40];
+        snprintf(buf, sizeof(buf), "Unknown reset reason (%d)", reason);
+        return buf;
+    }
+  }
 };
 
 class ESP32RTCClock : public mesh::RTCClock {


### PR DESCRIPTION
This small PR will add the Reset Reason functionality to the _pwrmgt.bootreason_ CLI command for **ESP32** based devices. Currently this was implemented for **nRF52** devices only.

All the code was already in the current firmware except the ESP32 implementation of the **getResetReason()** method on the board level.
https://github.com/meshcore-dev/MeshCore/blob/29f0a7fc4f8ed656bf607718d1b8d8a8a858ce76/src/MeshCore.h#L74

This should help with ESP32 boards that have rebooted for unknown reason e.g. during the test of new firmware ;)

Code is copied from https://github.com/IoTThinks/EasySkyMesh, so credits go to @IoTThinks (Thanks for this :+1: )
https://github.com/IoTThinks/MeshCore/commit/f25db3a7fa8f29912354de3a873ab00ed2c58b07