### PR TITLE
Add Data-Type to number_allocations.md

### DIFF
--- a/docs/number_allocations.md
+++ b/docs/number_allocations.md
@@ -17,6 +17,7 @@ Once you have a working app/project, you need to be able to demonstrate it exist
 | 0000 - 00FF     | -reserved for internal use- |                                                                   |
 | 0100            | MeshCore Open               | zsylvester@monitormx.com — https://github.com/zjs81/meshcore-open |
 | 0110 - 011F     | Ripple                      | ripple_biz@protonmail.com — https://buymeacoffee.com/ripplebiz    |
+| 0120 - 0121     | MCOimg                      | most.original.address@gmail.com — https://hdden.ru/MCOimg/        |
 | FF00 - FFFF     | -reserved for testing/dev-  |                                                                   |
 
 (add rows, inside the range 0100 - FEFF for custom apps)

--- a/docs/number_allocations.md
+++ b/docs/number_allocations.md
@@ -17,7 +17,7 @@ Once you have a working app/project, you need to be able to demonstrate it exist
 | 0000 - 00FF     | -reserved for internal use- |                                                                   |
 | 0100            | MeshCore Open               | zsylvester@monitormx.com — https://github.com/zjs81/meshcore-open |
 | 0110 - 011F     | Ripple                      | ripple_biz@protonmail.com — https://buymeacoffee.com/ripplebiz    |
-| 0120 - 0121     | MCOimg                      | most.original.address@gmail.com — https://hdden.ru/MCOimg/        |
+| 0120            | MCO Advanced                | most.original.address@gmail.com — https://hdden.ru/MCOa/          |
 | FF00 - FFFF     | -reserved for testing/dev-  |                                                                   |
 
 (add rows, inside the range 0100 - FEFF for custom apps)


### PR DESCRIPTION
Added Data-Type range for MeshCore Images codec (range is for small reserve to future versions). Now its implemented in [fork of «meshcore_open»](https://github.com/HDDen/meshcore-open/tree/rename-mco-advanced-alfa-build) and in [online demo](https://hdden.ru/MCOimg/).