### PR TITLE
companion_radio: tear down QSPI peripheral when its init fails (fixes #2827)

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -139,6 +139,18 @@ void setup() {
     if (!QSPIFlash.begin()) {
       // debug output might not be available at this point, might be too early. maybe should fall back to InternalFS here?
       MESH_DEBUG_PRINTLN("CustomLFS_QSPIFlash: failed to initialize");
+    #if defined(NRF52_PLATFORM)
+      // A failed QSPI init (e.g. nrfx_qspi_init() returning NRFX_ERROR_TIMEOUT)
+      // leaves the QSPI peripheral enabled and QSPI_IRQn enabled in the NVIC
+      // (at priority 0, which is reserved for the SoftDevice) and does NOT clean
+      // up after itself. That poisons the subsequent SoftDevice enable
+      // (Bluefruit.begin()), so on BLE builds the node never advertises (#2827).
+      // Tear the peripheral down so the SoftDevice can start cleanly.
+      NVIC_DisableIRQ(QSPI_IRQn);
+      NVIC_ClearPendingIRQ(QSPI_IRQn);
+      NRF_QSPI->TASKS_DEACTIVATE = 1;
+      NRF_QSPI->ENABLE = 0;
+    #endif
     } else {
       MESH_DEBUG_PRINTLN("CustomLFS_QSPIFlash: initialized successfully");
     }


### PR DESCRIPTION
## Problem
On nRF52 BLE companion builds, a failed external-flash init leaves BLE completely dead. The Elecrow ThinkNode M6 never advertises over BLE on any firmware version (#2827), even though the same unit runs fine over LoRa and pairs over BLE under other firmware.

## Root cause
When `nrfx_qspi_init()` fails (the M6 returns `NRFX_ERROR_TIMEOUT` / `0xBAD0007` during QSPI activation), it has **already** enabled the QSPI peripheral and enabled `QSPI_IRQn` in the NVIC at priority 0 (reserved for the SoftDevice) — and cleans none of it up before returning. The next step, `Bluefruit.begin()` enabling the SoftDevice, then fails; every later BLE call returns `NRF_ERROR_SOFTDEVICE_NOT_ENABLED`, so the node never advertises. USB companion builds are unaffected because they never enable the SoftDevice.

## Fix
On the `QSPIFlash.begin()` failure path, disable `QSPI_IRQn` and power the QSPI peripheral back down before continuing. Runs only on the failure path, so boards whose QSPI init succeeds are unaffected.

## Validation
On a ThinkNode M6 (with the QSPI init still timing out): the SoftDevice now enables, the node advertises, and the MeshCore app pairs and exchanges frames. Confirmed via boot-stage instrumentation that the SoftDevice enable goes from failing to succeeding once the peripheral is torn down.

## Notes
The underlying M6 QSPI-init timeout is a separate issue (the custom QSPI flash driver doesn't bring up the `MX25R1635F`); this PR makes BLE robust to that failure rather than fixing the flash itself.

Closes #2225 
