### PR TITLE
Improve brownout recovery

### DIFF
--- a/boards/nrf52840_s140_v6.ld
+++ b/boards/nrf52840_s140_v6.ld
@@ -33,6 +33,13 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    KEEP(*(.noinit))
+    . = ALIGN(4);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v6_extrafs.ld
+++ b/boards/nrf52840_s140_v6_extrafs.ld
@@ -33,6 +33,13 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    KEEP(*(.noinit))
+    . = ALIGN(4);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7.ld
+++ b/boards/nrf52840_s140_v7.ld
@@ -33,6 +33,13 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    KEEP(*(.noinit))
+    . = ALIGN(4);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7_extrafs.ld
+++ b/boards/nrf52840_s140_v7_extrafs.ld
@@ -33,6 +33,13 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    KEEP(*(.noinit))
+    . = ALIGN(4);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1115,12 +1115,16 @@ Returns a composite source and confidence state, for example `vusb+bat:valid`,
 `vusb-only:valid`, `bat-only:implausible`, or `vusb-only:possible-battery`.
 
 Confidence thresholds are board-configured in `PowerMgtConfig`. The current
-nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
+nRF52 power-management board configs all set `battery_min_present_mv = 1000`,
+`battery_min_plausible_mv = 2500`
 and `battery_max_plausible_mv = 4500`, so BAT voltage is `valid` from 2500mV
 to 4500mV inclusive. Readings outside that range are `implausible`, boards with
 unusable BAT sensing report `invalid`, and missing power-management
 configuration reports `unknown`. VUSB has no configured millivolt thresholds;
 it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
+BAT readings below 1000mV are treated as absent/floating for boot-lock
+decisions. Readings from 1000mV up to the boot-lock threshold still trigger
+protective shutdown; high readings above 4500mV are treated as unsafe evidence.
 If a battery is connected to VUSB and falls below the hardware VBUS-detect
 point while still powering the MCU, the source is reported as
 `vusb-only:possible-battery`.
@@ -1138,6 +1142,9 @@ point while still powering the MCU, the source is reported as
 
 #### View the boot voltage
 **Usage:** `get pwrmgt.bootmv`
+
+Adds `invalid` when the board configuration marks BAT voltage sensing as
+untrusted, for example `> 426 mV invalid`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1112,7 +1112,18 @@ region save
 **Usage:** `get pwrmgt.source`
 
 Returns a composite source and confidence state, for example `vusb+bat:valid`,
-`vusb-only:invalid`, `bat-only:implausible`, or `none:unknown`.
+`vusb-only:valid`, `bat-only:implausible`, or `undetected`.
+
+Confidence thresholds are board-configured in `PowerMgtConfig`. The current
+nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
+and `battery_max_plausible_mv = 4500`, so BAT voltage is `valid` from 2500mV
+to 4500mV inclusive. Readings outside that range are `implausible`, boards with
+unusable BAT sensing report `invalid`, and missing power-management
+configuration reports `unknown`. VUSB has no configured millivolt thresholds;
+it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
+If a battery is connected to VUSB and falls below the hardware VBUS-detect
+point while still powering the MCU, the source is reported as
+`undetected`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1111,6 +1111,9 @@ region save
 #### View the current power source
 **Usage:** `get pwrmgt.source`
 
+Returns a composite source and confidence state, for example `vusb+bat:valid`,
+`vusb-only:invalid`, `bat-only:implausible`, or `none:unknown`.
+
 **Note:** Returns an error on boards without power management support.
 
 ---

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1112,7 +1112,7 @@ region save
 **Usage:** `get pwrmgt.source`
 
 Returns a composite source and confidence state, for example `vusb+bat:valid`,
-`vusb-only:valid`, `bat-only:implausible`, or `undetected`.
+`vusb-only:valid`, `bat-only:implausible`, or `vusb-only:possible-battery`.
 
 Confidence thresholds are board-configured in `PowerMgtConfig`. The current
 nRF52 power-management board configs all set `battery_min_plausible_mv = 2500`
@@ -1123,7 +1123,7 @@ configuration reports `unknown`. VUSB has no configured millivolt thresholds;
 it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
 If a battery is connected to VUSB and falls below the hardware VBUS-detect
 point while still powering the MCU, the source is reported as
-`undetected`.
+`vusb-only:possible-battery`.
 
 **Note:** Returns an error on boards without power management support.
 

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1151,3 +1151,20 @@ untrusted, for example `> 426 mV invalid`.
 **Note:** Returns an error on boards without power management support.
 
 ---
+
+#### View the last radio initialisation status
+**Usage:** `get radio.init_status`
+
+---
+
+#### View the radio initialisation attempt count
+**Usage:** `get radio.init_attempts`
+
+---
+
+#### View compact boot diagnostics
+**Usage:** `get diag.boot`
+
+**Note:** Returns current and previous reset-retained boot diagnostics. `cur_sd` and `prev_sd` are raw shutdown/fault markers, including low voltage, boot protection, user shutdown, and radio initialisation failure.
+
+---

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1123,8 +1123,10 @@ unusable BAT sensing report `invalid`, and missing power-management
 configuration reports `unknown`. VUSB has no configured millivolt thresholds;
 it is detected through the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal.
 BAT readings below 1000mV are treated as absent/floating for boot-lock
-decisions. Readings from 1000mV up to the boot-lock threshold still trigger
-protective shutdown; high readings above 4500mV are treated as unsafe evidence.
+decisions and are not reported as a BAT source. With VBUS detected this reports
+`vusb-only:valid`; without VBUS detect this reports `vusb-only:possible-battery`.
+Readings from 1000mV up to the boot-lock threshold still trigger protective
+shutdown; high readings above 4500mV are treated as unsafe evidence.
 If a battery is connected to VUSB and falls below the hardware VBUS-detect
 point while still powering the MCU, the source is reported as
 `vusb-only:possible-battery`.

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -10,7 +10,7 @@ The nRF52 Power Management module provides battery protection features to preven
 - Checks battery voltage immediately after boot and before mesh operations commence
 - If voltage is below a configurable threshold (e.g., 3300mV), and the board declares the battery sense path valid, the device configures voltage wake and enters protective shutdown (SYSTEMOFF)
 - Prevents boot loops when battery is critically low
-- Skipped when external power (USB VBUS) is detected, or when the battery voltage evidence is invalid or implausible
+- Skipped when external power (USB VBUS) is detected, when the battery voltage sense path is invalid, when the battery reading is below the configured present threshold, or when the battery voltage evidence is implausibly high
 
 ### Voltage Wake (LPCOMP + VBUS)
 - Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF only when the board declares the LPCOMP sense node valid
@@ -34,7 +34,7 @@ Confidence suffixes are assigned as follows:
 | Suffix          | Condition                                                                                 | Protective BAT decisions |
 |-----------------|-------------------------------------------------------------------------------------------|--------------------------|
 | `:valid`        | Battery sense is enabled for the board and the reading is within the configured range      | Allowed                  |
-| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
+| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Present low readings still shut down; absent/floating and high readings are blocked |
 | `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
 | `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
 | `:possible-battery` | VBUS detect is low, BAT sense is invalid, and VUSB may be acting as a battery input   | Blocked                  |
@@ -43,10 +43,11 @@ The current nRF52 power-management board configs all use these plausibility thre
 
 | `PowerMgtConfig` field       | Configured value | Meaning                                      |
 |------------------------------|------------------|----------------------------------------------|
-| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are `:implausible`     |
-| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible`     |
+| `battery_min_present_mv`     | `1000`           | Readings below 1000mV are treated as absent/floating and skipped for boot protection |
+| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are reported as `:implausible`; readings at or above 1000mV still trigger boot protection when below `voltage_bootlock` |
+| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible` and skipped for boot protection |
 
-The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boards can override these fields in their own `PowerMgtConfig`.
+The confidence range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boot protection uses the lower present threshold separately: `1000mV <= battery_mv < voltage_bootlock` enters protective shutdown. Boards can override these fields in their own `PowerMgtConfig`.
 
 There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
 
@@ -139,6 +140,7 @@ To enable power management on a board variant:
      .battery_voltage_sense_valid = true,
      .lpcomp_voltage_wake_valid = true,
      .vbus_wake_valid = true,
+     .battery_min_present_mv = 1000,
      .battery_min_plausible_mv = 2500,
      .battery_max_plausible_mv = 4500,
      .power_fail_vdd_threshold = 0,    // Optional; 0 disables runtime POF shutdown
@@ -248,7 +250,7 @@ Power management status can be queried via the CLI:
 | `get pwrmgt.support`    | Returns "supported" or "unsupported"                                  |
 | `get pwrmgt.source`     | Returns composite source and confidence, e.g. `vusb+bat:valid`        |
 | `get pwrmgt.bootreason` | Returns reset and shutdown reason strings                             |
-| `get pwrmgt.bootmv`     | Returns boot voltage in millivolts                                    |
+| `get pwrmgt.bootmv`     | Returns boot voltage in millivolts, with `invalid` when BAT sense is not trustworthy |
 
 On boards without power management enabled, all commands except `get pwrmgt.support` return:
 ```

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -24,9 +24,32 @@ The nRF52 Power Management module provides battery protection features to preven
 - Does not replace hardware brownout behaviour: if voltage collapses before firmware runs the handler, recovery is controlled by reset and regulator hardware
 
 ### Power Source State
-- `get pwrmgt.source` returns a composite state with a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
+- `get pwrmgt.source` returns a source state. Normal detected sources use a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
 - `invalid` means the board cannot use the configured battery sense path for protective decisions
 - `implausible` means the sensed voltage is outside the board's configured plausible range
+- `undetected` means the board is powered, but neither VBUS detect nor a valid BAT sense path can prove which input is supplying it
+
+Confidence suffixes are assigned as follows:
+
+| Suffix          | Condition                                                                                 | Protective BAT decisions |
+|-----------------|-------------------------------------------------------------------------------------------|--------------------------|
+| `:valid`        | Battery sense is enabled for the board and the reading is within the configured range      | Allowed                  |
+| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
+| `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
+| `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
+
+The current nRF52 power-management board configs all use these plausibility thresholds:
+
+| `PowerMgtConfig` field       | Configured value | Meaning                                      |
+|------------------------------|------------------|----------------------------------------------|
+| `battery_min_plausible_mv`   | `2500`           | Readings below 2500mV are `:implausible`     |
+| `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible`     |
+
+The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boards can override these fields in their own `PowerMgtConfig`.
+
+There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
+
+This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware cannot prove the input path and reports `undetected` rather than `none`.
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them
@@ -115,8 +138,8 @@ To enable power management on a board variant:
      .battery_voltage_sense_valid = true,
      .lpcomp_voltage_wake_valid = true,
      .vbus_wake_valid = true,
-     .battery_min_plausible_mv = 1000,
-     .battery_max_plausible_mv = 6500,
+     .battery_min_plausible_mv = 2500,
+     .battery_max_plausible_mv = 4500,
      .power_fail_vdd_threshold = 0,    // Optional; 0 disables runtime POF shutdown
      .power_fail_vbus_wake = false     // Optional; true arms VBUS wake after POF shutdown
    };

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -99,7 +99,7 @@ Notes:
 - User power-off on Heltec T114 does not enable LPCOMP wake.
 - VBUS detection is used to skip boot lockout on external power. VBUS wake is configured independently from LPCOMP where supported hardware exposes VBUS to the nRF52.
 - XIAO nRF52 disables trusted BAT/LPCOMP protection by default because BAT+ may be disconnected while VUSB is the actual supply.
-- Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO USB builds it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery. XIAO BLE companion builds leave direct POF disabled because SoftDevice is enabled after `board.begin()` and owns POWER events once started.
+- Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO USB builds it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery. XIAO BLE companion builds leave direct POF disabled because SoftDevice is enabled after `board.begin()` and owns POWER events once started. USB builds that later enter OTA disable the direct POF handler before starting SoftDevice.
 
 ## Technical Details
 
@@ -209,7 +209,7 @@ This path is deliberately separate from SYSTEMOFF wake source selection:
 - If supply voltage simply collapses, firmware does not choose a wake source; reset and regulator hardware determine when execution resumes.
 - POF shutdown only applies if the MCU is still executing when VDD crosses the configured threshold.
 - When POF shutdown succeeds and `power_fail_vbus_wake` is true, recovery happens when the nRF52 VBUS detector sees VUSB again, not when BAT sense rises.
-- SoftDevice builds need a SoftDevice SoC event hook for `NRF_EVT_POWER_FAILURE_WARNING`. The current Adafruit nRF52 framework consumes that event internally, so this branch only enables direct POF shutdown when SoftDevice is not active.
+- SoftDevice builds need a SoftDevice SoC event hook for `NRF_EVT_POWER_FAILURE_WARNING`. The current Adafruit nRF52 framework consumes that event internally, so this branch only enables direct POF shutdown while SoftDevice is not active and disables it before OTA starts SoftDevice.
 
 **LPCOMP Reference Selection (PWRMGT_LPCOMP_REFSEL)**:
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -253,11 +253,14 @@ Power management status can be queried via the CLI:
 | `get pwrmgt.source`     | Returns composite source and confidence, e.g. `vusb+bat:valid`        |
 | `get pwrmgt.bootreason` | Returns reset and shutdown reason strings                             |
 | `get pwrmgt.bootmv`     | Returns boot voltage in millivolts, with `invalid` when BAT sense is not trustworthy |
+| `get diag.boot`         | Returns current and previous reset-retained boot/radio diagnostics     |
 
 On boards without power management enabled, all commands except `get pwrmgt.support` return:
 ```
 ERROR: Power management not supported
 ```
+
+`get diag.boot` includes raw current and previous boot records. The shutdown fields include all `GPREGRET2` markers, not only radio initialisation failure, so low-voltage and boot-protection context is preserved when diagnosing reset loops. The previous slot is retained across MCU resets where RAM is preserved; it is not a flash-backed history and may be lost after a complete power loss.
 
 ## Debug Output
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -34,7 +34,7 @@ Confidence suffixes are assigned as follows:
 | Suffix          | Condition                                                                                 | Protective BAT decisions |
 |-----------------|-------------------------------------------------------------------------------------------|--------------------------|
 | `:valid`        | Battery sense is enabled for the board and the reading is within the configured range      | Allowed                  |
-| `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Present low readings still shut down; absent/floating and high readings are blocked |
+| `:implausible`  | Battery sense is enabled, the reading is present, and it is below the plausible range or above maximum | Present low readings still shut down; absent/floating and high readings are blocked |
 | `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
 | `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
 | `:possible-battery` | VBUS detect is low, BAT sense is invalid, and VUSB may be acting as a battery input   | Blocked                  |
@@ -48,6 +48,8 @@ The current nRF52 power-management board configs all use these plausibility thre
 | `battery_max_plausible_mv`   | `4500`           | Readings above 4500mV are `:implausible` and skipped for boot protection |
 
 The confidence range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the board's battery sense path is enabled. Boot protection uses the lower present threshold separately: `1000mV <= battery_mv < voltage_bootlock` enters protective shutdown. Boards can override these fields in their own `PowerMgtConfig`.
+
+Readings below `battery_min_present_mv` are treated as no BAT source. With VBUS detected, the source is reported as `vusb-only:valid`; without VBUS detect, the source is reported as `vusb-only:possible-battery` because the board is still powered and VUSB may be acting as the battery input.
 
 There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
 
@@ -73,7 +75,7 @@ Shutdown reason codes (stored in GPREGRET2):
 
 | Board                                     | Implemented | LPCOMP wake | VBUS wake | Runtime POF shutdown |
 |-------------------------------------------|-------------|-------------|-----------|----------------------|
-| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       | Yes                  |
+| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       | USB builds only      |
 | RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       | No                   |
 | Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       | No                   |
 | GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       | No                   |
@@ -97,7 +99,7 @@ Notes:
 - User power-off on Heltec T114 does not enable LPCOMP wake.
 - VBUS detection is used to skip boot lockout on external power. VBUS wake is configured independently from LPCOMP where supported hardware exposes VBUS to the nRF52.
 - XIAO nRF52 disables trusted BAT/LPCOMP protection by default because BAT+ may be disconnected while VUSB is the actual supply.
-- Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery.
+- Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO USB builds it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery. XIAO BLE companion builds leave direct POF disabled because SoftDevice is enabled after `board.begin()` and owns POWER events once started.
 
 ## Technical Details
 
@@ -199,7 +201,7 @@ Runtime power-fail shutdown is configured by optional `PowerMgtConfig` fields:
 | `power_fail_vdd_threshold` | `0` | Disabled when `0`; otherwise an nRF52 `POWER_POFCON_THRESHOLD_*` value for regulated VDD |
 | `power_fail_vbus_wake` | `false` | When true, the POF handler arms VBUS detect as the SYSTEMOFF wake source |
 
-For nRF52840 VDD, supported POF thresholds are 1.7 V through 2.8 V in 0.1 V steps. The XIAO nRF52840 default uses `POWER_POFCON_THRESHOLD_V28`, the highest available regulated-VDD threshold, so firmware gets the earliest available warning when the 3.3 V rail starts to collapse.
+For nRF52840 VDD, supported POF thresholds are 1.7 V through 2.8 V in 0.1 V steps. The XIAO nRF52840 USB-build default uses `POWER_POFCON_THRESHOLD_V28`, the highest available regulated-VDD threshold, so firmware gets the earliest available warning when the 3.3 V rail starts to collapse.
 
 For nRF52840 VDDH, hardware also supports 2.7 V through 4.2 V thresholds. MeshCore does not currently use the VDDH threshold for XIAO because a battery on the XIAO VUSB pin is not the same as direct nRF52840 VDDH measurement in the board abstraction.
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -8,13 +8,13 @@ The nRF52 Power Management module provides battery protection features to preven
 
 ### Boot Voltage Protection
 - Checks battery voltage immediately after boot and before mesh operations commence
-- If voltage is below a configurable threshold (e.g., 3300mV), the device configures voltage wake (LPCOMP + VBUS) and enters protective shutdown (SYSTEMOFF)
+- If voltage is below a configurable threshold (e.g., 3300mV), and the board declares the battery sense path valid, the device configures voltage wake and enters protective shutdown (SYSTEMOFF)
 - Prevents boot loops when battery is critically low
-- Skipped when external power (USB VBUS) is detected
+- Skipped when external power (USB VBUS) is detected, or when the battery voltage evidence is invalid or implausible
 
 ### Voltage Wake (LPCOMP + VBUS)
-- Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF
-- Enables USB VBUS detection so external power can wake the device
+- Configures the nRF52's Low Power Comparator (LPCOMP) before entering SYSTEMOFF only when the board declares the LPCOMP sense node valid
+- Enables USB VBUS detection independently where hardware supports VBUS wake
 - Device automatically wakes when battery voltage rises above recovery threshold or when VBUS is detected
 
 ### Runtime Power-Fail Shutdown
@@ -22,6 +22,11 @@ The nRF52 Power Management module provides battery protection features to preven
 - Allows firmware to enter SYSTEMOFF before an uncontrolled brownout if VDD falls through the configured threshold
 - Can arm VBUS detection as the recovery wake source for builds powered by a battery connected to VUSB
 - Does not replace hardware brownout behaviour: if voltage collapses before firmware runs the handler, recovery is controlled by reset and regulator hardware
+
+### Power Source State
+- `get pwrmgt.source` returns a composite state with a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
+- `invalid` means the board cannot use the configured battery sense path for protective decisions
+- `implausible` means the sensed voltage is outside the board's configured plausible range
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them
@@ -43,7 +48,7 @@ Shutdown reason codes (stored in GPREGRET2):
 
 | Board                                     | Implemented | LPCOMP wake | VBUS wake | Runtime POF shutdown |
 |-------------------------------------------|-------------|-------------|-----------|----------------------|
-| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | Yes         | Yes       | Yes                  |
+| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       | Yes                  |
 | RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       | No                   |
 | Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       | No                   |
 | GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       | No                   |
@@ -65,7 +70,8 @@ Shutdown reason codes (stored in GPREGRET2):
 Notes:
 - "Implemented" reflects Phase 1 (boot lockout + shutdown reason capture).
 - User power-off on Heltec T114 does not enable LPCOMP wake.
-- VBUS detection is used to skip boot lockout on external power, and VBUS wake is configured alongside LPCOMP when supported hardware exposes VBUS to the nRF52.
+- VBUS detection is used to skip boot lockout on external power. VBUS wake is configured independently from LPCOMP where supported hardware exposes VBUS to the nRF52.
+- XIAO nRF52 disables trusted BAT/LPCOMP protection by default because BAT+ may be disconnected while VUSB is the actual supply.
 - Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery.
 
 ## Technical Details
@@ -106,6 +112,11 @@ To enable power management on a board variant:
      .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
      .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
      .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+     .battery_voltage_sense_valid = true,
+     .lpcomp_voltage_wake_valid = true,
+     .vbus_wake_valid = true,
+     .battery_min_plausible_mv = 1000,
+     .battery_max_plausible_mv = 6500,
      .power_fail_vdd_threshold = 0,    // Optional; 0 disables runtime POF shutdown
      .power_fail_vbus_wake = false     // Optional; true arms VBUS wake after POF shutdown
    };
@@ -116,7 +127,7 @@ To enable power management on a board variant:
                            reason == SHUTDOWN_REASON_BOOT_PROTECT);
 
      if (enable_lpcomp) {
-       configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+       configureVoltageWake(&power_config);
      }
 
      enterSystemOff(reason);
@@ -211,7 +222,7 @@ Power management status can be queried via the CLI:
 | Command                 | Description                                                           |
 |-------------------------|-----------------------------------------------------------------------|
 | `get pwrmgt.support`    | Returns "supported" or "unsupported"                                  |
-| `get pwrmgt.source`     | Returns current power source - "battery" or "external" (5V/USB power) |
+| `get pwrmgt.source`     | Returns composite source and confidence, e.g. `vusb+bat:valid`        |
 | `get pwrmgt.bootreason` | Returns reset and shutdown reason strings                             |
 | `get pwrmgt.bootmv`     | Returns boot voltage in millivolts                                    |
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -17,6 +17,12 @@ The nRF52 Power Management module provides battery protection features to preven
 - Enables USB VBUS detection so external power can wake the device
 - Device automatically wakes when battery voltage rises above recovery threshold or when VBUS is detected
 
+### Runtime Power-Fail Shutdown
+- Optionally arms the nRF52 power-fail warning comparator on regulated VDD
+- Allows firmware to enter SYSTEMOFF before an uncontrolled brownout if VDD falls through the configured threshold
+- Can arm VBUS detection as the recovery wake source for builds powered by a battery connected to VUSB
+- Does not replace hardware brownout behaviour: if voltage collapses before firmware runs the handler, recovery is controlled by reset and regulator hardware
+
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them
 - Allows firmware to determine why it booted (cold boot, watchdog, LPCOMP wake, etc.)
@@ -35,31 +41,32 @@ Shutdown reason codes (stored in GPREGRET2):
 ## Supported Boards
 
 
-| Board                                     | Implemented | LPCOMP wake | VBUS wake |
-|-------------------------------------------|-------------|-------------|-----------|
-| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | Yes         | Yes       |
-| RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       |
-| Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       |
-| GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       |
-| Promicro nRF52840                         | No          | No          | No        |
-| RAK WisMesh Tag                           | No          | No          | No        |
-| Heltec Mesh Solar                         | No          | No          | No        |
-| LilyGo T-Echo / T-Echo Lite               | No          | No          | No        |
-| SenseCAP Solar                            | Yes         | Yes         | Yes       |
-| WIO Tracker L1 / L1 E-Ink                 | No          | No          | No        |
-| WIO WM1110                                | No          | No          | No        |
-| Mesh Pocket                               | No          | No          | No        |
-| Nano G2 Ultra                             | No          | No          | No        |
-| ThinkNode M1/M3/M6                        | No          | No          | No        |
-| T1000-E                                   | No          | No          | No        |
-| Ikoka Nano/Stick/Handheld (nRF)           | No          | No          | No        |
-| Keepteen LT1                              | No          | No          | No        |
-| Minewsemi ME25LS01                        | No          | No          | No        |
+| Board                                     | Implemented | LPCOMP wake | VBUS wake | Runtime POF shutdown |
+|-------------------------------------------|-------------|-------------|-----------|----------------------|
+| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | Yes         | Yes       | Yes                  |
+| RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       | No                   |
+| Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       | No                   |
+| GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       | No                   |
+| Promicro nRF52840                         | No          | No          | No        | No                   |
+| RAK WisMesh Tag                           | No          | No          | No        | No                   |
+| Heltec Mesh Solar                         | No          | No          | No        | No                   |
+| LilyGo T-Echo / T-Echo Lite               | No          | No          | No        | No                   |
+| SenseCAP Solar                            | Yes         | Yes         | Yes       | No                   |
+| WIO Tracker L1 / L1 E-Ink                 | No          | No          | No        | No                   |
+| WIO WM1110                                | No          | No          | No        | No                   |
+| Mesh Pocket                               | No          | No          | No        | No                   |
+| Nano G2 Ultra                             | No          | No          | No        | No                   |
+| ThinkNode M1/M3/M6                        | No          | No          | No        | No                   |
+| T1000-E                                   | No          | No          | No        | No                   |
+| Ikoka Nano/Stick/Handheld (nRF)           | No          | No          | No        | No                   |
+| Keepteen LT1                              | No          | No          | No        | No                   |
+| Minewsemi ME25LS01                        | No          | No          | No        | No                   |
 
 Notes:
 - "Implemented" reflects Phase 1 (boot lockout + shutdown reason capture).
 - User power-off on Heltec T114 does not enable LPCOMP wake.
 - VBUS detection is used to skip boot lockout on external power, and VBUS wake is configured alongside LPCOMP when supported hardware exposes VBUS to the nRF52.
+- Runtime POF shutdown uses the nRF52 power-fail warning comparator. On XIAO it is configured for regulated VDD at 2.8 V and arms VBUS wake for SYSTEMOFF recovery.
 
 ## Technical Details
 
@@ -89,6 +96,7 @@ To enable power management on a board variant:
    #define PWRMGT_VOLTAGE_BOOTLOCK    3300   // Won't boot below this voltage (mV)
    #define PWRMGT_LPCOMP_AIN          7      // AIN channel for voltage sensing
    #define PWRMGT_LPCOMP_REFSEL       2      // REFSEL (0-6=1/8..7/8, 7=ARef, 8-15=1/16..15/16)
+   #define PWRMGT_POWER_FAIL_VDD_THRESHOLD POWER_POFCON_THRESHOLD_V28 // Optional; 2.8 V regulated VDD
    ```
 
 3. **Implement in board .cpp file**:
@@ -97,7 +105,9 @@ To enable power management on a board variant:
    const PowerMgtConfig power_config = {
      .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
      .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-     .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+     .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+     .power_fail_vdd_threshold = 0,    // Optional; 0 disables runtime POF shutdown
+     .power_fail_vbus_wake = false     // Optional; true arms VBUS wake after POF shutdown
    };
 
    void MyBoard::initiateShutdown(uint8_t reason) {
@@ -142,6 +152,25 @@ The LPCOMP (Low Power Comparator) is configured to:
 - Wake the device from SYSTEMOFF when triggered
 
 VBUS wake is enabled via the POWER peripheral USBDETECTED event whenever `configureVoltageWake()` is used. This requires USB VBUS to be routed to the nRF52 (typical on nRF52840 boards with native USB).
+
+### Runtime Power-Fail Configuration
+
+Runtime power-fail shutdown is configured by optional `PowerMgtConfig` fields:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `power_fail_vdd_threshold` | `0` | Disabled when `0`; otherwise an nRF52 `POWER_POFCON_THRESHOLD_*` value for regulated VDD |
+| `power_fail_vbus_wake` | `false` | When true, the POF handler arms VBUS detect as the SYSTEMOFF wake source |
+
+For nRF52840 VDD, supported POF thresholds are 1.7 V through 2.8 V in 0.1 V steps. The XIAO nRF52840 default uses `POWER_POFCON_THRESHOLD_V28`, the highest available regulated-VDD threshold, so firmware gets the earliest available warning when the 3.3 V rail starts to collapse.
+
+For nRF52840 VDDH, hardware also supports 2.7 V through 4.2 V thresholds. MeshCore does not currently use the VDDH threshold for XIAO because a battery on the XIAO VUSB pin is not the same as direct nRF52840 VDDH measurement in the board abstraction.
+
+This path is deliberately separate from SYSTEMOFF wake source selection:
+- If supply voltage simply collapses, firmware does not choose a wake source; reset and regulator hardware determine when execution resumes.
+- POF shutdown only applies if the MCU is still executing when VDD crosses the configured threshold.
+- When POF shutdown succeeds and `power_fail_vbus_wake` is true, recovery happens when the nRF52 VBUS detector sees VUSB again, not when BAT sense rises.
+- SoftDevice builds need a SoftDevice SoC event hook for `NRF_EVT_POWER_FAILURE_WARNING`. The current Adafruit nRF52 framework consumes that event internally, so this branch only enables direct POF shutdown when SoftDevice is not active.
 
 **LPCOMP Reference Selection (PWRMGT_LPCOMP_REFSEL)**:
 

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -75,7 +75,7 @@ Shutdown reason codes (stored in GPREGRET2):
 
 | Board                                     | Implemented | LPCOMP wake | VBUS wake | Runtime POF shutdown |
 |-------------------------------------------|-------------|-------------|-----------|----------------------|
-| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       | USB builds only      |
+| Seeed Studio XIAO nRF52840 (`xiao_nrf52`) | Yes         | No          | Yes       | Yes                  |
 | RAK4631 (`rak4631`)                       | Yes         | Yes         | Yes       | No                   |
 | Heltec T114 (`heltec_t114`)               | Yes         | Yes         | Yes       | No                   |
 | GAT562 Mesh Watch13                       | Yes         | Yes         | Yes       | No                   |

--- a/docs/nrf52_power_management.md
+++ b/docs/nrf52_power_management.md
@@ -27,7 +27,7 @@ The nRF52 Power Management module provides battery protection features to preven
 - `get pwrmgt.source` returns a source state. Normal detected sources use a confidence suffix: `vusb+bat`, `vusb-only`, `bat-only`, or `none`, followed by `:valid`, `:implausible`, `:invalid`, or `:unknown`
 - `invalid` means the board cannot use the configured battery sense path for protective decisions
 - `implausible` means the sensed voltage is outside the board's configured plausible range
-- `undetected` means the board is powered, but neither VBUS detect nor a valid BAT sense path can prove which input is supplying it
+- `possible-battery` means the board is powered without VBUS detect, and the board cannot prove whether VUSB is being used as a battery input
 
 Confidence suffixes are assigned as follows:
 
@@ -37,6 +37,7 @@ Confidence suffixes are assigned as follows:
 | `:implausible`  | Battery sense is enabled for the board but the reading is below minimum or above maximum   | Blocked                  |
 | `:invalid`      | Battery sense is not valid for the board's supported wiring or operating mode              | Blocked                  |
 | `:unknown`      | Power management has no active board configuration when the source is queried              | Blocked                  |
+| `:possible-battery` | VBUS detect is low, BAT sense is invalid, and VUSB may be acting as a battery input   | Blocked                  |
 
 The current nRF52 power-management board configs all use these plausibility thresholds:
 
@@ -49,7 +50,7 @@ The range is inclusive: `2500mV <= battery_mv <= 4500mV` is `:valid` when the bo
 
 There are no configured VUSB millivolt confidence thresholds in the current implementation. VUSB state is based on the nRF52 `USBREGSTATUS.VBUSDETECT` hardware signal, not a firmware ADC voltage reading centred around 5V. `PowerMgtConfig::vbus_wake_valid` only records whether VBUS wake is supported for the board.
 
-This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware cannot prove the input path and reports `undetected` rather than `none`.
+This means a battery connected to VUSB is reported as `vusb-only:valid` while `VBUSDETECT` is asserted. If that VUSB battery falls below the hardware detection point but still powers the MCU, firmware reports `vusb-only:possible-battery` rather than `none`.
 
 ### Early Boot Register Capture
 - Captures RESETREAS (reset reason) and GPREGRET2 (shutdown reason) before SystemInit() clears them

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -70,6 +70,7 @@ public:
 
   // Power management interface (boards with power management override these)
   virtual bool isExternalPowered() { return false; }
+  virtual const char* getPowerSourceState() { return isExternalPowered() ? "vusb-only:unknown" : "none:unknown"; }
   virtual uint16_t getBootVoltage() { return 0; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -72,6 +72,7 @@ public:
   virtual bool isExternalPowered() { return false; }
   virtual const char* getPowerSourceState() { return isExternalPowered() ? "vusb-only:unknown" : "none:unknown"; }
   virtual uint16_t getBootVoltage() { return 0; }
+  virtual bool isBootVoltageValid() { return false; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }
   virtual uint8_t getShutdownReason() const { return 0; }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -958,7 +958,8 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
       _board->getShutdownReasonString(_board->getShutdownReason()));
   } else if (memcmp(config, "pwrmgt.bootmv", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
-    sprintf(reply, "> %u mV", _board->getBootVoltage());
+    sprintf(reply, _board->isBootVoltageValid() ? "> %u mV" : "> %u mV invalid",
+      _board->getBootVoltage());
 #else
     strcpy(reply, "ERROR: Power management not supported");
 #endif

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -3,6 +3,7 @@
 #include "TxtDataHelpers.h"
 #include "AdvertDataHelpers.h"
 #include "TxtDataHelpers.h"
+#include "RadioInitDiagnostics.h"
 #include <RTClib.h>
 
 #ifndef BRIDGE_MAX_BAUD
@@ -963,6 +964,24 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
 #else
     strcpy(reply, "ERROR: Power management not supported");
 #endif
+  } else if (memcmp(config, "radio.init_status", 17) == 0) {
+    sprintf(reply, "> %d", (int)g_last_radio_init_status);
+  } else if (memcmp(config, "radio.init_attempts", 19) == 0) {
+    sprintf(reply, "> %u", (unsigned)g_radio_init_attempts);
+  } else if (memcmp(config, "diag.boot", 9) == 0) {
+    RadioInitBootRecord cur = radioInitCurrentBootRecord();
+    RadioInitBootRecord prev = radioInitPreviousBootRecord();
+    sprintf(reply, "> cur_rr=0x%08lX cur_sd=0x%02X cur_st=0x%02X cur_radio=%d cur_att=%u prev_rr=0x%08lX prev_sd=0x%02X prev_st=0x%02X prev_radio=%d prev_att=%u",
+      (unsigned long)cur.reset_reason,
+      (unsigned)cur.shutdown_reason,
+      (unsigned)cur.boot_stage,
+      (int)cur.radio_status,
+      (unsigned)cur.attempts,
+      (unsigned long)prev.reset_reason,
+      (unsigned)prev.shutdown_reason,
+      (unsigned)prev.boot_stage,
+      (int)prev.radio_status,
+      (unsigned)prev.attempts);
   } else {
     sprintf(reply, "??: %s", config);
   }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -948,7 +948,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
 #endif
   } else if (memcmp(config, "pwrmgt.source", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
-    strcpy(reply, _board->isExternalPowered() ? "> external" : "> battery");
+    sprintf(reply, "> %s", _board->getPowerSourceState());
 #else
     strcpy(reply, "ERROR: Power management not supported");
 #endif

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -1,5 +1,6 @@
 #if defined(NRF52_PLATFORM)
 #include "NRF52Board.h"
+#include "RadioInitDiagnostics.h"
 
 #include <bluefruit.h>
 #include <nrf_soc.h>
@@ -77,6 +78,7 @@ void NRF52Board::initPowerMgr() {
   // Copy early-captured register values
   reset_reason = g_nrf52_reset_reason;
   shutdown_reason = g_nrf52_shutdown_reason;
+  radioInitCaptureBoot(reset_reason, shutdown_reason);
   boot_voltage_mv = 0;  // Will be set by checkBootVoltage()
 
   // Clear registers for next boot

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -155,8 +155,13 @@ bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
     return true;
   }
 
-  if (!isBatteryVoltagePlausible(boot_voltage_mv, config)) {
-    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausible battery voltage)");
+  if (boot_voltage_mv < config->battery_min_present_mv) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (battery absent or floating)");
+    return true;
+  }
+
+  if (boot_voltage_mv > config->battery_max_plausible_mv) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausibly high battery voltage)");
     return true;
   }
 
@@ -339,6 +344,11 @@ bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtCo
   if (config == nullptr) return false;
   return millivolts >= config->battery_min_plausible_mv &&
          millivolts <= config->battery_max_plausible_mv;
+}
+
+bool NRF52Board::isBootVoltageValid() {
+  return active_power_config != nullptr &&
+         active_power_config->battery_voltage_sense_valid;
 }
 
 const char* NRF52Board::getPowerSourceState() {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -30,6 +30,7 @@ void NRF52Board::begin() {
 uint32_t g_nrf52_reset_reason = 0;     // Reset/Startup reason
 uint8_t g_nrf52_shutdown_reason = 0;   // Shutdown reason
 static bool nrf52_power_fail_vbus_wake = false;
+static bool nrf52_power_fail_configured = false;
 
 // Early constructor - runs before SystemInit() clears the registers
 // Priority 101 ensures this runs before SystemInit (102) and before
@@ -322,10 +323,28 @@ void NRF52Board::configurePowerFailShutdown(const PowerMgtConfig* config) {
 
   nrfx_power_pof_init(&pof_config);
   nrfx_power_pof_enable(&pof_config);
+  nrf52_power_fail_configured = true;
 
   MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown configured (VDD threshold code = %u; VBUS wake = %s)",
     config->power_fail_vdd_threshold,
     config->power_fail_vbus_wake ? "yes" : "no");
+}
+
+void NRF52Board::disablePowerFailShutdown() {
+  if (!nrf52_power_fail_configured) return;
+
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+  if (sd_enabled) {
+    MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown left unchanged (SoftDevice active)");
+    return;
+  }
+
+  nrfx_power_pof_disable();
+  nrfx_power_pof_uninit();
+  nrf52_power_fail_configured = false;
+  nrf52_power_fail_vbus_wake = false;
+  MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown disabled");
 }
 
 bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const {
@@ -462,6 +481,12 @@ bool NRF52Board::startOTAUpdate(const char *id, char reply[]) {
   // Note: All config***() function must be called before begin()
   Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
   Bluefruit.configPrphConn(92, BLE_GAP_EVENT_LENGTH_MIN, 16, 16);
+
+#ifdef NRF52_POWER_MANAGEMENT
+  // OTA enables SoftDevice after normal board startup. Release the direct
+  // nrfx POWER/POF handler first so SoftDevice owns POWER events cleanly.
+  disablePowerFailShutdown();
+#endif
 
   Bluefruit.begin(1, 0);
   // Set max power. Accepted values are: -40, -30, -20, -16, -12, -8, -4, 0, 4

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -351,7 +351,7 @@ const char* NRF52Board::getPowerSourceState() {
   uint16_t battery_mv = getBattMilliVolts();
 
   if (!active_power_config->battery_voltage_sense_valid) {
-    return vusb_connected ? "vusb-only:invalid" : "none:invalid";
+    return vusb_connected ? "vusb-only:valid" : "undetected";
   }
 
   if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -63,7 +63,7 @@ static void nrf52_power_fail_warning_handler() {
   // Keep the path register-only: Serial, delay(), and board callbacks are not
   // safe when VDD is already falling.
   nrfx_power_pof_disable();
-  nrf52_record_shutdown_reason(SHUTDOWN_REASON_LOW_VOLTAGE);
+  NRF_POWER->GPREGRET2 = SHUTDOWN_REASON_LOW_VOLTAGE;
 
   if (nrf52_power_fail_vbus_wake) {
     nrf52_configure_vbus_wake_direct();
@@ -342,9 +342,10 @@ void NRF52Board::disablePowerFailShutdown() {
 
   nrfx_power_pof_disable();
   nrfx_power_pof_uninit();
+  nrfx_power_uninit();
   nrf52_power_fail_configured = false;
   nrf52_power_fail_vbus_wake = false;
-  MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown disabled");
+  MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown disabled and POWER released");
 }
 
 bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -24,10 +24,12 @@ void NRF52Board::begin() {
 
 #ifdef NRF52_POWER_MANAGEMENT
 #include "nrf.h"
+#include <nrfx_power.h>
 
 // Power Management global variables
 uint32_t g_nrf52_reset_reason = 0;     // Reset/Startup reason
 uint8_t g_nrf52_shutdown_reason = 0;   // Shutdown reason
+static bool nrf52_power_fail_vbus_wake = false;
 
 // Early constructor - runs before SystemInit() clears the registers
 // Priority 101 ensures this runs before SystemInit (102) and before
@@ -35,6 +37,39 @@ uint8_t g_nrf52_shutdown_reason = 0;   // Shutdown reason
 static void __attribute__((constructor(101))) nrf52_early_reset_capture() {
   g_nrf52_reset_reason = NRF_POWER->RESETREAS;
   g_nrf52_shutdown_reason = NRF_POWER->GPREGRET2;
+}
+
+static void nrf52_record_shutdown_reason(uint8_t reason) {
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+  if (sd_enabled) {
+    sd_power_gpregret_clr(1, 0xFF);
+    sd_power_gpregret_set(1, reason);
+  } else {
+    NRF_POWER->GPREGRET2 = reason;
+  }
+}
+
+static void nrf52_configure_vbus_wake_direct() {
+#ifdef POWER_INTENSET_USBDETECTED_Msk
+  NRF_POWER->EVENTS_USBDETECTED = 0;
+  NRF_POWER->INTENSET = POWER_INTENSET_USBDETECTED_Msk;
+#endif
+}
+
+static void nrf52_power_fail_warning_handler() {
+  // This callback runs in the POWER interrupt with the SoftDevice disabled.
+  // Keep the path register-only: Serial, delay(), and board callbacks are not
+  // safe when VDD is already falling.
+  nrfx_power_pof_disable();
+  nrf52_record_shutdown_reason(SHUTDOWN_REASON_LOW_VOLTAGE);
+
+  if (nrf52_power_fail_vbus_wake) {
+    nrf52_configure_vbus_wake_direct();
+  }
+
+  NRF_POWER->SYSTEMOFF = POWER_SYSTEMOFF_SYSTEMOFF_Enter;
+  while (1) { }
 }
 
 void NRF52Board::initPowerMgr() {
@@ -100,6 +135,7 @@ bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
 
   // Read boot voltage
   boot_voltage_mv = getBattMilliVolts();
+  configurePowerFailShutdown(config);
   
   if (config->voltage_bootlock == 0) return true;  // Protection disabled
 
@@ -135,12 +171,7 @@ void NRF52Board::enterSystemOff(uint8_t reason) {
   // Record shutdown reason in GPREGRET2
   uint8_t sd_enabled = 0;
   sd_softdevice_is_enabled(&sd_enabled);
-  if (sd_enabled) {
-    sd_power_gpregret_clr(1, 0xFF);
-    sd_power_gpregret_set(1, reason);
-  } else {
-    NRF_POWER->GPREGRET2 = reason;
-  }
+  nrf52_record_shutdown_reason(reason);
 
   // Flush serial buffers
   Serial.flush();
@@ -161,6 +192,18 @@ void NRF52Board::enterSystemOff(uint8_t reason) {
 
   // If we get here, something went wrong. Reset to recover.
   NVIC_SystemReset();
+}
+
+void NRF52Board::configureVbusWake() {
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+  if (sd_enabled) {
+    sd_power_usbdetected_enable(1);
+  } else {
+    nrf52_configure_vbus_wake_direct();
+  }
+
+  MESH_DEBUG_PRINTLN("PWRMGT: VBUS wake configured");
 }
 
 void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
@@ -210,17 +253,53 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
       ain_channel, ref_num);
   }
 
-  // Configure VBUS (USB power) wake alongside LPCOMP
+  // Configure VBUS (USB power) wake alongside LPCOMP.
+  configureVbusWake();
+}
+
+void NRF52Board::configurePowerFailShutdown(const PowerMgtConfig* config) {
+  if (config->power_fail_vdd_threshold == 0) return;
+
   uint8_t sd_enabled = 0;
   sd_softdevice_is_enabled(&sd_enabled);
   if (sd_enabled) {
-    sd_power_usbdetected_enable(1);
-  } else {
-    NRF_POWER->EVENTS_USBDETECTED = 0;
-    NRF_POWER->INTENSET = POWER_INTENSET_USBDETECTED_Msk;
+    // SoftDevice delivers POFWARN through its SoC event queue. The current
+    // framework consumes that queue internally and does not expose a power-fail
+    // callback, so leave runtime power-fail shutdown disabled rather than
+    // installing a competing interrupt handler.
+    MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown skipped (SoftDevice active)");
+    return;
   }
 
-  MESH_DEBUG_PRINTLN("PWRMGT: VBUS wake configured");
+  nrfx_power_config_t power_config = {};
+  power_config.dcdcen = NRF_POWER->DCDCEN != 0;
+#if NRFX_POWER_SUPPORTS_DCDCEN_VDDH
+  power_config.dcdcenhv = NRF_POWER->DCDCEN0 != 0;
+#endif
+
+  nrfx_err_t err = nrfx_power_init(&power_config);
+  if (err != NRFX_SUCCESS && err != NRFX_ERROR_ALREADY_INITIALIZED) {
+    MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown setup failed (nrfx init %lu)", (unsigned long)err);
+    return;
+  }
+
+  nrf52_power_fail_vbus_wake = config->power_fail_vbus_wake;
+
+  nrfx_power_pofwarn_config_t pof_config = {};
+  pof_config.handler = nrf52_power_fail_warning_handler;
+#if NRFX_POWER_SUPPORTS_POFCON
+  pof_config.thr = (nrf_power_pof_thr_t)config->power_fail_vdd_threshold;
+#endif
+#if NRFX_POWER_SUPPORTS_POFCON_VDDH
+  pof_config.thrvddh = NRF_POWER_POFTHRVDDH_V27;
+#endif
+
+  nrfx_power_pof_init(&pof_config);
+  nrfx_power_pof_enable(&pof_config);
+
+  MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown configured (VDD threshold code = %u; VBUS wake = %s)",
+    config->power_fail_vdd_threshold,
+    config->power_fail_vbus_wake ? "yes" : "no");
 }
 #endif
 

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -283,18 +283,6 @@ void NRF52Board::configureVoltageWake(const PowerMgtConfig* config) {
   }
 }
 
-void NRF52Board::configureVbusWake() {
-  uint8_t sd_enabled = 0;
-  sd_softdevice_is_enabled(&sd_enabled);
-  if (sd_enabled) {
-    sd_power_usbdetected_enable(1);
-  } else {
-    nrf52_configure_vbus_wake_direct();
-  }
-
-  MESH_DEBUG_PRINTLN("PWRMGT: VBUS wake configured");
-}
-
 void NRF52Board::configurePowerFailShutdown(const PowerMgtConfig* config) {
   if (config->power_fail_vdd_threshold == 0) return;
 

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -131,6 +131,7 @@ const char* NRF52Board::getShutdownReasonString(uint8_t reason) {
 }
 
 bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
+  active_power_config = config;
   initPowerMgr();
 
   // Read boot voltage
@@ -149,9 +150,17 @@ bool NRF52Board::checkBootVoltage(const PowerMgtConfig* config) {
   MESH_DEBUG_PRINTLN("PWRMGT: Boot voltage = %u mV (threshold = %u mV)",
       boot_voltage_mv, config->voltage_bootlock);
 
-  // Only trigger shutdown if reading is valid (>1000mV) AND below threshold
-  // This prevents spurious shutdowns on ADC glitches or uninitialized reads
-  if (boot_voltage_mv > 1000 && boot_voltage_mv < config->voltage_bootlock) {
+  if (!config->battery_voltage_sense_valid) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (battery voltage sense invalid)");
+    return true;
+  }
+
+  if (!isBatteryVoltagePlausible(boot_voltage_mv, config)) {
+    MESH_DEBUG_PRINTLN("PWRMGT: Boot check skipped (implausible battery voltage)");
+    return true;
+  }
+
+  if (boot_voltage_mv < config->voltage_bootlock) {
     MESH_DEBUG_PRINTLN("PWRMGT: Boot voltage too low - entering protective shutdown");
 
     initiateShutdown(SHUTDOWN_REASON_BOOT_PROTECT);
@@ -253,8 +262,32 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
       ain_channel, ref_num);
   }
 
-  // Configure VBUS (USB power) wake alongside LPCOMP.
-  configureVbusWake();
+}
+
+void NRF52Board::configureVoltageWake(const PowerMgtConfig* config) {
+  if (config == nullptr) return;
+
+  if (config->lpcomp_voltage_wake_valid) {
+    configureVoltageWake(config->lpcomp_ain_channel, config->lpcomp_refsel);
+  } else {
+    MESH_DEBUG_PRINTLN("PWRMGT: LPCOMP wake skipped (voltage sense invalid)");
+  }
+
+  if (config->vbus_wake_valid) {
+    configureVbusWake();
+  }
+}
+
+void NRF52Board::configureVbusWake() {
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+  if (sd_enabled) {
+    sd_power_usbdetected_enable(1);
+  } else {
+    nrf52_configure_vbus_wake_direct();
+  }
+
+  MESH_DEBUG_PRINTLN("PWRMGT: VBUS wake configured");
 }
 
 void NRF52Board::configurePowerFailShutdown(const PowerMgtConfig* config) {
@@ -300,6 +333,32 @@ void NRF52Board::configurePowerFailShutdown(const PowerMgtConfig* config) {
   MESH_DEBUG_PRINTLN("PWRMGT: POF shutdown configured (VDD threshold code = %u; VBUS wake = %s)",
     config->power_fail_vdd_threshold,
     config->power_fail_vbus_wake ? "yes" : "no");
+}
+
+bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const {
+  if (config == nullptr) return false;
+  return millivolts >= config->battery_min_plausible_mv &&
+         millivolts <= config->battery_max_plausible_mv;
+}
+
+const char* NRF52Board::getPowerSourceState() {
+  bool vusb_connected = isExternalPowered();
+
+  if (active_power_config == nullptr) {
+    return vusb_connected ? "vusb-only:unknown" : "none:unknown";
+  }
+
+  uint16_t battery_mv = getBattMilliVolts();
+
+  if (!active_power_config->battery_voltage_sense_valid) {
+    return vusb_connected ? "vusb-only:invalid" : "none:invalid";
+  }
+
+  if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {
+    return vusb_connected ? "vusb+bat:implausible" : "bat-only:implausible";
+  }
+
+  return vusb_connected ? "vusb+bat:valid" : "bat-only:valid";
 }
 #endif
 

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -352,6 +352,10 @@ const char* NRF52Board::getPowerSourceState() {
     return vusb_connected ? "vusb-only:valid" : "vusb-only:possible-battery";
   }
 
+  if (battery_mv < active_power_config->battery_min_present_mv) {
+    return vusb_connected ? "vusb-only:valid" : "vusb-only:possible-battery";
+  }
+
   if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {
     return vusb_connected ? "vusb+bat:implausible" : "bat-only:implausible";
   }

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -351,7 +351,7 @@ const char* NRF52Board::getPowerSourceState() {
   uint16_t battery_mv = getBattMilliVolts();
 
   if (!active_power_config->battery_voltage_sense_valid) {
-    return vusb_connected ? "vusb-only:valid" : "undetected";
+    return vusb_connected ? "vusb-only:valid" : "vusb-only:possible-battery";
   }
 
   if (!isBatteryVoltagePlausible(battery_mv, active_power_config)) {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -129,6 +129,8 @@ const char* NRF52Board::getShutdownReasonString(uint8_t reason) {
     case SHUTDOWN_REASON_LOW_VOLTAGE:  return "Low Voltage";
     case SHUTDOWN_REASON_USER:         return "User Request";
     case SHUTDOWN_REASON_BOOT_PROTECT: return "Boot Protection";
+    case RADIO_INIT_FAULT_RADIO_INIT_FAIL:
+      return "Radio Init Fail";
   }
   return "Unknown";
 }
@@ -357,8 +359,16 @@ bool NRF52Board::isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtCo
 }
 
 bool NRF52Board::isBootVoltageValid() {
-  return active_power_config != nullptr &&
-         active_power_config->battery_voltage_sense_valid;
+  if (active_power_config == nullptr ||
+      !active_power_config->battery_voltage_sense_valid) {
+    return false;
+  }
+
+  if (boot_voltage_mv < active_power_config->battery_min_present_mv) {
+    return false;
+  }
+
+  return isBatteryVoltagePlausible(boot_voltage_mv, active_power_config);
 }
 
 const char* NRF52Board::getPowerSourceState() {

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -71,6 +71,7 @@ protected:
   void configureVoltageWake(const PowerMgtConfig* config);
   void configureVbusWake();
   void configurePowerFailShutdown(const PowerMgtConfig* config);
+  void disablePowerFailShutdown();
   virtual void initiateShutdown(uint8_t reason);
   bool isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const;
 #endif

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -28,8 +28,11 @@ struct PowerMgtConfig {
   bool lpcomp_voltage_wake_valid;
   bool vbus_wake_valid;
 
-  // Broad plausibility limits for a sensed battery voltage. Readings outside
-  // this range are treated as unsafe evidence for protective shutdown decisions.
+  // Battery voltage interpretation thresholds. Readings below the present
+  // threshold are treated as absent/floating, not as a discharged battery.
+  uint16_t battery_min_present_mv;
+
+  // Broad plausibility limits for source-state confidence reporting.
   uint16_t battery_min_plausible_mv;
   uint16_t battery_max_plausible_mv;
 
@@ -85,6 +88,7 @@ public:
 
 #ifdef NRF52_POWER_MANAGEMENT
   uint16_t getBootVoltage() override { return boot_voltage_mv; }
+  bool isBootVoltageValid() override;
   const char* getPowerSourceState() override;
   virtual uint32_t getResetReason() const override { return reset_reason; }
   uint8_t getShutdownReason() const override { return shutdown_reason; }

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -21,6 +21,18 @@ struct PowerMgtConfig {
   // Boot protection voltage threshold (millivolts)
   // Set to 0 to disable boot protection
   uint16_t voltage_bootlock;
+
+  // Optional nRF52 power-fail warning threshold for regulated VDD.
+  // Set to 0 to disable runtime power-fail shutdown. Threshold values are
+  // the nRF52 POWER_POFCON_THRESHOLD_* enum values, for example
+  // POWER_POFCON_THRESHOLD_V28 for 2.8 V.
+  uint8_t power_fail_vdd_threshold;
+
+  // If true, runtime power-fail shutdown arms VBUS detect as the SYSTEMOFF
+  // wake source. This is useful for boards powered by a battery on VUSB where
+  // BAT sense is not available, but it only applies after a deliberate
+  // firmware shutdown before uncontrolled brownout.
+  bool power_fail_vbus_wake;
 };
 #endif
 
@@ -41,6 +53,8 @@ protected:
   bool checkBootVoltage(const PowerMgtConfig* config);
   void enterSystemOff(uint8_t reason);
   void configureVoltageWake(uint8_t ain_channel, uint8_t refsel);
+  void configureVbusWake();
+  void configurePowerFailShutdown(const PowerMgtConfig* config);
   virtual void initiateShutdown(uint8_t reason);
 #endif
 

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -22,6 +22,17 @@ struct PowerMgtConfig {
   // Set to 0 to disable boot protection
   uint16_t voltage_bootlock;
 
+  // Capability flags describe what this board can prove from its sense wiring.
+  // They prevent VBUS loss from being treated as proof that a BAT sense node is valid.
+  bool battery_voltage_sense_valid;
+  bool lpcomp_voltage_wake_valid;
+  bool vbus_wake_valid;
+
+  // Broad plausibility limits for a sensed battery voltage. Readings outside
+  // this range are treated as unsafe evidence for protective shutdown decisions.
+  uint16_t battery_min_plausible_mv;
+  uint16_t battery_max_plausible_mv;
+
   // Optional nRF52 power-fail warning threshold for regulated VDD.
   // Set to 0 to disable runtime power-fail shutdown. Threshold values are
   // the nRF52 POWER_POFCON_THRESHOLD_* enum values, for example
@@ -49,13 +60,16 @@ protected:
   uint32_t reset_reason;              // RESETREAS register value
   uint8_t shutdown_reason;            // GPREGRET value (why we entered last SYSTEMOFF)
   uint16_t boot_voltage_mv;           // Battery voltage at boot (millivolts)
+  const PowerMgtConfig* active_power_config = nullptr;
 
   bool checkBootVoltage(const PowerMgtConfig* config);
   void enterSystemOff(uint8_t reason);
   void configureVoltageWake(uint8_t ain_channel, uint8_t refsel);
+  void configureVoltageWake(const PowerMgtConfig* config);
   void configureVbusWake();
   void configurePowerFailShutdown(const PowerMgtConfig* config);
   virtual void initiateShutdown(uint8_t reason);
+  bool isBatteryVoltagePlausible(uint16_t millivolts, const PowerMgtConfig* config) const;
 #endif
 
 public:
@@ -71,6 +85,7 @@ public:
 
 #ifdef NRF52_POWER_MANAGEMENT
   uint16_t getBootVoltage() override { return boot_voltage_mv; }
+  const char* getPowerSourceState() override;
   virtual uint32_t getResetReason() const override { return reset_reason; }
   uint8_t getShutdownReason() const override { return shutdown_reason; }
   const char* getResetReasonString(uint32_t reason) override;

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -24,6 +24,9 @@ struct PowerMgtConfig {
 
   // Capability flags describe what this board can prove from its sense wiring.
   // They prevent VBUS loss from being treated as proof that a BAT sense node is valid.
+  // Keep every board initialiser explicit because this aggregate is compiled
+  // by older nRF52 toolchains that do not safely combine designated
+  // initialisers with in-struct defaults.
   bool battery_voltage_sense_valid;
   bool lpcomp_voltage_wake_valid;
   bool vbus_wake_valid;

--- a/src/helpers/RadioInitDiagnostics.cpp
+++ b/src/helpers/RadioInitDiagnostics.cpp
@@ -1,0 +1,79 @@
+#include "RadioInitDiagnostics.h"
+
+volatile int16_t g_last_radio_init_status = RADIOLIB_ERR_NONE;
+volatile uint8_t g_radio_init_attempts = 0;
+volatile uint8_t g_radio_init_boot_stage = RADIO_BOOT_STAGE_NONE;
+volatile uint8_t g_radio_init_fault = RADIO_INIT_FAULT_NONE;
+
+#if defined(NRF52_PLATFORM)
+RadioInitBootHistory g_radio_init_boot_history __attribute__((section(".noinit")));
+#else
+RadioInitBootHistory g_radio_init_boot_history = {};
+#endif
+
+static void resetRecord(volatile RadioInitBootRecord& record) {
+  record.reset_reason = 0;
+  record.radio_status = RADIOLIB_ERR_NONE;
+  record.shutdown_reason = RADIO_INIT_FAULT_NONE;
+  record.fault = RADIO_INIT_FAULT_NONE;
+  record.boot_stage = RADIO_BOOT_STAGE_NONE;
+  record.attempts = 0;
+}
+
+static void ensureBootHistory() {
+  if (g_radio_init_boot_history.magic == RADIO_INIT_BOOT_DIAG_MAGIC &&
+      g_radio_init_boot_history.version == RADIO_INIT_BOOT_DIAG_VERSION) {
+    return;
+  }
+
+  g_radio_init_boot_history.magic = RADIO_INIT_BOOT_DIAG_MAGIC;
+  g_radio_init_boot_history.version = RADIO_INIT_BOOT_DIAG_VERSION;
+  resetRecord(g_radio_init_boot_history.current);
+  resetRecord(g_radio_init_boot_history.previous);
+}
+
+void radioInitCaptureBoot(uint32_t reset_reason, uint8_t shutdown_reason) {
+  ensureBootHistory();
+
+  g_radio_init_boot_history.previous = g_radio_init_boot_history.current;
+  resetRecord(g_radio_init_boot_history.current);
+
+  g_radio_init_boot_history.current.reset_reason = reset_reason;
+  g_radio_init_boot_history.current.shutdown_reason = shutdown_reason;
+  g_radio_init_boot_history.current.fault = shutdown_reason;
+
+  g_radio_init_fault = shutdown_reason;
+  g_radio_init_boot_stage = RADIO_BOOT_STAGE_NONE;
+  g_radio_init_attempts = 0;
+  g_last_radio_init_status = RADIOLIB_ERR_NONE;
+}
+
+RadioInitBootRecord radioInitCurrentBootRecord() {
+  ensureBootHistory();
+  return g_radio_init_boot_history.current;
+}
+
+RadioInitBootRecord radioInitPreviousBootRecord() {
+  ensureBootHistory();
+  return g_radio_init_boot_history.previous;
+}
+
+void radioInitHistorySetStage(uint8_t stage) {
+  ensureBootHistory();
+  g_radio_init_boot_history.current.boot_stage = stage;
+}
+
+void radioInitHistorySetAttempt(uint8_t attempt) {
+  ensureBootHistory();
+  g_radio_init_boot_history.current.attempts = attempt;
+}
+
+void radioInitHistorySetStatus(int16_t status) {
+  ensureBootHistory();
+  g_radio_init_boot_history.current.radio_status = status;
+}
+
+void radioInitHistorySetFault(uint8_t fault) {
+  ensureBootHistory();
+  g_radio_init_boot_history.current.fault = fault;
+}

--- a/src/helpers/RadioInitDiagnostics.h
+++ b/src/helpers/RadioInitDiagnostics.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+#include <RadioLib.h>
+
+#if defined(NRF52_PLATFORM)
+#include <nrf.h>
+#endif
+
+#ifndef RADIOLIB_ERR_SPI_CMD_TIMEOUT
+#define RADIOLIB_ERR_SPI_CMD_TIMEOUT -705
+#endif
+
+#define RADIO_INIT_FAULT_NONE 0x00
+#define RADIO_INIT_FAULT_RADIO_INIT_FAIL 0x52
+#define RADIO_INIT_BOOT_DIAG_MAGIC 0x4D435244UL  // "MCRD"
+#define RADIO_INIT_BOOT_DIAG_VERSION 1
+
+enum RadioInitBootStage : uint8_t {
+  RADIO_BOOT_STAGE_NONE = 0x00,
+  RADIO_BOOT_STAGE_RADIO_INIT_ENTERED = 0x30,
+  RADIO_BOOT_STAGE_RTC_BEGIN_ENTERED = 0x31,
+  RADIO_BOOT_STAGE_RTC_BEGIN_RETURNED = 0x32,
+  RADIO_BOOT_STAGE_RADIO_STD_INIT_ENTERED = 0x40,
+  RADIO_BOOT_STAGE_RADIO_STD_INIT_SUCCESS = 0x41,
+  RADIO_BOOT_STAGE_RADIO_STD_INIT_FAIL = 0x42,
+  RADIO_BOOT_STAGE_RADIO_BUSY_TIMEOUT = 0x43,
+};
+
+struct RadioInitBootRecord {
+  uint32_t reset_reason;
+  int16_t radio_status;
+  uint8_t shutdown_reason;
+  uint8_t fault;
+  uint8_t boot_stage;
+  uint8_t attempts;
+};
+
+struct RadioInitBootHistory {
+  uint32_t magic;
+  uint8_t version;
+  RadioInitBootRecord current;
+  RadioInitBootRecord previous;
+};
+
+extern volatile int16_t g_last_radio_init_status;
+extern volatile uint8_t g_radio_init_attempts;
+extern volatile uint8_t g_radio_init_boot_stage;
+extern volatile uint8_t g_radio_init_fault;
+extern RadioInitBootHistory g_radio_init_boot_history;
+
+void radioInitCaptureBoot(uint32_t reset_reason, uint8_t shutdown_reason);
+RadioInitBootRecord radioInitCurrentBootRecord();
+RadioInitBootRecord radioInitPreviousBootRecord();
+void radioInitHistorySetStage(uint8_t stage);
+void radioInitHistorySetAttempt(uint8_t attempt);
+void radioInitHistorySetStatus(int16_t status);
+void radioInitHistorySetFault(uint8_t fault);
+
+inline void radioInitSetBootStage(uint8_t stage) {
+  g_radio_init_boot_stage = stage;
+  radioInitHistorySetStage(stage);
+}
+
+inline void radioInitRecordAttempt(uint8_t attempt) {
+  g_radio_init_attempts = attempt;
+  radioInitHistorySetAttempt(attempt);
+}
+
+inline void radioInitRecordStatus(int16_t status) {
+  g_last_radio_init_status = status;
+  radioInitHistorySetStatus(status);
+}
+
+inline void radioInitRecordFault(uint8_t fault) {
+  g_radio_init_fault = fault;
+  radioInitHistorySetFault(fault);
+#if defined(NRF52_PLATFORM)
+  // GPREGRET2 is already used as a reset-persistent one-byte reason store on
+  // nRF52. Writing the radio fault before reset lets the next boot report that
+  // the previous boot failed before normal application startup.
+  NRF_POWER->GPREGRET2 = fault;
+#endif
+}
+
+inline const char* radioInitFaultString(uint8_t fault) {
+  switch (fault) {
+    case RADIO_INIT_FAULT_NONE:
+      return "None";
+    case RADIO_INIT_FAULT_RADIO_INIT_FAIL:
+      return "Radio Init Fail";
+  }
+  return "Unknown";
+}
+
+inline bool radioInitWaitBusyLow(uint32_t timeout_ms) {
+#if defined(P_LORA_BUSY)
+  if (P_LORA_BUSY == RADIOLIB_NC) return true;
+
+  pinMode(P_LORA_BUSY, INPUT);
+  uint32_t start = millis();
+  while (digitalRead(P_LORA_BUSY) == HIGH) {
+    if (millis() - start > timeout_ms) {
+      radioInitSetBootStage(RADIO_BOOT_STAGE_RADIO_BUSY_TIMEOUT);
+      radioInitRecordStatus(RADIOLIB_ERR_SPI_CMD_TIMEOUT);
+      return false;
+    }
+    delay(1);
+  }
+#endif
+  return true;
+}
+
+inline void radioInitResetPulse() {
+#if defined(P_LORA_RESET)
+  if (P_LORA_RESET == RADIOLIB_NC) return;
+
+  pinMode(P_LORA_RESET, OUTPUT);
+  digitalWrite(P_LORA_RESET, LOW);
+  delay(10);
+  digitalWrite(P_LORA_RESET, HIGH);
+  delay(10);
+#endif
+}
+
+inline void radioInitPowerCycle() {
+#if defined(SX126X_POWER_EN)
+  pinMode(SX126X_POWER_EN, OUTPUT);
+  digitalWrite(SX126X_POWER_EN, LOW);
+  delay(50);
+  digitalWrite(SX126X_POWER_EN, HIGH);
+  delay(100);
+#endif
+}
+
+inline void radioInitPrepareAttempt(uint8_t attempt) {
+  if (attempt == 2) {
+    radioInitResetPulse();
+    delay(100);
+  } else if (attempt >= 3) {
+    radioInitPowerCycle();
+    radioInitResetPulse();
+    delay(150);
+  }
+}
+
+inline void radioInitRebootAfterFault(mesh::MainBoard& board, uint8_t fault) {
+  radioInitRecordFault(fault);
+  Serial.flush();
+  delay(250);
+  board.reboot();
+}

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT56230SMeshKitBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT562EVBProBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.cpp
@@ -10,7 +10,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
@@ -20,7 +25,7 @@ void GAT562MeshTrackerProBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -14,6 +14,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -14,8 +14,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.cpp
@@ -10,14 +10,19 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 
 void GAT56MeshWatch13Board::initiateShutdown(uint8_t reason) {
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
   enterSystemOff(reason);
 }

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T096Board::initiateShutdown(uint8_t reason) {
@@ -25,7 +30,7 @@ void T096Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? HIGH : LOW);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T096Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -7,7 +7,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T1Board::initiateShutdown(uint8_t reason) {
@@ -19,7 +24,7 @@ void T1Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? ADC_CTRL_ENABLED : !ADC_CTRL_ENABLED);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -11,6 +11,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -11,8 +11,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T1Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void T114Board::initiateShutdown(uint8_t reason) {

--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void T114Board::initiateShutdown(uint8_t reason) {
@@ -25,7 +30,7 @@ void T114Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? HIGH : LOW);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/heltec_tower_v2/HeltecTowerV2Board.cpp
+++ b/variants/heltec_tower_v2/HeltecTowerV2Board.cpp
@@ -9,7 +9,13 @@ extern void variant_shutdown();
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = false,
+  .battery_min_present_mv = 1000,
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void HeltecTowerV2Board::initiateShutdown(uint8_t reason) {
@@ -27,7 +33,7 @@ void HeltecTowerV2Board::initiateShutdown(uint8_t reason) {
   digitalWrite(PIN_BAT_CTL, enable_lpcomp ? HIGH : LOW);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   variant_shutdown();

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void R1NeoBoard::initiateShutdown(uint8_t reason) {
@@ -22,7 +27,7 @@ void R1NeoBoard::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/muziworks_r1_neo/R1NeoBoard.cpp
+++ b/variants/muziworks_r1_neo/R1NeoBoard.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void R1NeoBoard::initiateShutdown(uint8_t reason) {

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void RAK3401Board::initiateShutdown(uint8_t reason) {

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void RAK3401Board::initiateShutdown(uint8_t reason) {
@@ -21,7 +26,7 @@ void RAK3401Board::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -13,6 +13,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -9,7 +9,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void RAK4631Board::initiateShutdown(uint8_t reason) {
@@ -18,7 +23,7 @@ void RAK4631Board::initiateShutdown(uint8_t reason) {
 
   if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
       reason == SHUTDOWN_REASON_BOOT_PROTECT) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/rak4631/RAK4631Board.cpp
+++ b/variants/rak4631/RAK4631Board.cpp
@@ -13,8 +13,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void RAK4631Board::initiateShutdown(uint8_t reason) {

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -11,8 +11,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500
 };
 
 void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -7,7 +7,12 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = true,
+  .lpcomp_voltage_wake_valid = true,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500
 };
 
 void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {
@@ -18,7 +23,7 @@ void SenseCapSolarBoard::initiateShutdown(uint8_t reason) {
   digitalWrite(VBAT_ENABLE, enable_lpcomp ? LOW : HIGH);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -11,6 +11,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = true,
   .lpcomp_voltage_wake_valid = true,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500
 };

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -17,6 +17,7 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = false,
   .lpcomp_voltage_wake_valid = false,
   .vbus_wake_valid = true,
+  .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500,
   .power_fail_vdd_threshold = PWRMGT_POWER_FAIL_VDD_THRESHOLD,

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -17,8 +17,8 @@ const PowerMgtConfig power_config = {
   .battery_voltage_sense_valid = false,
   .lpcomp_voltage_wake_valid = false,
   .vbus_wake_valid = true,
-  .battery_min_plausible_mv = 1000,
-  .battery_max_plausible_mv = 6500,
+  .battery_min_plausible_mv = 2500,
+  .battery_max_plausible_mv = 4500,
   .power_fail_vdd_threshold = PWRMGT_POWER_FAIL_VDD_THRESHOLD,
   .power_fail_vbus_wake = true
 };

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -11,7 +11,9 @@
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
-  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .power_fail_vdd_threshold = PWRMGT_POWER_FAIL_VDD_THRESHOLD,
+  .power_fail_vbus_wake = true
 };
 
 void XiaoNrf52Board::initiateShutdown(uint8_t reason) {

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -20,7 +20,13 @@ const PowerMgtConfig power_config = {
   .battery_min_present_mv = 1000,
   .battery_min_plausible_mv = 2500,
   .battery_max_plausible_mv = 4500,
+#ifdef BLE_PIN_CODE
+  // BLE companion builds enable SoftDevice after board.begin(). Do not install
+  // a direct nrfx POWER/POF interrupt before SoftDevice takes ownership.
+  .power_fail_vdd_threshold = 0,
+#else
   .power_fail_vdd_threshold = PWRMGT_POWER_FAIL_VDD_THRESHOLD,
+#endif
   .power_fail_vbus_wake = true
 };
 

--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -8,10 +8,17 @@
 #ifdef NRF52_POWER_MANAGEMENT
 // Static configuration for power management
 // Values set in variant.h defines
+// XIAO BAT+ is optional. When VUSB is the actual supply and BAT+ is open, the
+// BAT divider/LPCOMP node is not valid evidence for protective shutdown.
 const PowerMgtConfig power_config = {
   .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
   .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
   .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK,
+  .battery_voltage_sense_valid = false,
+  .lpcomp_voltage_wake_valid = false,
+  .vbus_wake_valid = true,
+  .battery_min_plausible_mv = 1000,
+  .battery_max_plausible_mv = 6500,
   .power_fail_vdd_threshold = PWRMGT_POWER_FAIL_VDD_THRESHOLD,
   .power_fail_vbus_wake = true
 };
@@ -24,7 +31,7 @@ void XiaoNrf52Board::initiateShutdown(uint8_t reason) {
   digitalWrite(VBAT_ENABLE, enable_lpcomp ? LOW : HIGH);
 
   if (enable_lpcomp) {
-    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+    configureVoltageWake(&power_config);
   }
 
   enterSystemOff(reason);

--- a/variants/xiao_nrf52/variant.h
+++ b/variants/xiao_nrf52/variant.h
@@ -79,6 +79,13 @@ static const uint8_t D10 = 10;
 // Set to 0 to disable boot protection
 #define PWRMGT_VOLTAGE_BOOTLOCK    3300   // Won't boot below this voltage
 
+// Runtime power-fail warning for VUSB-battery builds.
+// The nRF52840 can warn on regulated VDD down to configurable thresholds, but
+// it cannot directly measure VUSB without a board-level ADC path. Use the
+// highest VDD threshold so firmware can deliberately enter SYSTEMOFF before an
+// uncontrolled brownout when the regulator output starts to collapse.
+#define PWRMGT_POWER_FAIL_VDD_THRESHOLD  POWER_POFCON_THRESHOLD_V28
+
 // LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
 #define PWRMGT_LPCOMP_AIN           7     // AIN7 = P0.31 = PIN_VBAT
 // IMPORTANT: The XIAO exposes battery via a resistor divider (ADC_MULTIPLIER = 3.0).


### PR DESCRIPTION
I actually submitted most of this code a short while ago thinking it wasn't directly useful to me.  But as it happens, I needed it after all.  This PR is the rest of the bug fix that I was looking for.

Essentially, I kept finding myself needing to do a physical reset of repeaters based on the XIAO nRF52 MCU.  I had been a bit "lazy" when it came to wiring up my hardware, especially because I was using an external solar charge / battery controller, I had simply wired up the VUSB and GND pins and ignored the battery sense pins.

It turns out that in this configuration, if the battery gets very low, the device browns out and then can't recover.  That is because of a couple of issues:

- in many situations booting requires the battery sense checking routines to unlock the rest of the boot sequence.  If you haven't got the battery sense pins wired up, surprise surprise, it doesn't boot.  That logic is now more refined and it copes better with the extra layer of complexity.
- The device also has no way of knowing what voltage the battery is at when it is being delivered over VUSB.  This makes sense, however, what this means is the MCU basically carries on until the +ve rail's voltage collapses.  This then puts the MCU in a state that means it isn't willing to contemplate a soft reboot.

Along the way I have added a load of instrumentation so that it is possible to diagnose issues by using real data.