### PR TITLE
Enable warnings for the project

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,32 @@
+name: 'Run Stale Bot'
+on:
+  schedule:
+    - cron: '30 1 * * *' # daily at 1:30am
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-issues:
+    # only run on main repo, not forks
+    if: github.repository == "meshcore-dev/MeshCore"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # auto close issues
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          exempt-issue-labels: "keep-open"
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Remove the stale label or add a comment if this issue is still relevant, otherwise this issue will automatically close in 7 days."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          # don't auto close prs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   close-issues:
     # only run on main repo, not forks
-    if: github.repository == "meshcore-dev/MeshCore"
+    if: github.repository == 'meshcore-dev/MeshCore'
     runs-on: ubuntu-latest
     steps:
       - name: Close Stale Issues

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release only. We do not backport
+fixes to older versions.
+
+| Version | Supported |
+|---------|-----------|
+| 1.15+ | ✅ |
+| <1.15 | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Use GitHub's private vulnerability reporting instead:
+1. Go to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill in the details and submit
+
+### What to include
+
+A useful report tells us:
+- Which component or file is affected
+- What an attacker can do (impact) and under what conditions
+- A minimal reproduction case or proof-of-concept if you have one
+- Whether you believe it is remotely exploitable
+
+You do not need a working exploit to report. An incomplete report is better
+than no report.
+
+## What to expect
+
+This is a volunteer-maintained open-source project. We will do our best to
+respond in a reasonable timeframe, but cannot commit to specific deadlines.
+
+We ask that you give us a fair opportunity to investigate and address the
+issue before any public disclosure. If you have not heard back after
+**90 days**, feel free to follow up or proceed with disclosure at your
+discretion.
+
+## Scope
+
+In scope:
+- Remote code execution, memory corruption, or denial-of-service via crafted
+  radio packets
+- Authentication or encryption bypasses
+- Vulnerabilities in the packet routing or path handling logic
+
+Out of scope:
+- Physical access attacks (e.g., JTAG, UART extraction of keys)
+- Regulatory compliance (duty cycle, frequency restrictions)
+- Jamming or other physical-layer radio interference
+- Issues in third-party libraries (RadioLib, Crypto, etc.) — report those
+  upstream
+- "Best practice" suggestions without a demonstrated attack path

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -35,8 +35,8 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ### Power-off the node
 **Usage:**
 - `poweroff`, or
-- `shutdown
-`
+- `shutdown`
+
 **Note:** No reply is sent.
 
 ---
@@ -645,7 +645,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Parameters:**
 - `value`: Maximum flood hop count (0-64) for a packet without a scope (no region set)
 
-**Default:** `64` - indicates it hasn't been set, will track flood.max until it is.
+**Default:** `64` - (`0xFF` indicates it hasn't been set, will track flood.max until it is.)
 
 **Note:** An alternative to `region denyf *`, setting `flood.max.unscoped` to a lower value such as `3` would allow for local unscoped messages to propagate, while preventing noisy neighbors from flooding a local region.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -28,11 +28,24 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Usage:** 
 - `reboot`
 
+**Note:** No reply is sent.
+
+---
+
+### Power-off the node
+**Usage:**
+- `poweroff`, or
+- `shutdown
+`
+**Note:** No reply is sent.
+
 ---
 
 ### Reset the clock and reboot
 **Usage:**
 - `clkreboot`
+
+**Note:** No reply is sent.
 
 ---
 
@@ -632,10 +645,21 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Parameters:**
 - `value`: Maximum flood hop count (0-64) for a packet without a scope (no region set)
 
-**Default:** `0xFF` - indicates it hasn't been set, will track flood.max until it is.
+**Default:** `64` - indicates it hasn't been set, will track flood.max until it is.
 
 **Note:** An alternative to `region denyf *`, setting `flood.max.unscoped` to a lower value such as `3` would allow for local unscoped messages to propagate, while preventing noisy neighbors from flooding a local region.
 
+---
+
+#### Limit the number of hops for an advert flood message
+**Usage:**
+- `get flood.max.advert`
+- `set flood.max.advert <value>`
+
+**Parameters:**
+- `value`: Maximum flood hop count (0-64) for an advert packet
+
+**Default:** `8`
 
 ---
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0
   electroniccats/CayenneLPP @ 1.6.1
-build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
+build_flags = -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D LORA_FREQ=869.618
   -D LORA_BW=62.5
   -D LORA_SF=8
@@ -45,6 +45,11 @@ build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D RADIOLIB_EXCLUDE_BELL=1
   -D RADIOLIB_EXCLUDE_RTTY=1
   -D RADIOLIB_EXCLUDE_SSTV=1
+; warnings
+build_src_flags =
+  -Wall -Wextra
+  -Wcast-align -Wnull-dereference -Wconversion -Wsign-conversion
+  -Wshadow -Wdouble-promotion -Wfloat-equal -Wuseless-cast
 build_src_filter =
   +<*.cpp>
   +<helpers/*.cpp>
@@ -90,6 +95,13 @@ build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM
   -D LFS_NO_ASSERT=1
   -D EXTRAFS=1
+  ; SoftDevice/CMSIS SDK headers as -isystem so their warnings are dropped.
+  -isystem "lib/nrf52/include"
+  -isystem "lib/nrf52/s140_nrf52_7.3.0_API/include"
+  -isystem "lib/nrf52/s140_nrf52_7.3.0_API/include/nrf52"
+  -isystem "${platformio.packages_dir}/framework-arduinoadafruitnrf52/cores/nRF5/nordic/softdevice/s140_nrf52_7.3.0_API/include"
+  -isystem "${platformio.packages_dir}/framework-arduinoadafruitnrf52/cores/nRF5/nordic/softdevice/s140_nrf52_7.3.0_API/include/nrf52"
+  -isystem "${platformio.packages_dir}/framework-cmsis/CMSIS/Core/Include"
 lib_deps =
   ${arduino_base.lib_deps}
   https://github.com/oltaco/CustomLFS#0.2.2


### PR DESCRIPTION
Currently all warnings are suppressed, this is simply dangerous. There's a lot that has accumulated that should now be cleaned up.

The GCC version used is also incredibly old, this results in significantly worse codegen (GCC 7 binaries are 60kB bigger for my T1000-E) and diagnostics. GCC should be updated at first opportunity.

Old GCC also hinders excluding certain vendorized third-party dependencies from diagnostics.