### PR TITLE
Add variant for ikoka handheld to use Ebyte E22P module

### DIFF
--- a/variants/ikoka_handheld_nrf/platformio.ini
+++ b/variants/ikoka_handheld_nrf/platformio.ini
@@ -59,6 +59,18 @@ build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
 build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
 
+[env:ikoka_handheld_nrf_e22p_30dbm_096_companion_radio_ble]
+extends = ikoka_handheld_nrf
+build_unflags = -D SX126X_RXEN=D5
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
+  -D BLE_PIN_CODE=123456
+  -D LORA_TX_POWER=20
+  -D DX126X_RXEN=RADIOLIB_NC
+  -D P_LORA_EN=D5
+build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+
 [env:ikoka_handheld_nrf_e22_30dbm_096_rotated_companion_radio_ble]
 extends = ikoka_handheld_nrf
 board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld

--- a/variants/ikoka_handheld_nrf/target.cpp
+++ b/variants/ikoka_handheld_nrf/target.cpp
@@ -21,6 +21,10 @@ EnvironmentSensorManager sensors;
 
 bool radio_init() {
   rtc_clock.begin(Wire);
+#ifdef P_LORA_EN
+  pinMode(P_LORA_EN, OUTPUT);
+  digitalWrite(P_LORA_EN, HIGH);
+#endif
 
   return radio.std_init(&SPI);
 }


### PR DESCRIPTION
The original ikoka handheld was build for the Ebyte E22 module.
This commit includes the slight changes needed to adapt to the improved E22P module.
To allow both variants, a new build variant for the E22P was created.