### PR TITLE
Fixed GPS time sync for Heltec T114

### DIFF
--- a/variants/heltec_t114/target.cpp
+++ b/variants/heltec_t114/target.cpp
@@ -22,7 +22,7 @@ AutoDiscoverRTCClock rtc_clock(fallback_clock);
 
 #if ENV_INCLUDE_GPS
 #include <helpers/sensors/MicroNMEALocationProvider.h>
-MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1);
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
 EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
 #else
 EnvironmentSensorManager sensors;


### PR DESCRIPTION
Hello all,
This PR is to fix the issue in https://github.com/meshcore-dev/MeshCore/issues/2786
The GPS time sync is not working (not syncing up time) for Heltec T114.

Tested working for Heltec T114.
The time is autosynced fine after rebooting and locking GPS.
gps sync works fine too.

Credits to Ckoehler.