### PR TITLE
fix: prevent ESP32 KISS modem stalls under USB backpressure

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-build-environment
 
       - name: Run Unit Tests
-        run: pio test -e native -vv
+        run: pio test -e native -e native_kiss_modem -vv
 
       - name: Upload Test Results
         # Upload test results even if the test step failed.

--- a/docs/kiss_modem_protocol.md
+++ b/docs/kiss_modem_protocol.md
@@ -41,7 +41,7 @@ Maximum unescaped frame size: 512 bytes.
 
 | Command     | Value  | Data               | Description                                                 |
 |-------------|--------|--------------------|-------------------------------------------------------------|
-| Data        | `0x00` | Raw packet         | Queue packet for transmission                               |
+| Data        | `0x00` | Raw packet         | Queue packet for transmission (one pending at a time)       |
 | TXDELAY     | `0x01` | Delay (1 byte)     | Transmitter keyup delay in 10ms units (default: 50 = 500ms) |
 | Persistence | `0x02` | P (1 byte)         | CSMA persistence parameter 0-255 (default: 63)              |
 | SlotTime    | `0x03` | Interval (1 byte)  | CSMA slot interval in 10ms units (default: 10 = 100ms)      |
@@ -57,6 +57,12 @@ Maximum unescaped frame size: 512 bytes.
 | Data | `0x00` | Raw packet | Received packet from radio |
 
 Data frames carry raw packet data only, with no metadata prepended. The Data command payload is limited to 255 bytes to match the MeshCore maximum transmission unit (MAX_TRANS_UNIT); frames larger than 255 bytes are silently dropped. The KISS specification recommends at least 1024 bytes for general-purpose TNCs; this modem is intended for MeshCore packets only, whose protocol MTU is 255 bytes.
+
+Only one packet may be pending for radio transmission at a time. If the host sends a second Data frame before the first has completed, the modem responds with Error (0xF1) and TxBusy (0x07).
+
+### Host Output Backpressure
+
+Outbound frames are encoded into a 2-slot queue and flushed when serial output space is available; `loop()` never blocks on writes. Radio TX state advances independently of host read speed. TxDone is retained until it can be queued. If the outbound queue is full, the modem responds with Error (0xF1) and TxBusy (0x07). Hosts should read serial promptly to avoid delayed responses.
 
 ### CSMA Behavior
 
@@ -156,15 +162,15 @@ Response codes use the high-bit convention: `response = command | 0x80`. Generic
 | MacFailed     | `0x04` | MAC verification failed |
 | UnknownCmd    | `0x05` | Unknown sub-command     |
 | EncryptFailed | `0x06` | Encryption failed       |
-| TxBusy        | `0x07` | Transmit busy           |
+| TxBusy        | `0x07` | Radio TX busy, or host output queue full |
 
 ### Unsolicited Events
 
 The TNC sends these SetHardware frames without a preceding request:
 
-**TxDone (0xF8)**: Sent after a packet has been transmitted. Contains a single byte: 0x01 for success, 0x00 for failure.
+**TxDone (0xF8)**: Sent after radio transmission completes. Contains a single byte: 0x01 for success, 0x00 for failure. Delivery to the host may be delayed under serial backpressure but is not dropped.
 
-**RxMeta (0xF9)**: Sent immediately after each standard data frame (type 0x00) with metadata for the received packet. Contains SNR (1 byte, signed, value x4 for 0.25 dB precision) followed by RSSI (1 byte, signed, dBm). Enabled by default; can be toggled with SetSignalReport. Standard KISS clients ignore this frame.
+**RxMeta (0xF9)**: Sent after each standard data frame (type 0x00) with SNR (1 byte, signed, value x4) and RSSI (1 byte, signed, dBm). Queued with the data frame; omitted if the data frame cannot be queued. Enabled by default; toggle with SetSignalReport. Standard KISS clients ignore this frame.
 
 ## Data Formats
 

--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -22,6 +22,7 @@ KissModem::KissModem(Stream& serial, mesh::LocalIdentity& identity, mesh::RNG& r
   _getStatsCallback = nullptr;
   _config = {0, 0, 0, 0, 0};
   _signal_report_enabled = true;
+  resetOutputQueue();
 }
 
 void KissModem::begin() {
@@ -30,37 +31,168 @@ void KissModem::begin() {
   _rx_active = false;
   _has_pending_tx = false;
   _tx_state = TX_IDLE;
+  resetOutputQueue();
 }
 
-void KissModem::writeByte(uint8_t b) {
-  if (b == KISS_FEND) {
-    _serial.write(KISS_FESC);
-    _serial.write(KISS_TFEND);
-  } else if (b == KISS_FESC) {
-    _serial.write(KISS_FESC);
-    _serial.write(KISS_TFESC);
-  } else {
-    _serial.write(b);
+void KissModem::resetOutputQueue() {
+  _tx_frame_head = 0;
+  _tx_frame_tail = 0;
+  _tx_frame_count = 0;
+  _tx_busy_error_pending = false;
+  _tx_done_pending = false;
+  _tx_done_result = 0;
+}
+
+void KissModem::popTxFrame() {
+  _tx_frame_head = (uint8_t)((_tx_frame_head + 1) % KISS_TX_FRAME_QUEUE_DEPTH);
+  _tx_frame_count--;
+}
+
+uint16_t KissModem::appendEscapedByte(uint8_t* dest, uint16_t idx, uint16_t max_len, uint8_t b) {
+  if (b == KISS_FEND || b == KISS_FESC) {
+    if (idx + 2 > max_len) {
+      return 0;
+    }
+    dest[idx++] = KISS_FESC;
+    dest[idx++] = (b == KISS_FEND) ? KISS_TFEND : KISS_TFESC;
+    return idx;
   }
+  if (idx + 1 > max_len) {
+    return 0;
+  }
+  dest[idx++] = b;
+  return idx;
 }
 
-void KissModem::writeFrame(uint8_t type, const uint8_t* data, uint16_t len) {
-  _serial.write(KISS_FEND);
-  writeByte(type);
+uint16_t KissModem::encodeFrame(uint8_t type, const uint8_t* data, uint16_t len, uint8_t* dest, uint16_t max_len) {
+  if (max_len < KISS_FRAME_BOUNDARY_BYTES) {
+    return 0;
+  }
+
+  uint16_t idx = 0;
+  dest[idx++] = KISS_FEND;
+
+  idx = appendEscapedByte(dest, idx, max_len, type);
+  if (idx == 0) {
+    return 0;
+  }
+
   for (uint16_t i = 0; i < len; i++) {
-    writeByte(data[i]);
+    idx = appendEscapedByte(dest, idx, max_len, data[i]);
+    if (idx == 0) {
+      return 0;
+    }
   }
-  _serial.write(KISS_FEND);
+
+  if (idx + 1 > max_len) {
+    return 0;
+  }
+  dest[idx++] = KISS_FEND;
+  return idx;
 }
 
-void KissModem::writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len) {
-  _serial.write(KISS_FEND);
-  writeByte(KISS_CMD_SETHARDWARE);
-  writeByte(sub_cmd);
-  for (uint16_t i = 0; i < len; i++) {
-    writeByte(data[i]);
+bool KissModem::tryFlushFrames() {
+  while (_tx_frame_count > 0) {
+    const uint8_t idx = _tx_frame_head;
+    const uint16_t frame_len = _tx_frame_len[idx];
+    uint16_t written_len = _tx_frame_written[idx];
+
+    if (written_len >= frame_len) {
+      popTxFrame();
+      continue;
+    }
+
+    const int available = _serial.availableForWrite();
+    if (available <= 0) {
+      return false;
+    }
+
+    const uint16_t remaining = frame_len - written_len;
+    const uint16_t chunk_len = (available < (int)remaining) ? (uint16_t)available : remaining;
+    if (chunk_len == 0) {
+      return false;
+    }
+
+    size_t chunk_written = _serial.write(_tx_frame_buf[idx] + written_len, chunk_len);
+    if (chunk_written == 0) {
+      return false;
+    }
+
+    written_len += (uint16_t)chunk_written;
+    _tx_frame_written[idx] = written_len;
+
+    if (written_len < frame_len) {
+      return false;
+    }
+
+    popTxFrame();
   }
-  _serial.write(KISS_FEND);
+  return true;
+}
+
+bool KissModem::queueFrame(uint8_t type, const uint8_t* data, uint16_t len, bool mark_busy_error) {
+  if (_tx_frame_count >= KISS_TX_FRAME_QUEUE_DEPTH && !tryFlushFrames()) {
+    if (mark_busy_error) {
+      _tx_busy_error_pending = true;
+    }
+    return false;
+  }
+  const uint8_t idx = _tx_frame_tail;
+  uint16_t frame_len = encodeFrame(type, data, len, _tx_frame_buf[idx], sizeof(_tx_frame_buf[idx]));
+  if (frame_len == 0) {
+    return false;
+  }
+
+  _tx_frame_len[idx] = frame_len;
+  _tx_frame_written[idx] = 0;
+  _tx_frame_tail = (uint8_t)((_tx_frame_tail + 1) % KISS_TX_FRAME_QUEUE_DEPTH);
+  _tx_frame_count++;
+  tryFlushFrames();
+  return true;
+}
+
+bool KissModem::queuePendingBusyError() {
+  if (!_tx_busy_error_pending) {
+    return true;
+  }
+  const uint8_t err = HW_ERR_TX_BUSY;
+  if (!queueHardwareFrame(HW_RESP_ERROR, &err, 1, false)) {
+    return false;
+  }
+  _tx_busy_error_pending = false;
+  return true;
+}
+
+bool KissModem::queueHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len, bool mark_busy_error) {
+  if (len > KISS_MAX_FRAME_SIZE) {
+    return false;
+  }
+  _tx_hw_payload[0] = sub_cmd;
+  if (len > 0) {
+    memcpy(_tx_hw_payload + 1, data, len);
+  }
+  return queueFrame(KISS_CMD_SETHARDWARE, _tx_hw_payload, len + 1, mark_busy_error);
+}
+
+bool KissModem::queuePendingTxDone() {
+  if (!_tx_done_pending) {
+    return true;
+  }
+  if (!queueHardwareFrame(HW_RESP_TX_DONE, &_tx_done_result, 1, false)) {
+    return false;
+  }
+  _tx_done_pending = false;
+  return true;
+}
+
+void KissModem::setTxDonePending(uint8_t result) {
+  _tx_done_result = result;
+  _tx_done_pending = true;
+  _tx_state = TX_DONE_PENDING;
+}
+
+bool KissModem::writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len) {
+  return queueHardwareFrame(sub_cmd, data, len, true);
 }
 
 void KissModem::writeHardwareError(uint8_t error_code) {
@@ -68,6 +200,8 @@ void KissModem::writeHardwareError(uint8_t error_code) {
 }
 
 void KissModem::loop() {
+  tryFlushFrames();
+
   while (_serial.available()) {
     uint8_t b = _serial.read();
 
@@ -106,6 +240,8 @@ void KissModem::loop() {
   }
 
   processTx();
+  tryFlushFrames();
+  queuePendingBusyError();
 }
 
 void KissModem::processFrame() {
@@ -295,10 +431,7 @@ void KissModem::processTx() {
           _tx_timer = millis();
           _tx_state = TX_SENDING;
         } else {
-          uint8_t result = 0x00;
-          writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
-          _has_pending_tx = false;
-          _tx_state = TX_IDLE;
+          setTxDonePending(0x00);
         }
       }
       break;
@@ -306,14 +439,15 @@ void KissModem::processTx() {
     case TX_SENDING:
       if (_radio.isSendComplete()) {
         _radio.onSendFinished();
-        uint8_t result = 0x01;
-        writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
-        _has_pending_tx = false;
-        _tx_state = TX_IDLE;
+        setTxDonePending(0x01);
       } else if (millis() - _tx_timer >= _radio.getEstAirtimeFor(_pending_tx_len) * KISS_TX_TIMEOUT_FACTOR) {
         _radio.onSendFinished();
-        uint8_t result = 0x00;
-        writeHardwareFrame(HW_RESP_TX_DONE, &result, 1);
+        setTxDonePending(0x00);
+      }
+      break;
+
+    case TX_DONE_PENDING:
+      if (queuePendingTxDone()) {
         _has_pending_tx = false;
         _tx_state = TX_IDLE;
       }
@@ -322,8 +456,7 @@ void KissModem::processTx() {
 }
 
 void KissModem::onPacketReceived(int8_t snr, int8_t rssi, const uint8_t* packet, uint16_t len) {
-  writeFrame(KISS_CMD_DATA, packet, len);
-  if (_signal_report_enabled) {
+  if (queueFrame(KISS_CMD_DATA, packet, len) && _signal_report_enabled) {
     uint8_t meta[2] = { (uint8_t)snr, (uint8_t)rssi };
     writeHardwareFrame(HW_RESP_RX_META, meta, 2);
   }

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -13,6 +13,14 @@
 
 #define KISS_MAX_FRAME_SIZE  512
 #define KISS_MAX_PACKET_SIZE 255
+#define KISS_FRAME_BOUNDARY_BYTES 2
+#define KISS_TYPE_BYTES 1
+#define KISS_HW_SUBCMD_BYTES 1
+#define KISS_MAX_ESCAPABLE_BYTES (KISS_MAX_FRAME_SIZE + KISS_TYPE_BYTES + KISS_HW_SUBCMD_BYTES)
+#define KISS_MAX_ESCAPED_PAYLOAD_SIZE (2 * KISS_MAX_ESCAPABLE_BYTES)
+#define KISS_MAX_ENCODED_FRAME_SIZE (KISS_FRAME_BOUNDARY_BYTES + KISS_MAX_ESCAPED_PAYLOAD_SIZE)
+#define KISS_TX_FRAME_QUEUE_DEPTH 2
+#define KISS_HW_MAX_PAYLOAD_SIZE (KISS_MAX_FRAME_SIZE + KISS_HW_SUBCMD_BYTES)
 
 #define KISS_CMD_DATA        0x00
 #define KISS_CMD_TXDELAY     0x01
@@ -94,7 +102,8 @@ enum TxState {
   TX_WAIT_CLEAR,
   TX_SLOT_WAIT,
   TX_DELAY,
-  TX_SENDING
+  TX_SENDING,
+  TX_DONE_PENDING
 };
 
 class KissModem {
@@ -130,10 +139,28 @@ class KissModem {
 
   RadioConfig _config;
   bool _signal_report_enabled;
+  uint8_t _tx_frame_buf[KISS_TX_FRAME_QUEUE_DEPTH][KISS_MAX_ENCODED_FRAME_SIZE];
+  uint16_t _tx_frame_len[KISS_TX_FRAME_QUEUE_DEPTH];
+  uint16_t _tx_frame_written[KISS_TX_FRAME_QUEUE_DEPTH];
+  uint8_t _tx_frame_head;
+  uint8_t _tx_frame_tail;
+  uint8_t _tx_frame_count;
+  bool _tx_busy_error_pending;
+  bool _tx_done_pending;
+  uint8_t _tx_done_result;
+  uint8_t _tx_hw_payload[KISS_HW_MAX_PAYLOAD_SIZE];
 
-  void writeByte(uint8_t b);
-  void writeFrame(uint8_t type, const uint8_t* data, uint16_t len);
-  void writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len);
+  static uint16_t appendEscapedByte(uint8_t* dest, uint16_t idx, uint16_t max_len, uint8_t b);
+  static uint16_t encodeFrame(uint8_t type, const uint8_t* data, uint16_t len, uint8_t* dest, uint16_t max_len);
+  void resetOutputQueue();
+  void popTxFrame();
+  bool tryFlushFrames();
+  bool queueFrame(uint8_t type, const uint8_t* data, uint16_t len, bool mark_busy_error = true);
+  bool queuePendingBusyError();
+  bool queueHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len, bool mark_busy_error);
+  bool queuePendingTxDone();
+  void setTxDonePending(uint8_t result);
+  bool writeHardwareFrame(uint8_t sub_cmd, const uint8_t* data, uint16_t len);
   void writeHardwareError(uint8_t error_code);
   void processFrame();
   void handleHardwareCommand(uint8_t sub_cmd, const uint8_t* data, uint16_t len);
@@ -182,4 +209,5 @@ public:
   bool isTxBusy() const { return _tx_state != TX_IDLE; }
   /** True only when radio is actually transmitting; use to skip recvRaw in main loop. */
   bool isActuallyTransmitting() const { return _tx_state == TX_SENDING; }
+  bool isHostOutputBackedUp() const { return _tx_frame_count > 0 || _tx_busy_error_pending || _tx_done_pending; }
 };

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -20,6 +20,8 @@
 
 #define NOISE_FLOOR_CALIB_INTERVAL_MS 2000
 #define AGC_RESET_INTERVAL_MS 30000
+#define USB_TX_TIMEOUT_MS 50
+#define USB_TX_BUFFER_SIZE 1024
 
 StdRNG rng;
 mesh::LocalIdentity identity;
@@ -111,6 +113,12 @@ void setup() {
   uint32_t start = millis();
   while (!Serial && millis() - start < 3000) delay(10);
   delay(100);
+#if defined(ESP32)
+  Serial.setTxTimeoutMs(USB_TX_TIMEOUT_MS);
+#if ARDUINO_USB_MODE
+  Serial.setTxBufferSize(USB_TX_BUFFER_SIZE);
+#endif
+#endif
   modem = new KissModem(Serial, identity, rng, radio_driver, board, sensors);
 #endif
 
@@ -126,7 +134,7 @@ void setup() {
 void loop() {
   modem->loop();
 
-  if (!modem->isActuallyTransmitting()) {
+  if (!modem->isActuallyTransmitting() && !modem->isHostOutputBackedUp()) {
     if (!modem->isTxBusy()) {
       if ((uint32_t)(millis() - next_agc_reset_ms) >= AGC_RESET_INTERVAL_MS) {
         radio_driver.resetAGC();

--- a/platformio.ini
+++ b/platformio.ini
@@ -161,6 +161,7 @@ build_flags = -std=c++17
   -I src
   -I test/mocks
 test_build_src = yes
+test_filter = test_utils
 build_src_filter =
   -<*>
   +<../src/Utils.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -166,3 +166,18 @@ build_src_filter =
   +<../src/Utils.cpp>
 lib_deps =
   google/googletest @ 1.17.0
+
+[env:native_kiss_modem]
+platform = native
+test_framework = googletest
+build_flags = -std=c++17
+  -I test/mocks
+  -I src
+  -I examples/kiss_modem
+test_build_src = yes
+test_filter = test_kiss_modem
+build_src_filter =
+  -<*>
+  +<../examples/kiss_modem/KissModem.cpp>
+lib_deps =
+  google/googletest @ 1.17.0

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <cmath>
+#include "Stream.h"
+
+inline uint32_t g_mock_millis = 0;
+
+using std::isnan;
+
+inline uint32_t millis() {
+  return g_mock_millis;
+}
+
+inline void delay(uint32_t ms) {
+  g_mock_millis += ms;
+}

--- a/test/mocks/CayenneLPP.h
+++ b/test/mocks/CayenneLPP.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class CayenneLPP {
+public:
+  explicit CayenneLPP(size_t) {}
+  const uint8_t* getBuffer() const { return nullptr; }
+  uint16_t getSize() const { return 0; }
+};

--- a/test/mocks/Identity.h
+++ b/test/mocks/Identity.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include "Utils.h"
+
+namespace mesh {
+
+class Identity {
+public:
+  uint8_t pub_key[PUB_KEY_SIZE];
+
+  Identity() {
+    std::memset(pub_key, 0, sizeof(pub_key));
+  }
+
+  explicit Identity(const uint8_t* src) {
+    std::memcpy(pub_key, src, PUB_KEY_SIZE);
+  }
+
+  bool verify(const uint8_t*, const uint8_t*, int) const {
+    return true;
+  }
+};
+
+class LocalIdentity : public Identity {
+public:
+  LocalIdentity() : Identity() {}
+
+  void sign(uint8_t* sig, const uint8_t*, int) const {
+    std::memset(sig, 0x5A, SIGNATURE_SIZE);
+  }
+
+  void calcSharedSecret(uint8_t* secret, const uint8_t*) const {
+    std::memset(secret, 0x11, PUB_KEY_SIZE);
+  }
+};
+
+}

--- a/test/mocks/Mesh.h
+++ b/test/mocks/Mesh.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace mesh {
+
+class Radio {
+public:
+  virtual ~Radio() = default;
+  virtual bool isReceiving() { return false; }
+  virtual uint32_t getEstAirtimeFor(uint16_t) { return 10; }
+  virtual bool startSendRaw(const uint8_t*, uint16_t) { return true; }
+  virtual bool isSendComplete() { return true; }
+  virtual void onSendFinished() {}
+  virtual int16_t getNoiseFloor() { return -120; }
+};
+
+class MainBoard {
+public:
+  virtual ~MainBoard() = default;
+  virtual uint16_t getBattMilliVolts() { return 4200; }
+  virtual float getMCUTemperature() { return 25.0f; }
+  virtual const char* getManufacturerName() { return "mock-board"; }
+  virtual void reboot() {}
+};
+
+}

--- a/test/mocks/Stream.h
+++ b/test/mocks/Stream.h
@@ -1,10 +1,23 @@
 #pragma once
 
-// Mock Stream class for native testing
-// Provides minimal interface needed by Utils.h
+#include <cstddef>
+#include <cstdint>
 
 class Stream {
 public:
-    virtual void print(char c) {}
-    virtual void print(const char* str) {}
+    virtual ~Stream() = default;
+    virtual size_t write(uint8_t) { return 1; }
+    virtual size_t write(const uint8_t* buffer, size_t size) {
+        size_t total = 0;
+        for (size_t i = 0; i < size; i++) {
+            total += write(buffer[i]);
+        }
+        return total;
+    }
+    virtual int available() { return 0; }
+    virtual int availableForWrite() { return 0; }
+    virtual int read() { return -1; }
+    virtual void flush() {}
+    virtual void print(char) {}
+    virtual void print(const char*) {}
 };

--- a/test/mocks/Utils.h
+++ b/test/mocks/Utils.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+
+#define PUB_KEY_SIZE 32
+#define PRV_KEY_SIZE 64
+#define SIGNATURE_SIZE 64
+#define CIPHER_MAC_SIZE 16
+
+namespace mesh {
+
+class RNG {
+public:
+  virtual ~RNG() = default;
+  virtual void random(uint8_t* dest, size_t sz) = 0;
+};
+
+class Utils {
+public:
+  static void sha256(uint8_t* hash, size_t hash_len, const uint8_t*, int) {
+    std::memset(hash, 0, hash_len);
+  }
+
+  static int encryptThenMAC(const uint8_t*, uint8_t* dest, const uint8_t* src, int src_len) {
+    int out_len = src_len + CIPHER_MAC_SIZE;
+    std::memset(dest, 0xAA, CIPHER_MAC_SIZE);
+    std::memcpy(dest + CIPHER_MAC_SIZE, src, src_len);
+    return out_len;
+  }
+
+  static int MACThenDecrypt(const uint8_t*, uint8_t* dest, const uint8_t* src, int src_len) {
+    if (src_len < CIPHER_MAC_SIZE) {
+      return 0;
+    }
+    int out_len = src_len - CIPHER_MAC_SIZE;
+    std::memcpy(dest, src + CIPHER_MAC_SIZE, out_len);
+    return out_len;
+  }
+};
+
+}

--- a/test/mocks/helpers/SensorManager.h
+++ b/test/mocks/helpers/SensorManager.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+#include "CayenneLPP.h"
+
+class SensorManager {
+public:
+  virtual ~SensorManager() = default;
+  virtual bool querySensors(uint8_t, CayenneLPP&) { return false; }
+};

--- a/test/test_kiss_modem/test_tx_backpressure.cpp
+++ b/test/test_kiss_modem/test_tx_backpressure.cpp
@@ -1,0 +1,294 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include "KissModem.h"
+
+static constexpr int TEST_TX_AVAILABLE_BYTES = 4096;
+static constexpr size_t TEST_DEFAULT_MAX_WRITE_CHUNK = SIZE_MAX;
+static constexpr size_t TEST_PARTIAL_WRITE_CHUNK = 2;
+static constexpr int TEST_PARTIAL_WRITE_FLUSH_LOOPS = 3;
+static constexpr uint8_t TEST_SNR = 8;
+static constexpr uint8_t TEST_RSSI = 200;
+
+class BlockingStream : public Stream {
+public:
+  void pushRx(const std::vector<uint8_t>& bytes) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    for (uint8_t b : bytes) {
+      _rx.push(b);
+    }
+  }
+
+  void setBlockWrites(bool blocked) {
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      _block_writes = blocked;
+    }
+    _cv.notify_all();
+  }
+
+  bool isWriteBlocked() const {
+    return _entered_block.load();
+  }
+
+  size_t writesCount() const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writes.size();
+  }
+
+  std::vector<uint8_t> writesSnapshot() const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writes;
+  }
+
+  int availableForWrite() override {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _block_writes ? 0 : TEST_TX_AVAILABLE_BYTES;
+  }
+
+  void setMaxWriteChunk(size_t chunk) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _max_write_chunk = chunk;
+  }
+
+  size_t write(const uint8_t* buffer, size_t size) override {
+    std::unique_lock<std::mutex> lock(_mutex);
+    while (_block_writes) {
+      _entered_block.store(true);
+      _cv.wait(lock);
+    }
+    const size_t chunk = (size < _max_write_chunk) ? size : _max_write_chunk;
+    for (size_t i = 0; i < chunk; i++) {
+      _writes.push_back(buffer[i]);
+    }
+    return chunk;
+  }
+
+  size_t write(uint8_t b) override {
+    return write(&b, 1);
+  }
+
+  int available() override {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return static_cast<int>(_rx.size());
+  }
+
+  int read() override {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_rx.empty()) {
+      return -1;
+    }
+    int b = _rx.front();
+    _rx.pop();
+    return b;
+  }
+
+private:
+  mutable std::mutex _mutex;
+  std::condition_variable _cv;
+  std::queue<uint8_t> _rx;
+  std::vector<uint8_t> _writes;
+  bool _block_writes = false;
+  std::atomic<bool> _entered_block = false;
+  size_t _max_write_chunk = TEST_DEFAULT_MAX_WRITE_CHUNK;
+};
+
+class FakeRNG : public mesh::RNG {
+public:
+  void random(uint8_t* dest, size_t sz) override {
+    for (size_t i = 0; i < sz; i++) {
+      dest[i] = 0;
+    }
+  }
+};
+
+class FakeRadio : public mesh::Radio {
+public:
+  bool isReceiving() override { return false; }
+  uint32_t getEstAirtimeFor(uint16_t) override { return 10; }
+  bool startSendRaw(const uint8_t*, uint16_t) override {
+    _start_send_count++;
+    return _start_send_result;
+  }
+  bool isSendComplete() override { return _send_complete; }
+  void onSendFinished() override { _send_finished_count++; }
+  int16_t getNoiseFloor() override { return -120; }
+
+  void setStartSendResult(bool result) { _start_send_result = result; }
+  void setSendComplete(bool complete) { _send_complete = complete; }
+  int startSendCount() const { return _start_send_count; }
+  int sendFinishedCount() const { return _send_finished_count; }
+
+private:
+  bool _start_send_result = true;
+  bool _send_complete = true;
+  int _start_send_count = 0;
+  int _send_finished_count = 0;
+};
+
+class FakeBoard : public mesh::MainBoard {
+public:
+  uint16_t getBattMilliVolts() override { return 4200; }
+  float getMCUTemperature() override { return 24.0f; }
+  const char* getManufacturerName() override { return "test-board"; }
+  void reboot() override {}
+};
+
+class FakeSensors : public SensorManager {
+public:
+  bool querySensors(uint8_t, CayenneLPP&) override { return false; }
+};
+
+class KissModemFixture : public ::testing::Test {
+protected:
+  BlockingStream serial;
+  mesh::LocalIdentity identity;
+  FakeRNG rng;
+  FakeRadio radio;
+  FakeBoard board;
+  FakeSensors sensors;
+  KissModem modem;
+
+  KissModemFixture()
+    : modem(serial, identity, rng, radio, board, sensors) {
+    modem.begin();
+  }
+
+  static std::vector<uint8_t> dataFrame(const std::vector<uint8_t>& packet) {
+    std::vector<uint8_t> frame = {KISS_FEND, KISS_CMD_DATA};
+    frame.insert(frame.end(), packet.begin(), packet.end());
+    frame.push_back(KISS_FEND);
+    return frame;
+  }
+
+  void advanceToTxSending() {
+    modem.loop();
+    modem.loop();
+    delay((uint32_t)KISS_DEFAULT_TXDELAY * 10);
+    modem.loop();
+  }
+};
+
+TEST_F(KissModemFixture, PingResponseShouldNotStallLoopUnderTxBackpressure) {
+  serial.setBlockWrites(true);
+  serial.pushRx({KISS_FEND, KISS_CMD_SETHARDWARE, HW_CMD_PING, KISS_FEND});
+
+  auto future = std::async(std::launch::async, [this]() {
+    modem.loop();
+  });
+
+  auto status = future.wait_for(std::chrono::milliseconds(100));
+  EXPECT_EQ(status, std::future_status::ready) << "KissModem::loop blocked in serial write under TX backpressure";
+  EXPECT_FALSE(serial.isWriteBlocked()) << "KissModem entered blocking write path";
+
+  serial.setBlockWrites(false);
+  future.wait();
+  modem.loop();
+  EXPECT_GT(serial.writesCount(), 0U) << "KissModem did not flush queued response after backpressure cleared";
+}
+
+TEST_F(KissModemFixture, PingResponseKeepsStandardKissFraming) {
+  serial.pushRx({KISS_FEND, KISS_CMD_SETHARDWARE, HW_CMD_PING, KISS_FEND});
+  modem.loop();
+
+  const std::vector<uint8_t> expected = {KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP(HW_CMD_PING), KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+TEST_F(KissModemFixture, PingResponseKeepsFramingWithPartialBulkWrites) {
+  serial.setMaxWriteChunk(TEST_PARTIAL_WRITE_CHUNK);
+  serial.pushRx({KISS_FEND, KISS_CMD_SETHARDWARE, HW_CMD_PING, KISS_FEND});
+  for (int i = 0; i < TEST_PARTIAL_WRITE_FLUSH_LOOPS; i++) {
+    modem.loop();
+  }
+
+  const std::vector<uint8_t> expected = {KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP(HW_CMD_PING), KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+TEST_F(KissModemFixture, PacketAndMetaAreQueuedTogetherUnderBackpressure) {
+  static constexpr uint8_t TEST_PACKET[] = {0x01, 0x02, 0x03};
+
+  serial.setBlockWrites(true);
+  modem.onPacketReceived((int8_t)TEST_SNR, (int8_t)TEST_RSSI, TEST_PACKET, sizeof(TEST_PACKET));
+  serial.setBlockWrites(false);
+  modem.loop();
+  modem.loop();
+
+  const std::vector<uint8_t> expected = {
+      KISS_FEND, KISS_CMD_DATA, TEST_PACKET[0], TEST_PACKET[1], TEST_PACKET[2], KISS_FEND,
+      KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_RX_META, TEST_SNR, TEST_RSSI, KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+TEST_F(KissModemFixture, RadioTxCompletionAdvancesWhileHostOutputIsBackedUp) {
+  serial.pushRx(dataFrame({0x42}));
+  advanceToTxSending();
+  ASSERT_EQ(radio.startSendCount(), 1);
+
+  serial.setBlockWrites(true);
+  modem.loop();
+  EXPECT_EQ(radio.sendFinishedCount(), 1);
+  EXPECT_TRUE(modem.isTxBusy());
+
+  serial.setBlockWrites(false);
+  modem.loop();
+
+  const std::vector<uint8_t> expected = {KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_TX_DONE, 0x01, KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+  EXPECT_FALSE(modem.isTxBusy());
+}
+
+TEST_F(KissModemFixture, QueueFullReportsBusyWithoutDroppingQueuedFrames) {
+  static constexpr uint8_t TEST_PACKET_ONE[] = {0x11, 0x12};
+  static constexpr uint8_t TEST_PACKET_TWO[] = {0x21, 0x22};
+
+  serial.setBlockWrites(true);
+  modem.onPacketReceived((int8_t)TEST_SNR, (int8_t)TEST_RSSI, TEST_PACKET_ONE, sizeof(TEST_PACKET_ONE));
+  modem.onPacketReceived((int8_t)TEST_SNR, (int8_t)TEST_RSSI, TEST_PACKET_TWO, sizeof(TEST_PACKET_TWO));
+  serial.setBlockWrites(false);
+  modem.loop();
+
+  const std::vector<uint8_t> expected = {
+      KISS_FEND, KISS_CMD_DATA, TEST_PACKET_ONE[0], TEST_PACKET_ONE[1], KISS_FEND,
+      KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_RX_META, TEST_SNR, TEST_RSSI, KISS_FEND,
+      KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_ERROR, HW_ERR_TX_BUSY, KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+TEST_F(KissModemFixture, QueuedEncoderEscapesKissSpecialBytes) {
+  static constexpr uint8_t TEST_PACKET[] = {KISS_FEND, KISS_FESC, 0x01};
+
+  modem.onPacketReceived((int8_t)TEST_SNR, (int8_t)TEST_RSSI, TEST_PACKET, sizeof(TEST_PACKET));
+
+  const std::vector<uint8_t> expected = {
+      KISS_FEND, KISS_CMD_DATA, KISS_FESC, KISS_TFEND, KISS_FESC, KISS_TFESC, 0x01, KISS_FEND,
+      KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_RX_META, TEST_SNR, TEST_RSSI, KISS_FEND};
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+TEST_F(KissModemFixture, MaxPacketWorstCaseEscapingFitsQueuedFrame) {
+  std::vector<uint8_t> packet(KISS_MAX_PACKET_SIZE, KISS_FEND);
+  std::vector<uint8_t> expected = {KISS_FEND, KISS_CMD_DATA};
+  for (size_t i = 0; i < packet.size(); i++) {
+    expected.push_back(KISS_FESC);
+    expected.push_back(KISS_TFEND);
+  }
+  expected.push_back(KISS_FEND);
+  expected.insert(expected.end(), {KISS_FEND, KISS_CMD_SETHARDWARE, HW_RESP_RX_META, TEST_SNR, TEST_RSSI, KISS_FEND});
+
+  modem.onPacketReceived((int8_t)TEST_SNR, (int8_t)TEST_RSSI, packet.data(), packet.size());
+  EXPECT_EQ(serial.writesSnapshot(), expected);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -432,5 +432,10 @@ lib_deps =
 
 [env:heltec_v4_kiss_modem]
 extends = Heltec_lora32_v4
+build_unflags =
+  -DARDUINO_USB_MODE=0
+build_flags =
+  ${Heltec_lora32_v4.build_flags}
+  -DARDUINO_USB_MODE=1
 build_src_filter = ${Heltec_lora32_v4.build_src_filter}
   +<../examples/kiss_modem/>

--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -241,5 +241,10 @@ lib_deps =
 
 [env:Station_G2_kiss_modem]
 extends = Station_G2
+build_unflags =
+  -DARDUINO_USB_MODE=0
+build_flags =
+  ${Station_G2.build_flags}
+  -DARDUINO_USB_MODE=1
 build_src_filter = ${Station_G2.build_src_filter}
   +<../examples/kiss_modem/>


### PR DESCRIPTION
Switch ESP32-S3 KISS modem environments to HWCDC and move outbound KISS writes to a non-blocking queued frame path so loop() and TX completion keep progressing when the host reads slowly. Add native backpressure regression tests and correct the native_kiss_modem test filter so this suite runs directly with pio test.