### PR TITLE
Add ESP32-C3 SuperMini + DX-LR30 variant

### DIFF
--- a/variants/esp32c3_dxlr30/ESP32C3Board.h
+++ b/variants/esp32c3_dxlr30/ESP32C3Board.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <helpers/ESP32Board.h>
+#include <Arduino.h>
+
+#include <driver/rtc_io.h>
+#include <driver/uart.h>
+
+class ESP32C3Board : public ESP32Board {
+public:
+  void begin() {
+    ESP32Board::begin();
+
+    esp_reset_reason_t reason = esp_reset_reason();
+    if (reason == ESP_RST_DEEPSLEEP) {
+      long wakeup_source = esp_sleep_get_gpio_wakeup_status(); //  esp_sleep_get_ext1_wakeup_status();
+      if (wakeup_source & (1 << P_LORA_DIO_1)) {  // received a LoRa packet (while in deep sleep)
+        startup_reason = BD_STARTUP_RX_PACKET;
+      }
+
+  #if defined(LORA_TX_BOOST_PIN)
+      gpio_hold_dis((gpio_num_t) LORA_TX_BOOST_PIN);
+      gpio_deep_sleep_hold_dis();
+  #endif
+    }
+
+  #ifdef PIN_VBAT_READ
+    // battery read support
+    pinMode(PIN_VBAT_READ, INPUT);
+  #endif
+
+  #ifdef LORA_TX_BOOST_PIN
+    pinMode(LORA_TX_BOOST_PIN, OUTPUT);
+    digitalWrite(LORA_TX_BOOST_PIN, HIGH);
+  #endif
+
+  #ifdef P_LORA_TX_LED
+    pinMode(P_LORA_TX_LED, OUTPUT);
+    digitalWrite(P_LORA_TX_LED, LOW);
+  #endif
+  }
+
+  void enterDeepSleep(uint32_t secs, int8_t wake_pin = -1) {
+    gpio_set_direction(gpio_num_t(P_LORA_DIO_1), GPIO_MODE_INPUT);
+    if (wake_pin >= 0) {
+      gpio_set_direction((gpio_num_t)wake_pin, GPIO_MODE_INPUT);
+    }
+
+    //hold disable, isolate and power domain config functions may be unnecessary
+    //gpio_deep_sleep_hold_dis();
+    //esp_sleep_config_gpio_isolate();
+    gpio_deep_sleep_hold_en();
+
+#if defined(LORA_TX_BOOST_PIN)
+    gpio_hold_en((gpio_num_t) LORA_TX_BOOST_PIN);
+    gpio_deep_sleep_hold_en();
+#endif
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+    if (wake_pin >= 0) {
+      esp_deep_sleep_enable_gpio_wakeup((1 << P_LORA_DIO_1) | (1 << wake_pin), ESP_GPIO_WAKEUP_GPIO_HIGH);
+    } else {
+      esp_deep_sleep_enable_gpio_wakeup(1 << P_LORA_DIO_1, ESP_GPIO_WAKEUP_GPIO_HIGH);
+    }
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup(secs * 1000000);
+    }
+
+    // Finally set ESP32 into sleep
+    esp_deep_sleep_start();  // CPU halts here and never returns!
+  }
+
+#if defined(LORA_TX_BOOST_PIN) || defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+  #if defined(P_LORA_TX_LED)
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+  #endif
+  #if defined(LORA_TX_BOOST_PIN)
+    digitalWrite(LORA_TX_BOOST_PIN, LOW);
+    delay(5);
+  #endif
+  }
+  void onAfterTransmit() override {
+  #if defined(LORA_TX_BOOST_PIN)
+    digitalWrite(LORA_TX_BOOST_PIN, HIGH);
+  #endif
+  #if defined(P_LORA_TX_LED)
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+  #endif
+  }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+  #ifdef PIN_VBAT_READ
+    analogReadResolution(10);
+    uint32_t raw = 0;
+    for (int i = 0; i < 8; i++) {
+      raw += analogRead(PIN_VBAT_READ);
+    }
+    raw = raw / 8;
+
+    return ((5.78 * raw) / 1024.0) * 1000;
+  #else
+    return 0;  // not supported
+  #endif
+  }
+
+  const char* getManufacturerName() const override {
+    return "esp32c3";
+  }
+};

--- a/variants/esp32c3_dxlr30/platformio.ini
+++ b/variants/esp32c3_dxlr30/platformio.ini
@@ -1,0 +1,173 @@
+[ESP32_C3]
+extends = esp32_base
+board = esp32-c3-devkitm-1
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/esp32c3_dxlr30
+
+  -D ESP32_CPU_FREQ=80
+
+  ; USB serial for ESP32-C3 SuperMini
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+
+  ; ESP32-C3 <-----> DX-LR30 (SX1262)
+
+  ; GPIO10 --------> SCK (SPI Clock)
+  ; GPIO6 ---------- MISO (SPI)
+  ; GPIO7 ---------> MOSI (SPI)
+  ; GPIO5 ---------> NSS / CS (SPI Slave select)
+  ; GPIO20 <-------- DIO1 (IRQ)
+  ; GPIO4 <--------- BUSY
+  ; GPIO21 --------> RESET
+  ; GPIO2 ---------> RXEN
+  ; GPIO3 ---------> TXEN
+  ; 3V3 -----------> VCC (use 3.3v only)
+  ; GND -----------> GND 
+
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=6
+  -D P_LORA_MOSI=7
+  -D P_LORA_NSS=5
+  -D P_LORA_DIO_1=20
+  -D P_LORA_BUSY=4
+  -D P_LORA_RESET=21
+  -D SX126X_RXEN=2
+  -D SX126X_TXEN=3
+
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D LORA_TX_POWER=22
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  ; -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+
+  -D PIN_BOARD_SDA=8
+  -D PIN_BOARD_SCL=9
+
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/esp32c3_dxlr30>
+  +<helpers/sensors>
+
+lib_deps =
+  ${esp32_base.lib_deps}
+
+
+[env:ESP32_C3_repeater]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/simple_repeater/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+  ${sensor_base.build_flags}
+  -UENV_INCLUDE_GPS
+  -UENV_INCLUDE_VL53L0X
+  -D ADVERT_NAME='"ESP32 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${ESP32_C3.lib_deps}
+  ${sensor_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0
+
+
+[env:ESP32_C3_room_server]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/simple_room_server/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+  ${sensor_base.build_flags}
+  -UENV_INCLUDE_GPS
+  -UENV_INCLUDE_VL53L0X
+  -D ADVERT_NAME='"ESP32 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${ESP32_C3.lib_deps}
+  ${sensor_base.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0
+
+
+[env:ESP32_C3_companion_radio_ble]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<helpers/esp32/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+lib_deps =
+  ${ESP32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+
+[env:ESP32_C3_companion_radio_usb]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<helpers/esp32/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+  ; -D RADIOLIB_DEBUG=1
+lib_deps =
+  ${ESP32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+
+[env:ESP32_C3_companion_radio_wifi]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<helpers/esp32/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+lib_deps =
+  ${ESP32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+
+[env:ESP32_C3_kiss_modem]
+extends = ESP32_C3
+build_src_filter = ${ESP32_C3.build_src_filter}
+  +<../examples/kiss_modem/*.cpp>
+build_flags =
+  ${ESP32_C3.build_flags}
+lib_deps =
+  ${ESP32_C3.lib_deps}

--- a/variants/esp32c3_dxlr30/target.cpp
+++ b/variants/esp32c3_dxlr30/target.cpp
@@ -1,0 +1,42 @@
+#include <Arduino.h>
+#include "target.h"
+
+ESP32C3Board board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi(FSPI);
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI, P_LORA_NSS);
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}
+

--- a/variants/esp32c3_dxlr30/target.h
+++ b/variants/esp32c3_dxlr30/target.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <ESP32C3Board.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+
+extern ESP32C3Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();
+


### PR DESCRIPTION
Add support for ESP32-C3 SuperMini + DX-LR30 (SX1262)

**Hardware:**
ESP32-C3 SuperMini
DX-LR30 (SX1262)

**Pin mapping:**
SCK   GPIO10
MISO  GPIO6
MOSI  GPIO7
NSS   GPIO5
DIO1  GPIO20
BUSY  GPIO4
RESET GPIO21

**Notes:**
- Uses FSPI on ESP32-C3
- Requires SX126X_DIO2_AS_RF_SWITCH=true
- Verified TX/RX operation
- BLE Companion tested on Android