### PR TITLE
Rak WisMesh Tag fixes

### DIFF
--- a/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
+++ b/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
@@ -45,8 +45,8 @@ public:
         digitalWrite(BUZZER_EN, LOW);
     #endif
 
-    #ifdef PIN_GPS_EN
-        digitalWrite(PIN_GPS_EN, LOW);
+    #ifdef PIN_3V3_EN
+        digitalWrite(PIN_3V3_EN, LOW);
     #endif
 
     // set led on and wait for button release before poweroff

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -94,7 +94,6 @@ build_flags =
   -D BLE_PIN_CODE=123456
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
-  -D PIN_GPS_EN=34
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${rak_wismesh_tag.build_src_filter}

--- a/variants/rak_wismesh_tag/variant.cpp
+++ b/variants/rak_wismesh_tag/variant.cpp
@@ -15,7 +15,7 @@ void initVariant() {
   digitalWrite(LED_BLUE, LOW);
   digitalWrite(LED_GREEN, LOW);
 
-  // GPS
-  pinMode(PIN_GPS_EN, OUTPUT);
-  digitalWrite(PIN_GPS_EN, HIGH);
+  // 3V3 peripheral power rail
+  pinMode(PIN_3V3_EN, OUTPUT);
+  digitalWrite(PIN_3V3_EN, HIGH);
 }

--- a/variants/rak_wismesh_tag/variant.h
+++ b/variants/rak_wismesh_tag/variant.h
@@ -14,12 +14,11 @@
 #define USE_LFXO    // 32.768 kHz crystal oscillator
 #define VARIANT_MCK (64000000ul)
 
-#define WIRE_INTERFACES_COUNT   (1)
-#define PIN_TXCO                (21)
 ////////////////////////////////////////////////////////////////////////////////
 // Power
 
 #define PIN_PWR_EN              (12)
+#define PIN_3V3_EN              (34)
 
 #define BATTERY_PIN             (5)
 #define ADC_MULTIPLIER          (1.73F)
@@ -111,7 +110,6 @@ extern const int SCK;
 #define PIN_GPS_RX              (PIN_SERIAL1_TX)
 #define PIN_GPS_TX              (PIN_SERIAL1_RX)
 #define PIN_GPS_PPS             (17)
-#define PIN_GPS_EN              (34)
 
 ///////////////////////////////////////////////////////////////////////////////
 // OTHER PINS


### PR DESCRIPTION
- Remove duplicate WIRE_INTERFACES_COUNT
- Remove typo "PIN_TXCO" - TCXO is driven by DIO3 which is already handled
- Replace PIN_GPS_EN with PIN_3V3_EN - pin 34 drives the entire 3v3 peripheral bus and not just GPS
- Drive PIN_3V3_EN high on boot, low on power off