### PR TITLE
build: add gcc, gtest to nix shell, fix native test framework

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,12 @@
-{ pkgs ? import <nixpkgs> {} }:
-let
+{pkgs ? import <nixpkgs> {}}: let
 in
   pkgs.mkShell {
     buildInputs = [
       pkgs.platformio
       pkgs.python3
+      pkgs.gcc
+      pkgs.gtest
       # optional: needed as a programmer i.e. for esp32
       pkgs.avrdude
     ];
-}
+  }

--- a/platformio.ini
+++ b/platformio.ini
@@ -157,6 +157,7 @@ lib_deps =
 
 [env:native]
 platform = native
+test_framework = googletest
 build_flags = -std=c++17
   -I src
   -I test/mocks


### PR DESCRIPTION
Before, the nix devshell (loaded by direnv) didn't include all the necessary packages. This PR adds them, plus the googletest output for tests so they are recognized. See before and after below.

# Before

```
❯ pio test -e native
Verbosity level can be increased via `-v, -vv, or -vvv` option
Collected 1 tests

Processing test_utils in native environment
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Building...
Removing unused dependencies...
Library Manager: Removing googletest @ 1.17.0
Library Manager: googletest@1.17.0 has been removed!
Library Manager: Installing google/googletest @ 1.17.0
Unpacking  [####################################]  100%
Library Manager: googletest@1.17.0 has been installed!
Library Manager: Installing throwtheswitch/Unity @ ^2.6.1
Unpacking  [####################################]  100%
Library Manager: Unity@2.6.1 has been installed!
error: tool 'gcc' not found
error: tool 'g++' not found
error: tool 'gcc' not found
*** [.pio/build/native/unity_config_build/unity_config.o] Error 1
error: tool 'g++' not found
*** [.pio/build/native/test/test_utils/test_tohex.o] Error 1
error: tool 'g++' not found
*** [.pio/build/native/src/Utils.o] Error 1
error: tool 'g++' not found
*** [.pio/build/native/lib162/googletest/googlemock/src/gmock-cardinalities.o] Error 1
error: tool 'g++' not found
*** [.pio/build/native/lib162/googletest/googlemock/src/gmock-internal-utils.o] Error 1
Building stage has failed, see errors above. Use `pio test -vvv` option to enable verbose output.
------------------------------------------------------------------------------ native:test_utils [ERRORED] Took 6.04 seconds ------------------------------------------------------------------------------

================================================================================================= SUMMARY =================================================================================================
Environment    Test        Status    Duration
-------------  ----------  --------  ------------
native         test_utils  ERRORED   00:00:06.040
================================================================================ 1 test cases: 0 succeeded in 00:00:06.040 ================================================================================
```

# After

```
❯ pio test -e native
Verbosity level can be increased via `-v, -vv, or -vvv` option
Collected 1 tests

Processing test_utils in native environment
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Building...
Removing unused dependencies...
Library Manager: Removing Unity @ 2.6.1
Library Manager: Unity@2.6.1 has been removed!
Testing...
UtilsToHex.ConvertSingleByte    [PASSED]
UtilsToHex.ConvertMultipleBytes [PASSED]
UtilsToHex.ConvertZeroByte      [PASSED]
UtilsToHex.ConvertMaxByte       [PASSED]
UtilsToHex.NullTerminatesOnEmptyInput   [PASSED]
------------------------------------------------------------------------------ native:test_utils [PASSED] Took 8.32 seconds ------------------------------------------------------------------------------

================================================================================================= SUMMARY =================================================================================================
Environment    Test        Status    Duration
-------------  ----------  --------  ------------
native         test_utils  PASSED    00:00:08.321
================================================================================ 5 test cases: 5 succeeded in 00:00:08.321 ================================================================================

```