### PR TITLE
Fixed hibernate / poweroff for BLE companions and repeaters to stay at uA

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -697,8 +697,7 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    _display->turnOff();
-    radio_driver.powerOff();
+    // Power off board including radio, display, GPS and components
     _board->powerOff();
   }
 }

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -307,7 +307,7 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    radio_driver.powerOff();
+    // Power off board including radio, display, GPS and components
     _board->powerOff();
   }
 }

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -566,8 +566,7 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    _display->turnOff();
-    radio_driver.powerOff();
+    // Power off board including radio, display, GPS and components
     _board->powerOff();
   }
 }

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -1,6 +1,7 @@
 #ifdef ESP_PLATFORM
 
 #include "ESP32Board.h"
+#include <target.h>
 
 #if defined(ADMIN_PASSWORD) && !defined(DISABLE_WIFI_OTA)   // Repeater or Room Server only
 #include <WiFi.h>
@@ -44,4 +45,45 @@ bool ESP32Board::startOTAUpdate(const char* id, char reply[]) {
 }
 #endif
 
+void ESP32Board::powerOff() {
+  enterDeepSleep(0); // Do not wakeup
+}
+
+void ESP32Board::enterDeepSleep(uint32_t secs) {
+  // Power off the display if any
+#ifdef DISPLAY_CLASS
+  display.turnOff();
+#endif
+
+  // Power off LoRa
+  radio_driver.powerOff();
+
+  // Keep LoRa inactive during deepsleep
+  digitalWrite(P_LORA_NSS, HIGH);
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+  gpio_hold_en((gpio_num_t)P_LORA_NSS);
+#else
+  rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
+#endif
+
+  // Power off GPS if any
+  if (sensors.getLocationProvider() != NULL) {
+    sensors.getLocationProvider()->stop();
+  }
+
+  // Flush serial buffers
+  Serial.flush();
+  delay(100);
+
+  // Clear stale wakeup sources to avoid ghost wakeup
+  // This is required when Power Management and automatic lightsleep are enabled
+  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
+  if (secs > 0) {
+    esp_sleep_enable_timer_wakeup(secs * 1000000ULL);
+  }
+
+  // Finally set ESP32 into deepsleep
+  esp_deep_sleep_start(); // CPU halts here and never returns!
+}
 #endif

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -62,6 +62,9 @@ public:
     return raw / 4;
   }
 
+  virtual void powerOff() override;
+  void enterDeepSleep(uint32_t secs);
+
   uint32_t getIRQGpio() override {
     return P_LORA_DIO_1; // default for SX1262
   }

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -14,6 +14,7 @@
 #include <Wire.h>
 #include "soc/rtc.h"
 #include "esp_system.h"
+#include <driver/rtc_io.h>
 
 class ESP32Board : public mesh::MainBoard {
 protected:

--- a/src/helpers/MeshadventurerBoard.h
+++ b/src/helpers/MeshadventurerBoard.h
@@ -15,8 +15,6 @@
 
 #include "ESP32Board.h"
 
-#include <driver/rtc_io.h>
-
 class MeshadventurerBoard : public ESP32Board {
 
 public:
@@ -33,34 +31,6 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
-  }
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are held on required levels during deep sleep 
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void powerOff() override {
-    // TODO: re-enable this when there is a definite wake-up source pin:
-    //  enterDeepSleep(0);
   }
 
   uint16_t getBattMilliVolts() override {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -1,5 +1,6 @@
 #if defined(NRF52_PLATFORM)
 #include "NRF52Board.h"
+#include <target.h>
 
 #include <bluefruit.h>
 #include <nrf_soc.h>
@@ -295,6 +296,37 @@ float NRF52Board::getMCUTemperature() {
   NRF_TEMP->TASKS_STOP = 1;
 
   return temp * 0.25f; // Convert to *C
+}
+
+void NRF52Board::powerOff() {
+  // Power off the display if any
+#ifdef DISPLAY_CLASS
+  display.turnOff();
+#endif
+
+  // Power off LoRa
+  radio_driver.powerOff();
+
+  // Keep LoRa inactive during deepsleep
+  digitalWrite(P_LORA_NSS, HIGH);
+
+  // Power off GPS if any
+  if(sensors.getLocationProvider() != NULL) {
+    sensors.getLocationProvider()->stop();
+  }
+
+  // Flush serial buffers
+  Serial.flush();
+  delay(100);
+
+  // Enter SYSTEMOFF
+  uint8_t sd_enabled = 0;
+  sd_softdevice_is_enabled(&sd_enabled);
+  if (sd_enabled) { // SoftDevice is enabled
+    sd_power_system_off();
+  } else { // SoftDevice is not enable
+    NRF_POWER->SYSTEMOFF = POWER_SYSTEMOFF_SYSTEMOFF_Enter;
+  }
 }
 
 bool NRF52Board::getBootloaderVersion(char* out, size_t max_len) {

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -50,6 +50,7 @@ public:
   virtual uint8_t getStartupReason() const override { return startup_reason; }
   virtual float getMCUTemperature() override;
   virtual void reboot() override { NVIC_SystemReset(); }
+  virtual void powerOff() override;
   virtual bool getBootloaderVersion(char* version, size_t max_len) override;
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
   virtual void sleep(uint32_t secs) override;

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.h
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.h
@@ -47,7 +47,7 @@ public:
     uint32_t button_pin = PIN_BUTTON1;
     nrf_gpio_cfg_input(button_pin, NRF_GPIO_PIN_PULLUP);
     nrf_gpio_cfg_sense_set(button_pin, NRF_GPIO_PIN_SENSE_LOW);
-    sd_power_system_off(); 
+    NRF52Board::powerOff();
   }
 
 };

--- a/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.h
+++ b/variants/gat562_mesh_evb_pro/GAT562EVBProBoard.h
@@ -47,7 +47,7 @@ public:
     uint32_t button_pin = PIN_BUTTON1;
     nrf_gpio_cfg_input(button_pin, NRF_GPIO_PIN_PULLUP);
     nrf_gpio_cfg_sense_set(button_pin, NRF_GPIO_PIN_SENSE_LOW);
-    sd_power_system_off(); 
+    NRF52Board::powerOff();
   }
 
 };

--- a/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.h
+++ b/variants/gat562_mesh_tracker_pro/GAT562MeshTrackerProBoard.h
@@ -47,7 +47,7 @@ public:
     uint32_t button_pin = PIN_BUTTON1;
     nrf_gpio_cfg_input(button_pin, NRF_GPIO_PIN_PULLUP);
     nrf_gpio_cfg_sense_set(button_pin, NRF_GPIO_PIN_SENSE_LOW);
-    sd_power_system_off(); 
+    NRF52Board::powerOff();
   }
 
 };

--- a/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.h
+++ b/variants/gat562_mesh_watch13/GAT56MeshWatch13Board.h
@@ -38,7 +38,7 @@ public:
     uint32_t button_pin = PIN_BUTTON1;
     nrf_gpio_cfg_input(button_pin, NRF_GPIO_PIN_PULLUP);
     nrf_gpio_cfg_sense_set(button_pin, NRF_GPIO_PIN_SENSE_LOW);
-    sd_power_system_off(); 
+    NRF52Board::powerOff();
   }
 
 };

--- a/variants/heltec_e213/HeltecE213Board.cpp
+++ b/variants/heltec_e213/HeltecE213Board.cpp
@@ -20,33 +20,6 @@ void HeltecE213Board::begin() {
     }
   }
 
-  void HeltecE213Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void HeltecE213Board::powerOff()  {
-    enterDeepSleep(0);
-  }
-
   uint16_t HeltecE213Board::getBattMilliVolts()  {
     analogReadResolution(10);
     digitalWrite(PIN_ADC_CTRL, HIGH);

--- a/variants/heltec_e213/HeltecE213Board.h
+++ b/variants/heltec_e213/HeltecE213Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 
 class HeltecE213Board : public ESP32Board {
 
@@ -13,8 +12,6 @@ public:
   HeltecE213Board() : periph_power(PIN_VEXT_EN,PIN_VEXT_EN_ACTIVE) { }
 
   void begin();
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
-  void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 };

--- a/variants/heltec_e290/HeltecE290Board.cpp
+++ b/variants/heltec_e290/HeltecE290Board.cpp
@@ -20,33 +20,6 @@ void HeltecE290Board::begin() {
     }
   }
 
-  void HeltecE290Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void HeltecE290Board::powerOff()  {
-    enterDeepSleep(0);
-  }
-
   uint16_t HeltecE290Board::getBattMilliVolts()  {
     analogReadResolution(10);
     digitalWrite(PIN_ADC_CTRL, HIGH);

--- a/variants/heltec_e290/HeltecE290Board.h
+++ b/variants/heltec_e290/HeltecE290Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 
 class HeltecE290Board : public ESP32Board {
 
@@ -13,8 +12,6 @@ public:
   HeltecE290Board() : periph_power(PIN_VEXT_EN, PIN_VEXT_EN_ACTIVE) { }
 
   void begin();
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
-  void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -112,13 +112,9 @@ void T096Board::variant_shutdown() {
 }
 
 void T096Board::powerOff() {
-#if ENV_INCLUDE_GPS == 1
-    pinMode(PIN_GPS_EN, OUTPUT);
-    digitalWrite(PIN_GPS_EN, !PIN_GPS_EN_ACTIVE);
-#endif
-    loRaFEMControl.setSleepModeEnable();
-    variant_shutdown();
-    sd_power_system_off();
+  loRaFEMControl.setSleepModeEnable();
+  nrf_gpio_cfg_default(PIN_GPS_EN); // 363uA down to 39uA
+  NRF52Board::powerOff();
 }
 
 const char* T096Board::getManufacturerName() const {

--- a/variants/heltec_t1/T1Board.cpp
+++ b/variants/heltec_t1/T1Board.cpp
@@ -81,34 +81,6 @@ uint16_t T1Board::getBattMilliVolts() {
 }
 
 void T1Board::variant_shutdown() {
-  nrf_gpio_cfg_default(PIN_TFT_CS);
-  nrf_gpio_cfg_default(PIN_TFT_DC);
-  nrf_gpio_cfg_default(PIN_TFT_SDA);
-  nrf_gpio_cfg_default(PIN_TFT_SCL);
-  nrf_gpio_cfg_default(PIN_TFT_RST);
-  nrf_gpio_cfg_default(PIN_TFT_LEDA_CTL);
-  nrf_gpio_cfg_default(PIN_TFT_VDD_CTL);
-
-  nrf_gpio_cfg_default(PIN_WIRE_SDA);
-  nrf_gpio_cfg_default(PIN_WIRE_SCL);
-
-  nrf_gpio_cfg_default(LORA_CS);
-  nrf_gpio_cfg_default(SX126X_DIO1);
-  nrf_gpio_cfg_default(SX126X_BUSY);
-  nrf_gpio_cfg_default(SX126X_RESET);
-  nrf_gpio_cfg_default(PIN_SPI_MISO);
-  nrf_gpio_cfg_default(PIN_SPI_MOSI);
-  nrf_gpio_cfg_default(PIN_SPI_SCK);
-
-  nrf_gpio_cfg_default(PIN_SPI1_MOSI);
-  nrf_gpio_cfg_default(PIN_SPI1_SCK);
-
-  nrf_gpio_cfg_default(PIN_GPS_RESET);
-  nrf_gpio_cfg_default(PIN_GPS_EN);
-  nrf_gpio_cfg_default(PIN_GPS_PPS);
-  nrf_gpio_cfg_default(PIN_GPS_RX);
-  nrf_gpio_cfg_default(PIN_GPS_TX);
-
   nrf_gpio_cfg_default(PIN_BUZZER_VOLTAGE_MULTIPLIER_1);
   nrf_gpio_cfg_default(PIN_BUZZER_VOLTAGE_MULTIPLIER_2);
 
@@ -127,7 +99,7 @@ void T1Board::variant_shutdown() {
 
 void T1Board::powerOff() {
   variant_shutdown();
-  sd_power_system_off();
+  NRF52Board::powerOff();
 }
 
 const char* T1Board::getManufacturerName() const {

--- a/variants/heltec_t114/T114Board.h
+++ b/variants/heltec_t114/T114Board.h
@@ -50,10 +50,7 @@ public:
 #ifdef LED_PIN
     digitalWrite(LED_PIN, HIGH);
 #endif
-#if ENV_INCLUDE_GPS == 1
-    pinMode(GPS_EN, OUTPUT);
-    digitalWrite(GPS_EN, LOW);
-#endif
-    sd_power_system_off();
+
+    NRF52Board::powerOff();
   }
 };

--- a/variants/heltec_t190/HeltecT190Board.cpp
+++ b/variants/heltec_t190/HeltecT190Board.cpp
@@ -20,33 +20,6 @@ void HeltecT190Board::begin() {
     }
   }
 
-  void HeltecT190Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void HeltecT190Board::powerOff()  {
-    enterDeepSleep(0);
-  }
-
   uint16_t HeltecT190Board::getBattMilliVolts()  {
     analogReadResolution(10);
     digitalWrite(PIN_ADC_CTRL, HIGH);

--- a/variants/heltec_t190/HeltecT190Board.h
+++ b/variants/heltec_t190/HeltecT190Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 
 class HeltecT190Board : public ESP32Board {
 
@@ -13,8 +12,6 @@ public:
   HeltecT190Board() : periph_power(PIN_VEXT_EN,PIN_VEXT_EN_ACTIVE) { }
 
   void begin();
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
-  void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 

--- a/variants/heltec_tracker_v2/HeltecTrackerV2Board.cpp
+++ b/variants/heltec_tracker_v2/HeltecTrackerV2Board.cpp
@@ -35,33 +35,12 @@ void HeltecTrackerV2Board::begin() {
     loRaFEMControl.setRxModeEnable();
   }
 
-  void HeltecTrackerV2Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  void HeltecTrackerV2Board::powerOff() {
+    // Turn off PA
+    digitalWrite(P_LORA_PA_POWER, LOW);
+    rtc_gpio_hold_en((gpio_num_t)P_LORA_PA_POWER);
 
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    loRaFEMControl.setRxModeEnableWhenMCUSleep();//It also needs to be enabled in receive mode
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void HeltecTrackerV2Board::powerOff()  {
-    enterDeepSleep(0);
+    ESP32Board::powerOff();
   }
 
   uint16_t HeltecTrackerV2Board::getBattMilliVolts()  {

--- a/variants/heltec_tracker_v2/HeltecTrackerV2Board.h
+++ b/variants/heltec_tracker_v2/HeltecTrackerV2Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 #include "LoRaFEMControl.h"
 
 class HeltecTrackerV2Board : public ESP32Board {
@@ -17,7 +16,6 @@ public:
   void begin();
   void onBeforeTransmit(void) override;
   void onAfterTransmit(void) override;
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
   void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;

--- a/variants/heltec_v2/HeltecV2Board.h
+++ b/variants/heltec_v2/HeltecV2Board.h
@@ -7,8 +7,6 @@
 #define  PIN_VBAT_READ   37
 #define  PIN_LED_BUILTIN 25
 
-#include <driver/rtc_io.h>
-
 class HeltecV2Board : public ESP32Board {
 public:
   void begin() {
@@ -24,29 +22,6 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_0);
     }
-  }
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_0, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_0);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_0), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_0) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
   }
 
   uint16_t getBattMilliVolts() override {

--- a/variants/heltec_v3/HeltecV3Board.h
+++ b/variants/heltec_v3/HeltecV3Board.h
@@ -17,8 +17,6 @@
 #define  PIN_ADC_CTRL_ACTIVE    LOW
 #define  PIN_ADC_CTRL_INACTIVE  HIGH
 
-#include <driver/rtc_io.h>
-
 class HeltecV3Board : public ESP32Board {
 private:
   bool adc_active_state;
@@ -50,33 +48,6 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
-  }
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void powerOff() override {
-    enterDeepSleep(0);
   }
 
   uint16_t getBattMilliVolts() override {

--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -32,33 +32,12 @@ void HeltecV4Board::begin() {
     loRaFEMControl.setRxModeEnable();
   }
 
-  void HeltecV4Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  void HeltecV4Board::powerOff() {
+    // Turn off PA
+    digitalWrite(P_LORA_PA_POWER, LOW);
+    rtc_gpio_hold_en((gpio_num_t)P_LORA_PA_POWER);
 
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    loRaFEMControl.setRxModeEnableWhenMCUSleep();//It also needs to be enabled in receive mode
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void HeltecV4Board::powerOff()  {
-    enterDeepSleep(0);
+    ESP32Board::powerOff();
   }
 
   uint16_t HeltecV4Board::getBattMilliVolts()  {

--- a/variants/heltec_v4/HeltecV4Board.h
+++ b/variants/heltec_v4/HeltecV4Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 #include "LoRaFEMControl.h"
 
 #ifndef ADC_MULTIPLIER
@@ -23,7 +22,6 @@ public:
   void begin();
   void onBeforeTransmit(void) override;
   void onAfterTransmit(void) override;
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
   void powerOff() override;
   bool setLoRaFemLnaEnabled(bool enable) override;
   bool canControlLoRaFemLna() const override;

--- a/variants/keepteen_lt1/KeepteenLT1Board.h
+++ b/variants/keepteen_lt1/KeepteenLT1Board.h
@@ -37,8 +37,4 @@ public:
     digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
   }
 #endif
-
-  void powerOff() override {
-    sd_power_system_off();
-  }
 };

--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
@@ -48,12 +48,10 @@ public:
   }
 
   void powerOff() override {
+    // power off system
+    NRF52Board::powerOff();
 
     // turn off 3.3v
     digitalWrite(RT9080_EN, LOW);
-
-    // power off system
-    sd_power_system_off();
-
   }
 };

--- a/variants/lilygo_tdeck/TDeckBoard.h
+++ b/variants/lilygo_tdeck/TDeckBoard.h
@@ -3,7 +3,6 @@
 #include <Wire.h>
 #include <Arduino.h>
 #include "helpers/ESP32Board.h"
-#include <driver/rtc_io.h>
 
 #define PIN_VBAT_READ 4
 #define BATTERY_SAMPLES 8
@@ -22,29 +21,6 @@ public:
       digitalWrite(P_LORA_TX_LED, HIGH); // turn TX LED off - invert pin for SX1276
     }
   #endif
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH); // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH); // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start(); // CPU halts here and never returns!
-  }
 
   uint16_t getBattMilliVolts() {
     #if defined(PIN_VBAT_READ) && defined(ADC_MULTIPLIER)

--- a/variants/lilygo_techo/TechoBoard.h
+++ b/variants/lilygo_techo/TechoBoard.h
@@ -24,6 +24,7 @@ public:
   }
 
   void powerOff() override {
+    NRF52Board::powerOff();
     #ifdef LED_RED
     digitalWrite(LED_RED, HIGH);
     #endif
@@ -39,6 +40,5 @@ public:
     #ifdef PIN_PWR_EN
     digitalWrite(PIN_PWR_EN, LOW);
     #endif
-    sd_power_system_off();
   }
 };

--- a/variants/lilygo_techo_card/TechoCardBoard.cpp
+++ b/variants/lilygo_techo_card/TechoCardBoard.cpp
@@ -91,7 +91,7 @@ void TechoCardBoard::powerOff() {
   nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
   turnOffLeds();
   digitalWrite(PIN_PWR_EN, LOW);
-  sd_power_system_off();
+  NRF52Board::powerOff();
 }
 
 #endif

--- a/variants/lilygo_techo_lite/TechoBoard.h
+++ b/variants/lilygo_techo_lite/TechoBoard.h
@@ -22,6 +22,8 @@ public:
   }
 
   void powerOff() override {
+    NRF52Board::powerOff();
+
     digitalWrite(PIN_VBAT_MEAS_EN, LOW);
     #ifdef LED_RED
     digitalWrite(LED_RED, LOW);
@@ -38,6 +40,5 @@ public:
     #ifdef PIN_PWR_EN
     digitalWrite(PIN_PWR_EN, LOW);
     #endif
-    sd_power_system_off();
   }
 };

--- a/variants/mesh_pocket/MeshPocket.h
+++ b/variants/mesh_pocket/MeshPocket.h
@@ -32,8 +32,4 @@ public:
   const char* getManufacturerName() const override {
     return "Heltec MeshPocket";
   }
-
-  void powerOff() override {
-    sd_power_system_off();
-  }
 };

--- a/variants/meshtiny/MeshtinyBoard.h
+++ b/variants/meshtiny/MeshtinyBoard.h
@@ -60,7 +60,7 @@ public:
     nrf_gpio_cfg_sense_input(g_ADigitalPinMap[PIN_USER_BTN], NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
 #endif
 
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 
 };

--- a/variants/minewsemi_me25ls01/MinewsemiME25LS01Board.h
+++ b/variants/minewsemi_me25ls01/MinewsemiME25LS01Board.h
@@ -65,7 +65,7 @@ public:
     #ifdef BUTTON_PIN
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
     #endif
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 
   #if defined(P_LORA_TX_LED)

--- a/variants/nano_g2_ultra/nano-g2.h
+++ b/variants/nano_g2_ultra/nano-g2.h
@@ -52,6 +52,6 @@ public:
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(PIN_USER_BTN), NRF_GPIO_PIN_NOPULL,
                              NRF_GPIO_PIN_SENSE_LOW);
 
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/promicro/PromicroBoard.h
+++ b/variants/promicro/PromicroBoard.h
@@ -72,8 +72,4 @@ public:
     #endif
       return 0;
   }
-
-  void powerOff() override {
-    sd_power_system_off();
-  }
 };

--- a/variants/rak3112/RAK3112Board.h
+++ b/variants/rak3112/RAK3112Board.h
@@ -16,8 +16,6 @@
 #define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
 #define  BATTERY_SAMPLES 8
 
-#include <driver/rtc_io.h>
-
 class RAK3112Board : public ESP32Board {
 private:
   bool adc_active_state;
@@ -49,33 +47,6 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
-  }
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
-  }
-
-  void powerOff() override {
-    enterDeepSleep(0);
   }
 
   uint16_t getBattMilliVolts() override {

--- a/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
+++ b/variants/rak_wismesh_tag/RAKWismeshTagBoard.h
@@ -69,6 +69,6 @@ public:
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
     #endif
 
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/sensecap_solar/SenseCapSolarBoard.h
+++ b/variants/sensecap_solar/SenseCapSolarBoard.h
@@ -54,7 +54,7 @@ public:
 #ifdef NRF52_POWER_MANAGEMENT
     initiateShutdown(SHUTDOWN_REASON_USER);
 #else
-    sd_power_system_off();
+    NRF52Board::powerOff();
 #endif
   }
 };

--- a/variants/station_g2/StationG2Board.h
+++ b/variants/station_g2/StationG2Board.h
@@ -2,7 +2,6 @@
 
 #include <Arduino.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 
 class StationG2Board : public ESP32Board {
 public:
@@ -19,29 +18,6 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
-  }
-
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();   // CPU halts here and never returns!
   }
 
   uint16_t getBattMilliVolts() override {

--- a/variants/station_g3_esp32/StationG3Board.cpp
+++ b/variants/station_g3_esp32/StationG3Board.cpp
@@ -1,0 +1,15 @@
+#include "StationG3Board.h"
+
+void StationG3Board::powerOff() {
+#ifdef P_PA1_EN
+  setPAModeHigh(false);
+  rtc_gpio_hold_en((gpio_num_t)P_PA1_EN);
+#endif
+
+#ifdef P_PRIMARY_LNA_EN
+  setPrimaryLNAControl(true);
+  rtc_gpio_hold_en((gpio_num_t)P_PRIMARY_LNA_EN);
+#endif
+
+  ESP32Board::powerOff();
+}

--- a/variants/station_g3_esp32/StationG3Board.h
+++ b/variants/station_g3_esp32/StationG3Board.h
@@ -73,36 +73,7 @@ public:
     setPrimaryLNAControl(true);
   }
 
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
-    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-#ifdef P_PA1_EN
-    setPAModeHigh(false);
-    rtc_gpio_hold_en((gpio_num_t)P_PA1_EN);
-#endif
-
-#ifdef P_PRIMARY_LNA_EN
-    setPrimaryLNAControl(true);
-    rtc_gpio_hold_en((gpio_num_t)P_PRIMARY_LNA_EN);
-#endif
-
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);
-    } else {
-      esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1) | (1ULL << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    esp_deep_sleep_start();
-  }
+  void powerOff() override;
 
   uint16_t getBattMilliVolts() override {
     return 0;

--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -88,6 +88,6 @@ public:
     nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_HIGH);
     #endif
 
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/thinknode_m1/ThinkNodeM1Board.h
+++ b/variants/thinknode_m1/ThinkNodeM1Board.h
@@ -40,7 +40,6 @@ public:
     #endif
 
     // power off board
-    sd_power_system_off();
-
+    NRF52Board::powerOff();
   }
 };

--- a/variants/thinknode_m2/ThinknodeM2Board.cpp
+++ b/variants/thinknode_m2/ThinknodeM2Board.cpp
@@ -1,40 +1,30 @@
 #include "ThinknodeM2Board.h"
 
-
-
 void ThinknodeM2Board::begin() {
-    pinMode(PIN_VEXT_EN, OUTPUT); 
-    digitalWrite(PIN_VEXT_EN, !PIN_VEXT_EN_ACTIVE); // force power cycle
-    delay(20); // allow power rail to discharge
-    digitalWrite(PIN_VEXT_EN, PIN_VEXT_EN_ACTIVE); // turn backlight back on
-    delay(120); // give display time to bias on cold boot
-    ESP32Board::begin();
-    pinMode(PIN_STATUS_LED, OUTPUT); // init power led
-  }
-
-  void ThinknodeM2Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_deep_sleep_start();
-  }
-
-  void ThinknodeM2Board::powerOff()  {
-    enterDeepSleep(0);
-  }
-
- uint16_t ThinknodeM2Board::getBattMilliVolts() {
-    analogReadResolution(12);
-    analogSetPinAttenuation(PIN_VBAT_READ, ADC_11db);
-
-    uint32_t mv = 0;
-      for (int i = 0; i < 8; ++i) {
-        mv += analogReadMilliVolts(PIN_VBAT_READ);
-        delayMicroseconds(200);
-      }
-    mv /= 8;
-
-    analogReadResolution(10);  
-    return static_cast<uint16_t>(mv * ADC_MULTIPLIER );
+  pinMode(PIN_VEXT_EN, OUTPUT);
+  digitalWrite(PIN_VEXT_EN, !PIN_VEXT_EN_ACTIVE); // force power cycle
+  delay(20);                                      // allow power rail to discharge
+  digitalWrite(PIN_VEXT_EN, PIN_VEXT_EN_ACTIVE);  // turn backlight back on
+  delay(120);                                     // give display time to bias on cold boot
+  ESP32Board::begin();
+  pinMode(PIN_STATUS_LED, OUTPUT); // init power led
 }
 
-  const char* ThinknodeM2Board::getManufacturerName() const {
-    return "Elecrow ThinkNode M2";
+uint16_t ThinknodeM2Board::getBattMilliVolts() {
+  analogReadResolution(12);
+  analogSetPinAttenuation(PIN_VBAT_READ, ADC_11db);
+
+  uint32_t mv = 0;
+  for (int i = 0; i < 8; ++i) {
+    mv += analogReadMilliVolts(PIN_VBAT_READ);
+    delayMicroseconds(200);
   }
+  mv /= 8;
+
+  analogReadResolution(10);
+  return static_cast<uint16_t>(mv * ADC_MULTIPLIER);
+}
+
+const char *ThinknodeM2Board::getManufacturerName() const {
+  return "Elecrow ThinkNode M2";
+}

--- a/variants/thinknode_m2/ThinknodeM2Board.h
+++ b/variants/thinknode_m2/ThinknodeM2Board.h
@@ -3,15 +3,11 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 
 class ThinknodeM2Board : public ESP32Board {
 
 public:
-
   void begin();
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
-  void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 

--- a/variants/thinknode_m3/ThinkNodeM3Board.h
+++ b/variants/thinknode_m3/ThinkNodeM3Board.h
@@ -49,6 +49,6 @@ public:
     #endif
 
     // power off board
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/thinknode_m5/ThinknodeM5Board.cpp
+++ b/variants/thinknode_m5/ThinknodeM5Board.cpp
@@ -19,14 +19,6 @@ void ThinknodeM5Board::begin() {
     ESP32Board::begin();
   }
 
-  void ThinknodeM5Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-    esp_deep_sleep_start();
-  }
-
-  void ThinknodeM5Board::powerOff()  {
-    enterDeepSleep(0);
-  }
-
  uint16_t ThinknodeM5Board::getBattMilliVolts() {
     analogReadResolution(12);
     analogSetPinAttenuation(PIN_VBAT_READ, ADC_11db);

--- a/variants/thinknode_m5/ThinknodeM5Board.h
+++ b/variants/thinknode_m5/ThinknodeM5Board.h
@@ -3,7 +3,6 @@
 #include <Arduino.h>
 #include <helpers/RefCountedDigitalPin.h>
 #include <helpers/ESP32Board.h>
-#include <driver/rtc_io.h>
 #include <PCA9557.h>
 
 extern PCA9557 expander;
@@ -13,8 +12,6 @@ class ThinknodeM5Board : public ESP32Board {
 public:
 
   void begin();
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
-  void powerOff() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 

--- a/variants/thinknode_m6/ThinkNodeM6Board.h
+++ b/variants/thinknode_m6/ThinkNodeM6Board.h
@@ -44,6 +44,6 @@ public:
     #endif
 
     // power off board
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/wio-tracker-l1/WioTrackerL1Board.h
+++ b/variants/wio-tracker-l1/WioTrackerL1Board.h
@@ -35,6 +35,6 @@ public:
   }
 
   void powerOff() override {
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };

--- a/variants/xiao_c3/XiaoC3Board.h
+++ b/variants/xiao_c3/XiaoC3Board.h
@@ -3,7 +3,6 @@
 #include <helpers/ESP32Board.h>
 #include <Arduino.h>
 
-#include <driver/rtc_io.h>
 #include <driver/uart.h>
 
 class XiaoC3Board : public ESP32Board {
@@ -38,37 +37,6 @@ public:
     pinMode(P_LORA_TX_LED, OUTPUT);
     digitalWrite(P_LORA_TX_LED, LOW);
   #endif
-  }
-
-  void enterDeepSleep(uint32_t secs, int8_t wake_pin = -1) {
-    gpio_set_direction(gpio_num_t(P_LORA_DIO_1), GPIO_MODE_INPUT);
-    if (wake_pin >= 0) {
-      gpio_set_direction((gpio_num_t)wake_pin, GPIO_MODE_INPUT);
-    }
-
-    //hold disable, isolate and power domain config functions may be unnecessary
-    //gpio_deep_sleep_hold_dis();
-    //esp_sleep_config_gpio_isolate();
-    gpio_deep_sleep_hold_en();
-
-#if defined(LORA_TX_BOOST_PIN)
-    gpio_hold_en((gpio_num_t) LORA_TX_BOOST_PIN);
-    gpio_deep_sleep_hold_en();
-#endif
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-    if (wake_pin >= 0) {
-      esp_deep_sleep_enable_gpio_wakeup((1 << P_LORA_DIO_1) | (1 << wake_pin), ESP_GPIO_WAKEUP_GPIO_HIGH);
-    } else {
-      esp_deep_sleep_enable_gpio_wakeup(1 << P_LORA_DIO_1, ESP_GPIO_WAKEUP_GPIO_HIGH);
-    }
-
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
-    }
-
-    // Finally set ESP32 into sleep
-    esp_deep_sleep_start();  // CPU halts here and never returns!
   }
 
 #if defined(LORA_TX_BOOST_PIN) || defined(P_LORA_TX_LED)

--- a/variants/xiao_nrf52/XiaoNrf52Board.h
+++ b/variants/xiao_nrf52/XiaoNrf52Board.h
@@ -50,7 +50,7 @@ public:
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(g_ADigitalPinMap[PIN_USER_BTN]), NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_LOW);
 #endif
 
-    sd_power_system_off();
+    NRF52Board::powerOff();
   }
 };
 


### PR DESCRIPTION
Hi all,
This is another big PR to fix hibernate / poweroff for BLE companions and repeaters to stay at uA. E.g: Heltec v4 is at 13uA (not mA).
When hibernating / powerOff, the device with 3000 mAh **should last months or even years**.

Current situations in hibernating / poweroff:
- powerOff / enterDeepSleep are duplicated in many variants and not stay at uA. The boards are stay in 6-10mA or more.
- GPS: GPS is never off and consumes 10-20mA.
- BLE companions: BLE companions with GPS does not off GPS when hibernating.
- Repeaters: powerOff in NRF52 will stay at 6mA not work as "sd_power_system_off()" only works for devices with soft device (such as BLE).
- poweroff CLI in repeaters does not cut power for OLED, LoRa and GPS.
- Wakeup when there is LoRa packets: It should remain off even there are coming LoRa packets. In crowded areas, the devices will be waken up in 5s.

The proposed PR:
- Put powerOff() in NRF52Board and ESP32Board to turn off OLED, LoRa, GPS.
- Child variants can put in extra code and reuse the powerOff in NRF52Board and ESP32Board
- Remove wakeup by buttons for ESP32Board. No board uses it. You can click RESET button to power on the board again.

I have tested with common boards in our lab.
However, you are welcome to test the PR for your boards.

Have a great day.