### PR TITLE
GPS: poll up to 5s for cold-start detection instead of a single 1s check

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -748,14 +748,18 @@ void EnvironmentSensorManager::initBasicGPS() {
     MESH_DEBUG_PRINTLN("No GPS wake/reset pin found for this board. Continuing on...");
   #endif
 
-  // Give GPS a moment to power up and send data
-  delay(1000);
-
-  // We'll consider GPS detected if we see any data on Serial1
+  // Give the GPS time to power up and emit its first NMEA sentence. Cold-start
+  // modules can take several seconds, so poll for up to ~5s instead of checking
+  // once after a fixed 1s delay -- returning as soon as any data appears, so
+  // fast modules add no boot delay (issue #2258).
 #ifdef ENV_SKIP_GPS_DETECT
   gps_detected = true;
 #else
-  gps_detected = (Serial1.available() > 0);
+  gps_detected = false;
+  for (int i = 0; i < 20 && !gps_detected; i++) {
+    delay(250);
+    gps_detected = (Serial1.available() > 0);
+  }
 #endif
 
   if (gps_detected) {


### PR DESCRIPTION
## Problem
`EnvironmentSensorManager::initBasicGPS()` waits a fixed **1 second**, then decides the GPS is present only if NMEA data has already arrived. Cold-start GPS modules often need **2–5 seconds** before emitting their first sentence, so on a cold boot detection frequently fails.

A failed detection sets `gps_detected = false`, which **hides all GPS CLI settings and disables GPS time sync until the next reboot** — so the GPS appears permanently dead even though the hardware is fine. This affects the ~20 GPS-equipped variants that don't set the `ENV_SKIP_GPS_DETECT`/`PERSISTANT_GPS` bypass flags.

## Fix
Poll for up to ~5 seconds (in 250 ms steps) and return **as soon as any data appears**. Fast modules are detected almost immediately and add no boot delay; slow cold-start modules now get enough time. The `ENV_SKIP_GPS_DETECT` bypass is unchanged.

## Trade-off
Boards that have `ENV_INCLUDE_GPS` but no physical GPS will now wait the full ~5 s at boot (vs. 1 s before), since detection never succeeds. This seemed the right call given the alternative is GPS silently not working, but happy to shorten the cap if preferred.

## Testing
Builds clean (verified on a ThinkNode M6 companion build). The change is a drop-in replacement for the single check.

Fixes #2258.
