### PR TITLE
ThinkNode M6: enable status LED, button and low-battery shutdown (run UITask)

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -88,7 +88,9 @@ class HomeScreen : public UIScreen {
     FIRST,
     RECENT,
     RADIO,
+#ifndef UI_HIDE_BLUETOOTH_PAGE
     BLUETOOTH,
+#endif
     ADVERT,
 #if ENV_INCLUDE_GPS == 1
     GPS,
@@ -278,6 +280,7 @@ public:
       display.setCursor(0, 53);
       sprintf(tmp, "Noise floor: %d", radio_driver.getNoiseFloor());
       display.print(tmp);
+#ifndef UI_HIDE_BLUETOOTH_PAGE
     } else if (_page == HomePage::BLUETOOTH) {
       display.setColor(DisplayDriver::GREEN);
       display.drawXbm((display.width() - 32) / 2, 18,
@@ -285,6 +288,7 @@ public:
           32, 32);
       display.setTextSize(1);
       display.drawTextCentered(display.width() / 2, 64 - 11, "toggle: " PRESS_LABEL);
+#endif
     } else if (_page == HomePage::ADVERT) {
       display.setColor(DisplayDriver::GREEN);
       display.drawXbm((display.width() - 32) / 2, 18, advert_icon, 32, 32);
@@ -425,6 +429,7 @@ public:
       }
       return true;
     }
+#ifndef UI_HIDE_BLUETOOTH_PAGE
     if (c == KEY_ENTER && _page == HomePage::BLUETOOTH) {
       if (_task->isSerialEnabled()) {  // toggle Bluetooth on/off
         _task->disableSerial();
@@ -433,6 +438,7 @@ public:
       }
       return true;
     }
+#endif
     if (c == KEY_ENTER && _page == HomePage::ADVERT) {
       _task->notify(UIEventType::ack);
       if (the_mesh.advert()) {

--- a/variants/thinknode_m6/platformio.ini
+++ b/variants/thinknode_m6/platformio.ini
@@ -85,12 +85,16 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
   -D QSPIFLASH=1
+  -D DISPLAY_CLASS=NullDisplayDriver
+  -D PIN_STATUS_LED=PIN_LED_RED
+  -D UI_HIDE_BLUETOOTH_PAGE
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M6.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${ThinkNode_M6.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -109,10 +113,14 @@ build_flags =
   -D QSPIFLASH=1
   -D OFFLINE_QUEUE_SIZE=256
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
+  -D DISPLAY_CLASS=NullDisplayDriver
+  -D PIN_STATUS_LED=PIN_LED_RED
+  -D UI_HIDE_BLUETOOTH_PAGE
 build_src_filter = ${ThinkNode_M6.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
   ${ThinkNode_M6.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/thinknode_m6/target.h
+++ b/variants/thinknode_m6/target.h
@@ -10,7 +10,9 @@
 #include <helpers/sensors/EnvironmentSensorManager.h>
 #include <helpers/sensors/LocationProvider.h>
 #ifdef DISPLAY_CLASS
-  #include <helpers/ui/GxEPDDisplay.h>
+  // The M6 is screenless; DISPLAY_CLASS=NullDisplayDriver is used only to run
+  // UITask headless so the status LED (PIN_STATUS_LED) and button work.
+  #include <helpers/ui/NullDisplayDriver.h>
   #include <helpers/ui/MomentaryButton.h>
 #endif
 


### PR DESCRIPTION
## Problem
The Elecrow ThinkNode M6's two LEDs work in the bootloader and on other firmware, but the MeshCore companion builds give no status indication. The red LED (P0.12) is initialised off and never used again; the blue LED only blinks on LoRa TX.

## Cause
The companion status LED, user-button handling, and low-battery auto-shutdown all live in `UITask`, which is only instantiated when `DISPLAY_CLASS` is defined. The M6 is screenless, so `UITask` never ran — `PIN_STATUS_LED` was never set, the button was inert, and even the `AUTO_SHUTDOWN_MILLIVOLTS=3300` flag already in the env had no effect.

## Fix
Run `UITask` headless with `NullDisplayDriver`, exactly as the other screenless boards (t1000-e, RAK WisMesh Tag) do, and define `PIN_STATUS_LED`. This enables, on both `companion_radio_ble` and `companion_radio_usb`:

- **Status LED** on the previously-unused **red** LED — heartbeat (brief blink every ~4 s, longer when there are unread messages). The blue LED keeps its LoRa-TX function.
- **User button** — navigation + long-press select, same as other screenless boards. Groundwork toward the button-shutdown request in #2313.
- **Low-battery auto-shutdown** at 3.3 V — previously configured but dormant.

### Screenless-safe button menu
Because the M6 has no screen, this also hides the **Bluetooth toggle page** from the button menu, behind a new opt-in `UI_HIDE_BLUETOOTH_PAGE` flag (no effect on boards that don't set it). On a screenless node, a blind long-press on that page would silently disable BLE with no way to see it or undo it. With it hidden, the reachable button actions are **send-advert / GPS-toggle / hibernate**, which are all safe to trigger blind.

The LED pins/polarity were already correct (RED=12, BLUE=7, active-high), so no hardware-config change is needed — only `target.h` (use `NullDisplayDriver`), the two env definitions, and the `UI_HIDE_BLUETOOTH_PAGE` guards in `UITask.cpp`.

## Testing
Built and flashed on a ThinkNode M6: the red LED shows the heartbeat and blinks longer with unread messages; the blue TX blink is unchanged; the Bluetooth page is gone from the menu. Both companion BLE and USB build and run.

## Notes
Relates to #2313 (Shutdown for ThinkNode M6) — this makes the user button active, a prerequisite for button-driven shutdown, though it doesn't add a dedicated long-press-shutdown/wakeup mapping itself.
