### PR TITLE
feat(sensor): grant read-only telemetry via allow_read_only / guest password

### DIFF
--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -328,19 +328,29 @@ int SensorMesh::getAGCResetInterval() const {
 }
 
 uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* secret, uint32_t sender_timestamp, const uint8_t* data, bool is_flood) {
-  ClientInfo* client;
+  ClientInfo* client = NULL;
   if (data[0] == 0) {   // blank password, just check if sender is in ACL
     client = acl.getClient(sender.pub_key, PUB_KEY_SIZE);
-    if (client == NULL) {
+  #if MESH_DEBUG
+    if (client == NULL) MESH_DEBUG_PRINTLN("Login, sender not in ACL");
+  #endif
+  }
+  if (client == NULL) {
+    // Determine the role this login grants. Admin needs the admin
+    // password; a matching guest password (if set) or the open
+    // allow_read_only switch grants READ_ONLY, which is enough to read
+    // telemetry (current + min/avg/max history). Mirrors the login
+    // cascade used by the repeater and room-server examples.
+    uint8_t perms;
+    if (strcmp((char *) data, _prefs.password) == 0) {  // valid admin password
+      perms = PERM_ACL_ADMIN;
+    } else if (_prefs.guest_password[0] != 0 && strcmp((char *) data, _prefs.guest_password) == 0) {
+      perms = PERM_ACL_READ_ONLY;   // matched the configured guest password
+    } else if (_prefs.allow_read_only) {
+      perms = PERM_ACL_READ_ONLY;   // open read-only telemetry for everyone
+    } else {
     #if MESH_DEBUG
-      MESH_DEBUG_PRINTLN("Login, sender not in ACL");
-    #endif
-      return 0;
-    }
-  } else {
-    if (strcmp((char *) data, _prefs.password) != 0) {  // check for valid admin password
-    #if MESH_DEBUG
-      MESH_DEBUG_PRINTLN("Invalid password: %s", &data[4]);
+      MESH_DEBUG_PRINTLN("Invalid password");
     #endif
       return 0;
     }
@@ -354,10 +364,12 @@ uint8_t SensorMesh::handleLoginReq(const mesh::Identity& sender, const uint8_t* 
     MESH_DEBUG_PRINTLN("Login success!");
     client->last_timestamp = sender_timestamp;
     client->last_activity = getRTCClock()->getCurrentTime();
-    client->permissions |= PERM_ACL_ADMIN;
+    client->permissions = (client->permissions & ~PERM_ACL_ROLE_MASK) | perms;
     memcpy(client->shared_secret, secret, PUB_KEY_SIZE);
 
-    dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
+    if (perms != PERM_ACL_READ_ONLY) {   // avoid an FS write per transient read-only viewer
+      dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
+    }
   }
 
   if (is_flood) {


### PR DESCRIPTION
Related to #2005

## Summary

`SensorMesh::handleLoginReq` previously accepted only the admin password or an existing ACL entry, so the `guest_password` and `allow_read_only` preferences — which already exist in the common CLI and are honoured by the repeater and room-server examples — were **inert for sensor nodes**. There was no way to expose telemetry to non-admin clients without handing out the admin password or pre-authorising each public key with `setperm`.

This ports the same login cascade used by `simple_repeater` and `simple_room_server` into the sensor, so the existing settings finally do something on a sensor node.

## Behaviour

On a login where the sender isn't already a known contact, the granted role is now:

- **admin password** → `PERM_ACL_ADMIN` (unchanged)
- **matching `guest_password`** (when one is set) → `PERM_ACL_READ_ONLY`
- **`allow_read_only` enabled** → `PERM_ACL_READ_ONLY` for everyone
- otherwise → rejected (unchanged)

`READ_ONLY` is the level that unlocks both current telemetry and the min/avg/max history (`REQ_TYPE_GET_AVG_MIN_MAX`), while admin actions stay password-gated. Transient read-only viewers are not persisted to flash, avoiding an FS write per viewer.

## How to enable

Over serial or the companion admin console:

```
# open it up to everyone (read-only):
set allow.read.only on

# OR gate it behind a shared guest password:
set guest.password <password>
```

`get allow.read.only` / `get guest.password` read the current values back.

## Testing

Tested on hardware (RAK4631) and confirmed working end-to-end:

- **`allow.read.only on`** — a non-admin client with no password is granted read-only and can read telemetry. Works cleanly.
- **Guest password** (`set guest.password <pw>`) — the node authenticates the login, grants `READ_ONLY`, and telemetry is accessible afterward (verified via the node's `Login success!` debug and a successful telemetry read).

### iOS companion app limitation

The MeshCore **iOS** app's password prompt for a node is an *admin* login. When you log into a sensor with the **guest** password, the app shows an **"access denied"** error — because the node returns a successful but non-admin login (`isAdmin = 0`), which the admin-oriented UI rejects. **Despite the error, the login succeeds at the protocol level and telemetry is accessible afterward.** So the guest-password path is functional; the error is purely a client-side UI limitation, not a firmware issue. The `allow.read.only` path is unaffected and works without any error in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)