### PR TITLE
Enable warnings for the project

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0
   electroniccats/CayenneLPP @ 1.6.1
-build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
+build_flags = -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D LORA_FREQ=869.618
   -D LORA_BW=62.5
   -D LORA_SF=8
@@ -45,6 +45,10 @@ build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D RADIOLIB_EXCLUDE_BELL=1
   -D RADIOLIB_EXCLUDE_RTTY=1
   -D RADIOLIB_EXCLUDE_SSTV=1
+build_src_flags =
+  -Wall -Wextra
+  -Wcast-align -Wnull-dereference -Wconversion -Wsign-conversion
+  -Wshadow -Wdouble-promotion -Wfloat-equal -Wuseless-cast
 build_src_filter =
   +<*.cpp>
   +<helpers/*.cpp>
@@ -90,6 +94,13 @@ build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM
   -D LFS_NO_ASSERT=1
   -D EXTRAFS=1
+  ; SoftDevice/CMSIS SDK headers as -isystem so their warnings are dropped
+  -isystem "lib/nrf52/include"
+  -isystem "lib/nrf52/s140_nrf52_7.3.0_API/include"
+  -isystem "lib/nrf52/s140_nrf52_7.3.0_API/include/nrf52"
+  -isystem "${platformio.packages_dir}/framework-arduinoadafruitnrf52/cores/nRF5/nordic/softdevice/s140_nrf52_7.3.0_API/include"
+  -isystem "${platformio.packages_dir}/framework-arduinoadafruitnrf52/cores/nRF5/nordic/softdevice/s140_nrf52_7.3.0_API/include/nrf52"
+  -isystem "${platformio.packages_dir}/framework-cmsis/CMSIS/Core/Include"
 lib_deps =
   ${arduino_base.lib_deps}
   https://github.com/oltaco/CustomLFS#0.2.2


### PR DESCRIPTION
Currently all warnings are suppressed, this is simply dangerous. There's a lot that has accumulated that should now be cleaned up.

The GCC version used is also incredibly old, this results in significantly worse codegen (GCC 7 binaries are 60kB bigger for my T1000-E) and diagnostics. GCC should be updated at first opportunity.

Old GCC also hinders excluding certain vendorized third-party dependencies from diagnostics.