### PR TITLE
[Feature request] Disable blue LED during Bluetooth connection

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -130,7 +130,7 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   snprintf(charpin, sizeof(charpin), "%lu", (unsigned long)pin_code);
   
   // If we want to control BLE LED ourselves, uncomment this:
-  // Bluefruit.autoConnLed(false);
+  Bluefruit.autoConnLed(false);
   Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
   Bluefruit.begin();
  


### PR DESCRIPTION
To save power, do not indicate an active Bluetooth connection with a steadily lit blue LED.