### PR TITLE
Lilygo T-Echo Lite - nRF52840 DC-DC

### DIFF
--- a/variants/lilygo_techo_lite/TechoBoard.cpp
+++ b/variants/lilygo_techo_lite/TechoBoard.cpp
@@ -6,7 +6,7 @@
 #ifdef LILYGO_TECHO
 
 void TechoBoard::begin() {
-  NRF52Board::begin();
+  NRF52BoardDCDC::begin();
 
   // Configure battery measurement control BEFORE Wire.begin()
   // to ensure P0.02 is not claimed by another peripheral


### PR DESCRIPTION
- Enable nRF52840 DC-DC - board idle usage reduced from ~12mA to ~7mA