### PR TITLE
thinknode_m1: stop GPS code from driving the LoRa radio power pin

### DIFF
--- a/variants/thinknode_m1/variant.h
+++ b/variants/thinknode_m1/variant.h
@@ -137,7 +137,12 @@ extern const int SCK;
 #define PIN_GPS_RX              (40)
 #define PIN_GPS_TX              (41)
 #define GPS_EN                  (34)
-#define PIN_GPS_RESET           (37)
+// NOTE: pin 37 is the LoRa radio power enable (SX126X_POWER_EN), NOT a GPS reset.
+// It must not be defined as PIN_GPS_RESET: the location provider drives the GPS
+// reset pin in begin()/stop(), so doing so would toggle the radio's power -- in
+// particular, turning GPS off would cut power to the LoRa radio. The M1 GPS has
+// no MCU-controlled reset line, so tell the provider there is none.
+#define GPS_RESET               (-1)
 #define PIN_GPS_PPS             (36)
 #define PIN_GPS_STANDBY         (34)
 #define PIN_GPS_SWITCH          (33)


### PR DESCRIPTION
## Problem

On the ThinkNode M1, pin 37 is the **LoRa radio power enable** (`SX126X_POWER_EN=37`, driven HIGH in `ThinkNodeM1Board.cpp`). But `variants/thinknode_m1/variant.h` also defined `PIN_GPS_RESET (37)` — the same pin.

The M1 builds its location provider with default constructor args:

```cpp
MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
// -> pin_reset = GPS_RESET = PIN_GPS_RESET = 37
```

So `MicroNMEALocationProvider` drives pin 37 thinking it's the GPS reset: `begin()` drives it HIGH and `stop()` drives it LOW. The result is that **turning GPS off (e.g. via the GPS switch) drives pin 37 low and cuts power to the LoRa radio.** The constructor also drives it low at static-init time before the board powers the radio.

## Fix

The M1 GPS has no MCU-controlled reset line. Remove the incorrect `PIN_GPS_RESET (37)` define and set `GPS_RESET (-1)` so the location provider never touches pin 37. The radio driver continues to own that pin and keeps it powered.

GPS is unaffected — the L76K streams NMEA without any reset pulse. Verified on hardware: the M1 GPS acquires normally and gets a 3D fix in ~80 s.

## Note

This is the M1 analogue of the M6 REINIT-pin issue (#2863): in both cases the location provider was driving a pin that must not be driven. Different pin, different consequence (M6 silenced the GPS; M1 cuts the radio), same root pattern.
