### PR TITLE
Encourage adoption of regions and multi-byte hashes

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -428,6 +428,10 @@ void MyMesh::sendFloodReply(mesh::Packet* packet, unsigned long delay_millis, ui
 
 bool MyMesh::allowPacketForward(const mesh::Packet *packet) {
   if (_prefs.disable_fwd) return false;
+  if (packet->getPathHashCount() > _prefs.repeat_unrestricted_hops) {
+    if (packet->getRouteType() == ROUTE_TYPE_FLOOD) return false;
+    if (packet->getPathHashSize() < _prefs.repeat_restrict_path_hash_size) return false;
+  }
   if (packet->isRouteFlood()) {
     if (packet->getPathHashCount() >= _prefs.flood_max) return false;
     if (packet->getRouteType() == ROUTE_TYPE_FLOOD && packet->getPathHashCount() >= _prefs.flood_max_unscoped) return false;
@@ -892,6 +896,8 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.flood_max = 64;
   _prefs.flood_max_unscoped = 64;
   _prefs.flood_max_advert = 8;
+  _prefs.repeat_unrestricted_hops = 64; // disabled
+  _prefs.repeat_restrict_path_hash_size = 1; // min x for x-Byte paths
   _prefs.interference_threshold = 0; // disabled
   _prefs.cad_enabled = 0;            // hardware CAD before TX (off by default; 'set cad on')
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -93,7 +93,9 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));             // 292
     file.read((uint8_t *)&_prefs->radio_fem_rxgain, sizeof(_prefs->radio_fem_rxgain));             // 293
     file.read((uint8_t *)&_prefs->cad_enabled, sizeof(_prefs->cad_enabled));                       // 294
-    // next: 295
+    file.read((uint8_t *)&_prefs->repeat_unrestricted_hops, sizeof(_prefs->repeat_unrestricted_hops)); // 295
+    file.read((uint8_t *)&_prefs->repeat_restrict_path_hash_size, sizeof(_prefs->repeat_restrict_path_hash_size)); // 296
+    // next: 297
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -190,7 +192,9 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));             // 292
     file.write((uint8_t *)&_prefs->radio_fem_rxgain, sizeof(_prefs->radio_fem_rxgain));             // 293
     file.write((uint8_t *)&_prefs->cad_enabled, sizeof(_prefs->cad_enabled));                       // 294
-    // next: 295
+    file.write((uint8_t *)&_prefs->repeat_unrestricted_hops, sizeof(_prefs->repeat_unrestricted_hops)); // 295
+    file.write((uint8_t *)&_prefs->repeat_restrict_path_hash_size, sizeof(_prefs->repeat_restrict_path_hash_size)); // 296
+    // next: 297
 
     file.close();
   }
@@ -662,6 +666,24 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     } else {
       strcpy(reply, "Error, max 64");
     }
+  } else if (memcmp(config, "repeat.unrestricted.hops ", 25) == 0) {
+    uint8_t m = atoi(&config[25]);
+    if (m <= 64) {
+      _prefs->repeat_unrestricted_hops = m;
+      savePrefs();
+      strcpy(reply, "OK");
+    } else {
+      strcpy(reply, "Error, max 64");
+    }
+  } else if (memcmp(config, "repeat.restrict.path.hash.size ", 31) == 0) {
+    uint8_t m = atoi(&config[31]);
+    if (m >= 1 && m <= 3) {
+      _prefs->repeat_restrict_path_hash_size = m;
+      savePrefs();
+      strcpy(reply, "OK");
+    } else {
+      strcpy(reply, "Error, between 1 and 3");
+    }
   } else if (memcmp(config, "flood.max ", 10) == 0) {
     uint8_t m = atoi(&config[10]);
     if (m <= 64) {
@@ -829,6 +851,10 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", tmp);
   } else if (memcmp(config, "name", 4) == 0) {
     sprintf(reply, "> %s", _prefs->node_name);
+  } else if (memcmp(config, "repeat.restrict.path.hash.size", 30) == 0) {
+    sprintf(reply, "> %d", _prefs->repeat_restrict_path_hash_size);
+  } else if (memcmp(config, "repeat.unrestricted.hops", 24) == 0) {
+    sprintf(reply, "> %d", _prefs->repeat_unrestricted_hops);
   } else if (memcmp(config, "repeat", 6) == 0) {
     sprintf(reply, "> %s", _prefs->disable_fwd ? "off" : "on");
   } else if (memcmp(config, "lat", 3) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -42,6 +42,8 @@ struct NodePrefs { // persisted to file
   uint8_t flood_max;
   uint8_t flood_max_unscoped;
   uint8_t flood_max_advert;
+  uint8_t repeat_unrestricted_hops;
+  uint8_t repeat_restrict_path_hash_size;
   uint8_t interference_threshold;
   uint8_t agc_reset_interval; // secs / 4
   // Bridge settings


### PR DESCRIPTION
This patch defines two new settings for repeaters.

- `repeat.unrestricted.hops` (default 64) defines the number of hops for which the repeater will not apply any restrictions to packets.
- `repeat.restrict.path.hash.size` (default 1) defines the minimum path hash size which the repeater will require for repeating packets with restrictions applying.

# How
The repeater will first look whether restrictions should apply to incoming packets by evaluating their path length and comparing them with `repeat.unrestricted.hops`. If the path length is exceeding this maximum and restrictions apply, packets without transport codes (aka scope or region) will be discarded. Packets with transport codes will be considered for repeating if their path hash size is at least matching the minimum `repeat.restrict.path.hash.size`. All other mainstream repeater restrictions (`flood.max`, `flood.max.unscoped`, `flood.max.advert`, scope/region logic, etc.) apply _after_ these new checks.

The default values make sure that the new settings won't affect the repeater until explicitly set.

# Why
The recommended settings will create a safe zone of three hops which newbies can use to get in contact with others no matter whether they have regions or hash sizes set to modern values. Other mesh users in this hop proximity can instruct these newbies how to adjust their settings for achieving a wider message distribution range, for instance by using regions and avoiding ID/path collisions by using multi-byte hash sizes.

# Recommended settings
```
set repeat.unrestricted.hops 2       // the repeater will add itself as hop 3
set repeat.restrict.path.hash.size 2 // deny 1-byte, allow 2 and 3-byte hashes
region allowf *                      // reset to default
set flood.max 64                     // reset to no-op/default
set flood.max.unscoped 64            // reset to no-op/default
set flood.max.advert 8               // reset to default
```