### PR TITLE
Fix nrf52 power source validity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ compile_commands.json
 .venv/
 venv/
 platformio.local.ini
+Pipfile

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1108,7 +1108,18 @@ region save
 **Usage:** `get pwrmgt.source`
 
 Returns a composite source and confidence state, for example `vusb+bat:valid`,
-`vusb-only:invalid`, `bat-only:implausible`, or `none:unknown`.
+`vusb-only:valid`, `bat-only:implausible`, or `undetected`.
+
+Confidence thresholds are board-configured in `PowerMgtConfig`. The current
+nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
+and `battery_max_plausible_mv = 4500`, so BAT voltage is `valid` from 2500mV
+to 4500mV inclusive. Readings outside that range are `implausible`, boards with
+unusable BAT sensing report `invalid`, and missing power-management
+configuration reports `unknown`. VUSB has no configured millivolt thresholds;
+it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
+If a battery is connected to VUSB and falls below the hardware VBUS-detect
+point while still powering the MCU, the source is reported as
+`undetected`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1111,12 +1111,16 @@ Returns a composite source and confidence state, for example `vusb+bat:valid`,
 `vusb-only:valid`, `bat-only:implausible`, or `vusb-only:possible-battery`.
 
 Confidence thresholds are board-configured in `PowerMgtConfig`. The current
-nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
+nRF52 power-management board configs all set `battery_min_present_mv = 1000`,
+`battery_min_plausible_mv = 2500`
 and `battery_max_plausible_mv = 4500`, so BAT voltage is `valid` from 2500mV
 to 4500mV inclusive. Readings outside that range are `implausible`, boards with
 unusable BAT sensing report `invalid`, and missing power-management
 configuration reports `unknown`. VUSB has no configured millivolt thresholds;
 it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
+BAT readings below 1000mV are treated as absent/floating for boot-lock
+decisions. Readings from 1000mV up to the boot-lock threshold still trigger
+protective shutdown; high readings above 4500mV are treated as unsafe evidence.
 If a battery is connected to VUSB and falls below the hardware VBUS-detect
 point while still powering the MCU, the source is reported as
 `vusb-only:possible-battery`.
@@ -1134,6 +1138,9 @@ point while still powering the MCU, the source is reported as
 
 #### View the boot voltage
 **Usage:** `get pwrmgt.bootmv`
+
+Adds `invalid` when the board configuration marks BAT voltage sensing as
+untrusted, for example `> 426 mV invalid`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1108,7 +1108,7 @@ region save
 **Usage:** `get pwrmgt.source`
 
 Returns a composite source and confidence state, for example `vusb+bat:valid`,
-`vusb-only:valid`, `bat-only:implausible`, or `undetected`.
+`vusb-only:valid`, `bat-only:implausible`, or `vusb-only:possible-battery`.
 
 Confidence thresholds are board-configured in `PowerMgtConfig`. The current
 nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
@@ -1119,7 +1119,7 @@ configuration reports `unknown`. VUSB has no configured millivolt thresholds;
 it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
 If a battery is connected to VUSB and falls below the hardware VBUS-detect
 point while still powering the MCU, the source is reported as
-`undetected`.
+`vusb-only:possible-battery`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1107,6 +1107,9 @@ region save
 #### View the current power source
 **Usage:** `get pwrmgt.source`
 
+Returns a composite source and confidence state, for example `vusb+bat:valid`,
+`vusb-only:invalid`, `bat-only:implausible`, or `none:unknown`.
+
 **Note:** Returns an error on boards without power management support.
 
 ---

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -8,14 +8,19 @@ The nRF52 Power Management module provides battery protection features to preven
 
 ### Boot Voltage Protection
 - Checks battery voltage immediately after boot and before mesh operations commence
-- If voltage is below a configurable threshold (e.g., 3300mV), the device configures voltage wake (LPCOMP + VBUS) and enters protective shutdown (SYSTEMOFF)
+- If voltage is below a configurable threshold (e.g., 3300mV), and the board declares the battery sense path valid, the device configures voltage wake and enters protective shutdown (SYSTEMOFF)
 - Prevents boot loops when battery is critically low
-- Skipped when external power (USB VBUS) is detected
+- Skipped when external power (USB VBUS) is detected, or when the battery voltage evidence is invalid or implausible
 
 ### Voltage Wake (LPCOMP + VBUS)
-- Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF
-- Enables USB VBUS detection so external power can wake the device
+- Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF only when the board declares the LPCOMP sense node valid
+- Enables USB VBUS detection independently where hardware supports VBUS wake
 - Device automatically wakes when battery voltage rises above recovery threshold or when VBUS is detected
+
+### Power Source State
+- `get pwrmgt.source` returns a composite state with a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
+- `invalid` means the board cannot use the configured battery sense path for protective decisions
+- `implausible` means the sensed voltage is outside the board's configured plausible range
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them
@@ -37,7 +42,7 @@ Shutdown reason codes (stored in GPREGRET2):
 
 | Board                                     | Implemented | LPCOMP wake | VBUS wake |
 |-------------------------------------------|-------------|-------------|-----------|
-| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | Yes         | Yes       |
+| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       |
 | RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       |
 | Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       |
 | GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       |
@@ -59,7 +64,8 @@ Shutdown reason codes (stored in GPREGRET2):
 Notes:
 - "Implemented" reflects Phase 1 (boot lockout + shutdown reason capture).
 - User power-off on Heltec T114 does not enable LPCOMP wake.
-- VBUS detection is used to skip boot lockout on external power, and VBUS wake is configured alongside LPCOMP when supported hardware exposes VBUS to the nRF52.
+- VBUS detection is used to skip boot lockout on external power. VBUS wake is configured independently from LPCOMP where supported hardware exposes VBUS to the nRF52.
+- XIAO nRF52 disables trusted BAT/LPCOMP protection by default because BAT+ may be disconnected while VUSB is the actual supply.
 
 ## Technical Details
 
@@ -97,7 +103,12 @@ To enable power management on a board variant:
    const PowerMgtConfig power_config = {
      .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
      .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-     .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+     .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+     .battery_voltage_sense_valid = true,
+     .lpcomp_voltage_wake_valid = true,
+     .vbus_wake_valid = true,
+     .battery_min_plausible_mv = 1000,
+     .battery_max_plausible_mv = 6500
    };
 
    void MyBoard::initiateShutdown(uint8_t reason) {
@@ -106,7 +117,7 @@ To enable power management on a board variant:
                            reason == SHUTDOWN_REASON_BOOT_PROTECT);
 
      if (enable_lpcomp) {
-       configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+       configureVoltageWake(&power_config);
      }
 
      enterSystemOff(reason);
@@ -182,7 +193,7 @@ Power management status can be queried via the CLI:
 | Command                 | Description                                                           |
 |-------------------------|-----------------------------------------------------------------------|
 | `get pwrmgt.support`    | Returns "supported" or "unsupported"                                  |
-| `get pwrmgt.source`     | Returns current power source - "battery" or "external" (5V/USB power) |
+| `get pwrmgt.source`     | Returns composite source and confidence, e.g. `vusb+bat:valid`        |
 | `get pwrmgt.bootreason` | Returns reset and shutdown reason strings                             |
 | `get pwrmgt.bootmv`     | Returns boot voltage in millivolts                                    |
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -21,7 +21,7 @@ The nRF52 Power Management module provides battery protection features to preven
 - `get pwrmgt.source` returns a source state. Normal detected sources use a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
 - `invalid` means the board cannot use the configured battery sense path for protective decisions
 - `implausible` means the sensed voltage is outside the board's configured plausible range
-- `undetected` means the board is powered, but neither VBUS detect nor a valid BAT sense path can prove which input is supplying it
+- `possible-battery` means the board is powered without VBUS detect, and the board cannot prove whether VUSB is being used as a battery input
 
 Confidence suffixes are assigned as follows:
 
@@ -31,6 +31,7 @@ Confidence suffixes are assigned as follows:
 | `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
 | `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
 | `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
+| `:possible-battery` | VBUS detect is low, BAT sense is invalid, and VUSB may be acting as a battery input   | Blocked                  |
 
 The current nRF52 power-management board configs all use these plausibility thresholds:
 
@@ -43,7 +44,7 @@ The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the bo
 
 There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
 
-This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware cannot prove the input path and reports `undetected` rather than `none`.
+This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware reports `vusb-only:possible-battery` rather than `none`.
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -10,7 +10,7 @@ The nRF52 Power Management module provides battery protection features to preven
 - Checks battery voltage immediately after boot and before mesh operations commence
 - If voltage is below a configurable threshold (e.g., 3300mV), and the board declares the battery sense path valid, the device configures voltage wake and enters protective shutdown (SYSTEMOFF)
 - Prevents boot loops when battery is critically low
-- Skipped when external power (USB VBUS) is detected, or when the battery voltage evidence is invalid or implausible
+- Skipped when external power (USB VBUS) is detected, when the battery voltage sense path is invalid, when the battery reading is below the configured present threshold, or when the battery voltage evidence is implausibly high
 
 ### Voltage Wake (LPCOMP + VBUS)
 - Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF only when the board declares the LPCOMP sense node valid
@@ -28,7 +28,7 @@ Confidence suffixes are assigned as follows:
 | Suffix          | Condition                                                                                 | Protective BAT decisions |
 |-----------------|-------------------------------------------------------------------------------------------|--------------------------|
 | `:valid`        | Battery sense is enabled for the board and the reading is within the configured range      | Allowed                  |
-| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
+| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Present low readings still shut down; absent/floating and high readings are blocked |
 | `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
 | `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
 | `:possible-battery` | VBUS detect is low, BAT sense is invalid, and VUSB may be acting as a battery input   | Blocked                  |
@@ -37,10 +37,11 @@ The current nRF52 power-management board configs all use these plausibility thre
 
 | `PowerMgtConfig` field       | Configured value | Meaning                                      |
 |------------------------------|------------------|----------------------------------------------|
-| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are `:implausible`     |
-| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible`     |
+| `battery_min_present_mv`     | `1000`           | Readings below 1000mV are treated as absent/floating and skipped for boot protection |
+| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are reported as `:implausible`; readings at or above 1000mV still trigger boot protection when below `voltage_bootlock` |
+| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible` and skipped for boot protection |
 
-The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boards can override these fields in their own `PowerMgtConfig`.
+The confidence range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boot protection uses the lower present threshold separately: `1000mV <= battery_mv < voltage_bootlock` enters protective shutdown. Boards can override these fields in their own `PowerMgtConfig`.
 
 There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
 
@@ -131,6 +132,7 @@ To enable power management on a board variant:
      .battery_voltage_sense_valid = true,
      .lpcomp_voltage_wake_valid = true,
      .vbus_wake_valid = true,
+     .battery_min_present_mv = 1000,
      .battery_min_plausible_mv = 2500,
      .battery_max_plausible_mv = 4500
    };
@@ -219,7 +221,7 @@ Power management status can be queried via the CLI:
 | `get pwrmgt.support`    | Returns "supported" or "unsupported"                                  |
 | `get pwrmgt.source`     | Returns composite source and confidence, e.g. `vusb+bat:valid`        |
 | `get pwrmgt.bootreason` | Returns reset and shutdown reason strings                             |
-| `get pwrmgt.bootmv`     | Returns boot voltage in millivolts                                    |
+| `get pwrmgt.bootmv`     | Returns boot voltage in millivolts, with `invalid` when BAT sense is not trustworthy |
 
 On boards without power management enabled, all commands except `get pwrmgt.support` return:
 ```

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -18,9 +18,32 @@ The nRF52 Power Management module provides battery protection features to preven
 - Device automatically wakes when battery voltage rises above recovery threshold or when VBUS is detected
 
 ### Power Source State
-- `get pwrmgt.source` returns a composite state with a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
+- `get pwrmgt.source` returns a source state. Normal detected sources use a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
 - `invalid` means the board cannot use the configured battery sense path for protective decisions
 - `implausible` means the sensed voltage is outside the board's configured plausible range
+- `undetected` means the board is powered, but neither VBUS detect nor a valid BAT sense path can prove which input is supplying it
+
+Confidence suffixes are assigned as follows:
+
+| Suffix          | Condition                                                                                 | Protective BAT decisions |
+|-----------------|-------------------------------------------------------------------------------------------|--------------------------|
+| `:valid`        | Battery sense is enabled for the board and the reading is within the configured range      | Allowed                  |
+| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
+| `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
+| `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
+
+The current nRF52 power-management board configs all use these plausibility thresholds:
+
+| `PowerMgtConfig` field       | Configured value | Meaning                                      |
+|------------------------------|------------------|----------------------------------------------|
+| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are `:implausible`     |
+| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible`     |
+
+The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boards can override these fields in their own `PowerMgtConfig`.
+
+There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
+
+This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware cannot prove the input path and reports `undetected` rather than `none`.
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them
@@ -107,8 +130,8 @@ To enable power management on a board variant:
      .battery_voltage_sense_valid = true,
      .lpcomp_voltage_wake_valid = true,
      .vbus_wake_valid = true,
-     .battery_min_plausible_mv = 1000,
-     .battery_max_plausible_mv = 6500
+     .battery_min_plausible_mv = 2500,
+     .battery_max_plausible_mv = 4500
    };
 
    void MyBoard::initiateShutdown(uint8_t reason) {

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -67,6 +67,7 @@ public:
 
   // Power management interface (boards with power management override these)
   virtual bool isExternalPowered() { return false; }
+  virtual const char* getPowerSourceState() { return isExternalPowered() ? "vusb-only:unknown" : "none:unknown"; }
   virtual uint16_t getBootVoltage() { return 0; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -69,6 +69,7 @@ public:
   virtual bool isExternalPowered() { return false; }
   virtual const char* getPowerSourceState() { return isExternalPowered() ? "vusb-only:unknown" : "none:unknown"; }
   virtual uint16_t getBootVoltage() { return 0; }
+  virtual bool isBootVoltageValid() { return false; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }
   virtual uint8_t getShutdownReason() const { return 0; }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -908,7 +908,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
 #endif
   } else if (memcmp(config, "pwrmgt.source", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
-    strcpy(reply, _board->isExternalPowered() ? "> external" : "> battery");
+    sprintf(reply, "> %s", _board->getPowerSourceState());
 #else
     strcpy(reply, "ERROR: Power management not supported");
 #endif

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -922,7 +922,8 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
 #endif
   } else if (memcmp(config, "pwrmgt.bootmv", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
-    sprintf(reply, "> %u mV", _board->getBootVoltage());
+    sprintf(reply, _board->isBootVoltageValid() ? "> %u mV" : "> %u mV invalid",
+      _board->getBootVoltage());
 #else
     strcpy(reply, "ERROR: Power management not supported");
 #endif

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -119,8 +119,13 @@ bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
     return true;
   }
 
-  if (!isBatteryVoltagePlausible(boot_voltage_mv, config)) {
-    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausible battery voltage)");
+  if (boot_voltage_mv < config->battery_min_present_mv) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (battery absent or floating)");
+    return true;
+  }
+
+  if (boot_voltage_mv > config->battery_max_plausible_mv) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausibly high battery voltage)");
     return true;
   }
 
@@ -252,6 +257,11 @@ bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtCo
   if (config == nullptr) return false;
   return millivolts >= config->battery_min_plausible_mv &&
          millivolts <= config->battery_max_plausible_mv;
+}
+
+bool NRF52Board::isBootVoltageValid() {
+  return active_power_config != nullptr &&
+         active_power_config->battery_voltage_sense_valid;
 }
 
 const char* NRF52Board::getPowerSourceState() {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -96,6 +96,7 @@ const char* NRF52Board::getShutdownReasonString(uint8_t reason) {
 }
 
 bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
+  active_power_config = config;
   initPowerMgr();
 
   // Read boot voltage
@@ -113,9 +114,17 @@ bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
   MESH_DEBUG_PRINTLN("PWRMGT: Boot voltage = %u mV (threshold = %u mV)",
       boot_voltage_mv, config->voltage_bootlock);
 
-  // Only trigger shutdown if reading is valid (>1000mV) AND below threshold
-  // This prevents spurious shutdowns on ADC glitches or uninitialized reads
-  if (boot_voltage_mv > 1000 && boot_voltage_mv < config->voltage_bootlock) {
+  if (!config->battery_voltage_sense_valid) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (battery voltage sense invalid)");
+    return true;
+  }
+
+  if (!isBatteryVoltagePlausible(boot_voltage_mv, config)) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausible battery voltage)");
+    return true;
+  }
+
+  if (boot_voltage_mv < config->voltage_bootlock) {
     MESH_DEBUG_PRINTLN("PWRMGT: Boot voltage too low - entering protective shutdown");
 
     initiateShutdown(SHUTDOWN_REASON_BOOT_PROTECT);
@@ -210,7 +219,23 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
       ain_channel, ref_num);
   }
 
-  // Configure VBUS (USB power) wake alongside LPCOMP
+}
+
+void NRF52Board::configureVoltageWake(const PowerMgtConfig* config) {
+  if (config == nullptr) return;
+
+  if (config->lpcomp_voltage_wake_valid) {
+    configureVoltageWake(config->lpcomp_ain_channel, config->lpcomp_refsel);
+  } else {
+    MESH_DEBUG_PRINTLN("PWRMGT: LPCOMP wake skipped (voltage sense invalid)");
+  }
+
+  if (config->vbus_wake_valid) {
+    configureVbusWake();
+  }
+}
+
+void NRF52Board::configureVbusWake() {
   uint8_t sd_enabled = 0;
   sd_softdevice_is_enabled(&sd_enabled);
   if (sd_enabled) {
@@ -221,6 +246,32 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
   }
 
   MESH_DEBUG_PRINTLN("PWRMGT: VBUS wake configured");
+}
+
+bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const {
+  if (config == nullptr) return false;
+  return millivolts >= config->battery_min_plausible_mv &&
+         millivolts <= config->battery_max_plausible_mv;
+}
+
+const char* NRF52Board::getPowerSourceState() {
+  bool vusb_connected = isExternalPowered();
+
+  if (active_power_config == nullptr) {
+    return vusb_connected ? "vusb-only:unknown" : "none:unknown";
+  }
+
+  uint16_t battery_mv = getBattMilliVolts();
+
+  if (!active_power_config->battery_voltage_sense_valid) {
+    return vusb_connected ? "vusb-only:invalid" : "none:invalid";
+  }
+
+  if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {
+    return vusb_connected ? "vusb+bat:implausible" : "bat-only:implausible";
+  }
+
+  return vusb_connected ? "vusb+bat:valid" : "bat-only:valid";
 }
 #endif
 

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -264,7 +264,7 @@ const char* NRF52Board::getPowerSourceState() {
   uint16_t battery_mv = getBattMilliVolts();
 
   if (!active_power_config->battery_voltage_sense_valid) {
-    return vusb_connected ? "vusb-only:invalid" : "none:invalid";
+    return vusb_connected ? "vusb-only:valid" : "undetected";
   }
 
   if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -264,7 +264,7 @@ const char* NRF52Board::getPowerSourceState() {
   uint16_t battery_mv = getBattMilliVolts();
 
   if (!active_power_config->battery_voltage_sense_valid) {
-    return vusb_connected ? "vusb-only:valid" : "undetected";
+    return vusb_connected ? "vusb-only:valid" : "vusb-only:possible-battery";
   }
 
   if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -28,8 +28,11 @@ struct PowerMgtConfig {
   bool lpcomp_voltage_wake_valid;
   bool vbus_wake_valid;
 
-  // Broad plausibility limits for a sensed battery voltage. Readings outside
-  // this range are treated as unsafe evidence for protective shutdown decisions.
+  // Battery voltage interpretation thresholds. Readings below the present
+  // threshold are treated as absent/floating, not as a discharged battery.
+  uint16_t battery_min_present_mv;
+
+  // Broad plausibility limits for source-state confidence reporting.
   uint16_t battery_min_plausible_mv;
   uint16_t battery_max_plausible_mv;
 };
@@ -72,6 +75,7 @@ public:
 
 #ifdef NRF52_POWER_MANAGEMENT
   uint16_t getBootVoltage() override { return boot_voltage_mv; }
+  bool isBootVoltageValid() override;
   const char* getPowerSourceState() override;
   virtual uint32_t getResetReason() const override { return reset_reason; }
   uint8_t getShutdownReason() const override { return shutdown_reason; }

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -21,6 +21,17 @@ struct PowerMgtConfig {
   // Boot protection voltage threshold (millivolts)
   // Set to 0 to disable boot protection
   uint16_t voltage_bootlock;
+
+  // Capability flags describe what this board can prove from its sense wiring.
+  // They prevent VBUS loss from being treated as proof that a BAT sense node is valid.
+  bool battery_voltage_sense_valid;
+  bool lpcomp_voltage_wake_valid;
+  bool vbus_wake_valid;
+
+  // Broad plausibility limits for a sensed battery voltage. Readings outside
+  // this range are treated as unsafe evidence for protective shutdown decisions.
+  uint16_t battery_min_plausible_mv;
+  uint16_t battery_max_plausible_mv;
 };
 #endif
 
@@ -37,11 +48,15 @@ protected:
   uint32_t reset_reason;              // RESETREAS register value
   uint8_t shutdown_reason;            // GPREGRET value (why we entered last SYSTEMOFF)
   uint16_t boot_voltage_mv;           // Battery voltage at boot (millivolts)
+  const PowerMgtConfig* active_power_config = nullptr;
 
   bool checkBootVoltage(const PowerMgtConfig* config);
   void enterSystemOff(uint8_t reason);
   void configureVoltageWake(uint8_t ain_channel, uint8_t refsel);
+  void configureVoltageWake(const PowerMgtConfig* config);
+  void configureVbusWake();
   virtual void initiateShutdown(uint8_t reason);
+  bool isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const;
 #endif
 
 public:
@@ -57,6 +72,7 @@ public:
 
 #ifdef NRF52_POWER_MANAGEMENT
   uint16_t getBootVoltage() override { return boot_voltage_mv; }
+  const char* getPowerSourceState() override;
   virtual uint32_t getResetReason() const override { return reset_reason; }
   uint8_t getShutdownReason() const override { return shutdown_reason; }
   const char* getResetReasonString(uint32_t reason) override;

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT56230SMeshKitBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT562EVBProBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT562MeshTrackerProBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -10,14 +10,19 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
 void GAT56MeshWatch13Board::initiateShutdown(uint8_t reason) {
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
   enterSystemOff(reason);
 }

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T096Board::initiateShutdown(uint8_t reason) {
@@ -25,7 +30,7 @@ void T096Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? HIGH : LOW);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T096Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -7,7 +7,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T1Board::initiateShutdown(uint8_t reason) {
@@ -19,7 +24,7 @@ void T1Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? ADC_CTRL_ENABLED : !ADC_CTRL_ENABLED);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -11,6 +11,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -11,8 +11,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T1Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T114Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T114Board::initiateShutdown(uint8_t reason) {
@@ -25,7 +30,7 @@ void T114Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? HIGH : LOW);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void R1NeoBoard::initiateShutdown(uint8_t reason) {
@@ -22,7 +27,7 @@ void R1NeoBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void R1NeoBoard::initiateShutdown(uint8_t reason) {

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void RAK3401Board::initiateShutdown(uint8_t reason) {

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void RAK3401Board::initiateShutdown(uint8_t reason) {
@@ -21,7 +26,7 @@ void RAK3401Board::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void RAK4631Board::initiateShutdown(uint8_t reason) {
@@ -18,7 +23,7 @@ void RAK4631Board::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void RAK4631Board::initiateShutdown(uint8_t reason) {

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -11,8 +11,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -7,7 +7,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {
@@ -18,7 +23,7 @@ void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {
   digitalWrite(VBAT_ENABLE, enable_lpcomp ? LOW : HIGH);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -11,6 +11,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -17,6 +17,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = false,
   .lpcomp_voltage_wake_valid = false,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -8,10 +8,17 @@
 #ifdef NRF52_POWER_MANAGEMENT
 // Static configuration for power management
 // Values set in variant.h defines
+// XIAO BAT+ is optional. When VUSB is the actual supply and BAT+ is open, the
+// BAT divider/LPCOMP node is not valid evidence for protective shutdown.
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = false,
+  .lpcomp_voltage_wake_valid = false,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void XiaoNrf52Board::initiateShutdown(uint8_t reason) {
@@ -22,7 +29,7 @@ void XiaoNrf52Board::initiateShutdown(uint8_t reason) {
   digitalWrite(VBAT_ENABLE, enable_lpcomp ? LOW : HIGH);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -17,8 +17,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = false,
   .lpcomp_voltage_wake_valid = false,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void XiaoNrf52Board::initiateShutdown(uint8_t reason) {


### PR DESCRIPTION
Again, whilst working through trying to identify a different bug, I ended up making a load of changes to the battery sensing approach.  Nearly all of this is about instrumentation and debugging.  But there are a couple of smaller behaviour changes.  These centre on what circumstances are suitable for using the results of battery measurements for decisions about boot locking.  On its own, I am not sure how much this code is useful, but I didn't want to just throw it away as there are issues open / comments discussing further development of this area of the codebase.