### PR TITLE
thinknode_m6: don't drive GPS REINIT pin so the L76K is detected

### DIFF
--- a/variants/thinknode_m6/variant.cpp
+++ b/variants/thinknode_m6/variant.cpp
@@ -30,6 +30,8 @@ void initVariant() {
   digitalWrite(PIN_GPS_STANDBY, HIGH);
   pinMode(PIN_GPS_EN, OUTPUT);
   digitalWrite(PIN_GPS_EN, HIGH);
-  pinMode(PIN_GPS_RESET, OUTPUT);
-  digitalWrite(PIN_GPS_RESET, HIGH);
+  // PIN_GPS_RESET (pin 29 / REINIT) is intentionally left floating (input).
+  // Driving it HIGH holds the L76K silent, so it never streams NMEA and the
+  // firmware reports "no GPS". Letting it float lets the module run, matching
+  // the Meshtastic M6 variant. See GPS_RESET (-1) in variant.h.
 }

--- a/variants/thinknode_m6/variant.h
+++ b/variants/thinknode_m6/variant.h
@@ -102,7 +102,12 @@
 #define PIN_GPS_RX              (2)
 #define PIN_GPS_TX              (3)
 #define PIN_GPS_EN              (6)    // EN
-#define PIN_GPS_RESET           (29)
+#define PIN_GPS_RESET           (29)   // REINIT - must FLOAT; driving it (esp. HIGH) silences the L76K
+// The M6's L76K streams NMEA on its own and must not have its REINIT pin driven.
+// Tell the location provider there is no reset pin so it never touches pin 29
+// (driving it HIGH holds the module silent). Matches Meshtastic, which leaves
+// this pin as an input. See variant.cpp (pin 29 is intentionally not configured).
+#define GPS_RESET               (-1)
 #define PIN_GPS_STANDBY         (30)   // STANDBY
 #define PIN_GPS_PPS             (31)
 #define GPS_BAUD_RATE           9600


### PR DESCRIPTION
## Problem

On the ThinkNode M6, the L76K GPS was never detected — the companion app reported "no GPS / not supported", and on-device the GPS stayed at `sat 0`. The same sealed unit's GPS works fine under Meshtastic, so the hardware is good.

## Root cause

Pin 29 (`PIN_GPS_RESET`, which is the module's **REINIT** line on this board) was being driven **HIGH**, which holds the L76K silent — it never emits any NMEA, so detection (`Serial1.available()`) sees zero bytes and the GPS setting is hidden.

It was driven HIGH in two places:
- `variants/thinknode_m6/variant.cpp` `initVariant()` drove it HIGH at boot.
- Because `PIN_GPS_RESET` was defined, `MicroNMEALocationProvider::begin()` also drove it HIGH (`GPS_RESET` = 29, `GPS_RESET_FORCE` = LOW, so `begin()` writes `!LOW` = HIGH).

The Meshtastic M6 variant leaves this exact pin as a floating input and never drives it — which is why GPS works there.

## Verification (no logic analyzer; M6 is a sealed unit)

A standalone sketch powered the GPS and passively captured NMEA at 9600 baud while changing **one variable at a time**:

| pin 29 state | result |
| --- | --- |
| driven HIGH (current firmware) | **0 bytes** |
| left floating (INPUT) | **full NMEA stream** (`$GNGGA/$GNRMC/$GNGSA/$GNGSV`) |

An EN power-cycle was tried as well and made no difference — floating pin 29 alone is sufficient.

The GPS streams standard NMEA at 9600 by default and needs no `$PCAS`/config commands.

## Fix

- `variant.h`: define `GPS_RESET (-1)` so the location provider never touches pin 29.
- `variant.cpp`: stop driving pin 29; leave it floating.

This matches the Meshtastic M6 variant. Confirmed on hardware: GPS is now detected and the app shows live coordinates, altitude, and map position.

Fixes #2862.

## Note for maintainers

The same pattern may affect other Elecrow ThinkNode boards whose reset pin is labeled "REINIT" — notably the **M3** (`variant.h` has `PIN_GPS_RESET (25) // REINIT`), which has a matching open report (#1864). I don't have M3 hardware to verify, so it's intentionally left out of this PR.
