### PR TITLE
Add identity sign CLI command

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -405,6 +405,16 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+#### Sign data with this node's identity
+**Usage:** `identity sign <data_hex>`
+
+**Parameters:**
+- `data_hex`: 1-64 bytes encoded as hex
+
+**Returns:** Ed25519 signature encoded as hex
+
+---
+
 #### View this node's firmware version
 **Usage:** `ver`
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -27,6 +27,21 @@ static bool isValidName(const char *n) {
   return true;
 }
 
+static bool parseHexBytes(uint8_t* dest, size_t max_len, const char* hex, size_t* len_out) {
+  size_t hex_len = strlen(hex);
+  if (hex_len == 0 || (hex_len & 1)) return false;
+  if (hex_len / 2 > max_len) return false;
+
+  for (size_t i = 0; i < hex_len; i++) {
+    if (!mesh::Utils::isHexChar(hex[i])) return false;
+  }
+
+  size_t len = hex_len / 2;
+  if (!mesh::Utils::fromHex(dest, len, hex)) return false;
+  *len_out = len;
+  return true;
+}
+
 void CommonCLI::loadPrefs(FILESYSTEM* fs) {
   if (fs->exists("/com_prefs")) {
     loadPrefsInt(fs, "/com_prefs");   // new filename
@@ -298,6 +313,22 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       savePrefs();
       sprintf(reply, "password now: ");
       StrHelper::strncpy(&reply[14], _prefs->password, 160-15);   // echo back just to let admin know for sure!!
+    } else if (memcmp(command, "identity sign", 13) == 0 && (command[13] == 0 || command[13] == ' ')) {
+      const char* hex = &command[13];
+      while (*hex == ' ') hex++;
+
+      uint8_t data[64];
+      size_t data_len = 0;
+      if (*hex == 0) {
+        strcpy(reply, "Usage: identity sign <data_hex>");
+      } else if (!parseHexBytes(data, sizeof(data), hex, &data_len)) {
+        strcpy(reply, "Error: data must be 1-64 bytes hex");
+      } else {
+        uint8_t signature[SIGNATURE_SIZE];
+        _callbacks->getSelfId().sign(signature, data, data_len);
+        strcpy(reply, "> ");
+        mesh::Utils::toHex(&reply[2], signature, SIGNATURE_SIZE);
+      }
     } else if (memcmp(command, "clear stats", 11) == 0) {
       _callbacks->clearStats();
       strcpy(reply, "(OK - stats reset)");


### PR DESCRIPTION
Adds a command to sign arbitrary data with the repeater / room server private key. The use is to authenticate repeater ownership on analysis platforms etc. 

- data is limited to 64 bytes due to CLI input / output buffer limitations, didn't want to change them
- verification command `identity verify <message> <signature>` was planned but scrapped due to the same limitations
- not sure if "identity sign" is the best command name but might be an ok command namespace for future additions
- `mesh::Utils::fromHex()` returns 0 for errors like non-hexchars which is a bit ambiguous so a new helper `parseHexBytes()` was added, this could be inlined of course

Example: I want to view my node's detailed statistics so the platorm asks me to sign a random string (in this case "MeshCore"):

```
identity sign
  -> Usage: identity sign <data_hex>

identity sign 4d657368436f7265
  -> > E861F72FC8BBF2DBB7C4997257289CC0727D48D9A011DF6AF66F264802A1F4BF51FC864A6FF967A16AF6475A4898A23B4F8CF7F0B99A7735C3289F5C6C793802
```

After pasting the resulting signature to the platform it can be certain that I have access to the node and its private key, allowing me to link the repeater to my account.

Note: This function already exists in the KISS firmware as the SetHardware Extensions (0x06) -> SignData (0x04) TNC command and includes the verify command as well. So this brings the same feature to the repeater CLI.