### PR TITLE
Fix: Treat all-zero channel secrets as empty/deleted slots instead of valid channel keys

### DIFF
--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -9,6 +9,12 @@
   #define TXT_ACK_DELAY     200
 #endif
 
+#ifdef MAX_GROUP_CHANNELS
+namespace {
+static const uint8_t ZERO_CHANNEL_SECRET[32] = {};
+}
+#endif
+
 void BaseChatMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis) {
   sendFlood(pkt, delay_millis);
 }
@@ -368,6 +374,10 @@ void BaseChatMesh::handleReturnPathRetry(const ContactInfo& contact, const uint8
 int BaseChatMesh::searchChannelsByHash(const uint8_t* hash, mesh::GroupChannel dest[], int max_matches) {
   int n = 0;
   for (int i = 0; i < MAX_GROUP_CHANNELS && n < max_matches; i++) {
+    if (memcmp(channels[i].channel.secret, ZERO_CHANNEL_SECRET, sizeof(ZERO_CHANNEL_SECRET)) == 0) {
+      continue;
+    }
+
     if (channels[i].channel.hash[0] == hash[0]) {
       dest[n++] = channels[i].channel;
     }
@@ -903,6 +913,11 @@ bool BaseChatMesh::setChannel(int idx, const ChannelDetails& src) {
   static uint8_t zeroes[] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
 
   if (idx >= 0 && idx < MAX_GROUP_CHANNELS) {
+    if (memcmp(src.channel.secret, ZERO_CHANNEL_SECRET, sizeof(ZERO_CHANNEL_SECRET)) == 0) {
+      memset(&channels[idx], 0, sizeof(channels[idx]));
+      return true;
+    }
+
     channels[idx] = src;
     if (memcmp(&src.channel.secret[16], zeroes, 16) == 0) {
       mesh::Utils::sha256(channels[idx].channel.hash, sizeof(channels[idx].channel.hash), src.channel.secret, 16);  // 128-bit key
@@ -914,7 +929,11 @@ bool BaseChatMesh::setChannel(int idx, const ChannelDetails& src) {
   return false;
 }
 int BaseChatMesh::findChannelIdx(const mesh::GroupChannel& ch) {
+  if (memcmp(ch.secret, ZERO_CHANNEL_SECRET, sizeof(ZERO_CHANNEL_SECRET)) == 0) return -1;
+
   for (int i = 0; i < MAX_GROUP_CHANNELS; i++) {
+    if (memcmp(channels[i].channel.secret, ZERO_CHANNEL_SECRET, sizeof(ZERO_CHANNEL_SECRET)) == 0) continue;
+
     if (memcmp(ch.secret, channels[i].channel.secret, sizeof(ch.secret)) == 0) return i;
   }
   return -1;  // not found


### PR DESCRIPTION
## Summary

Treat all-zero channel secrets as empty or deleted slots instead of valid channel keys.

This PR was prompted after multiple users reported receiving unexpected group messages on channel they had never configured. Depending on the client, these messages appeared only in the RX log, as an unnamed channel, or as #unknown (also in meshcore-cli).

Clients represent channel removal by writing an empty channel record with a 32-byte zero secret. Previously, such a slot could still be interpreted as a valid 128-bit channel: the firmware would hash the first 16 zero bytes, producing channel hash `0x37`.

Because empty slots were still considered during channel lookup, packets created with the publicly known zero key could be decrypted and handled like normal group messages. This could cause unsolicited messages to appear in connected clients under an empty or unknown channel and enter the regular message notification flow.

## Changes

* Add a shared 32-byte zero-secret constant.
* Skip zero-secret slots in `searchChannelsByHash()`.
* Treat a zero secret passed to `setChannel()` as channel deletion and clear the slot.
* Prevent zero-secret channels and empty slots from matching in `findChannelIdx()`.

## Result

Empty and deleted channel slots are now consistently treated as inactive. They no longer participate in channel lookup or decryption, preventing zero-key group messages from reaching connected Companion clients.

---

## Cases

Shared key: `00000000000000000000000000000000`
Example packet: `154535 B9 56 8F 05 60 10 0A B1 B537 7F 9A 2F 24 96 7F 45 5A C9 B5 4A 6C 12 E0 14 0F B7 B5 67 33 69 6D 37 64 A0 ED 9E A4 B4 50 A2 54 82 E7` ([analyzer](https://analyzer.meshcore.cz/#/packets/3BE02ADD00D2C332?observer=F7F57B8E5482B5AAD6735174C8ACDA31196CC3B38F67EF96EC049F34F748803A))

<img width="200"  alt="photo_2026-07-05 17 05 44" src="https://github.com/user-attachments/assets/1c984573-0f21-44d8-bfdf-351b764dc1ff" />
<img width="200" alt="photo_2026-07-05 17 06 02" src="https://github.com/user-attachments/assets/c71f5e32-0ca1-4290-9a53-d4291308f9bb" />
