### PR TITLE
Ikoka Handheld: Fix LED state polarity

### DIFF
--- a/variants/ikoka_handheld_nrf/variant.h
+++ b/variants/ikoka_handheld_nrf/variant.h
@@ -35,7 +35,7 @@ extern "C"
 #define LED_GREEN               (13)
 #define LED_BLUE                (12)
 
-#define LED_STATE_ON            (1)     // State when LED is litted
+#define LED_STATE_ON            (0)     // State when LED is litted
 
 // Buttons
 #define PIN_BUTTON1             (PINS_COUNT)


### PR DESCRIPTION
LEDs are lit with LED_STATE_ON == 0 as with all Xiao nRF52 boards.
This caused inverted LED behavior when code used the default PIN_LED + LED_STATE_ON defines, such as the Bluefruit Library.