### PR TITLE
Refactor builds via GitHub Actions to be super fast

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -25,5 +25,14 @@ runs:
     - name: Extract Version from Git Tag
       shell: bash
       run: |
-        GIT_TAG_NAME="${GITHUB_REF#refs/tags/}"
-        echo "GIT_TAG_VERSION=${GIT_TAG_NAME##*-}" >> $GITHUB_ENV
+        if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          # triggered by a tag push (e.g: refs/tags/companion-v1.2.3)
+          GIT_TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION_STRING="${GIT_TAG_NAME##*-}"
+        else
+          # triggered by a workflow dispatch (e.g: refs/heads/main)
+          # strip "refs/heads/" prefix and replace any remaining "/" with "-" to protect file paths
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          VERSION_STRING=$(echo "$BRANCH_NAME" | tr '/' '-')
+        fi
+        echo "GIT_TAG_VERSION=${VERSION_STRING}" >> $GITHUB_ENV

--- a/.github/workflows/build-companion-firmwares.yml
+++ b/.github/workflows/build-companion-firmwares.yml
@@ -10,33 +10,8 @@ on:
       - 'companion-*'
 
 jobs:
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Clone Repo
-        uses: actions/checkout@v6
-
-      - name: Setup Build Environment
-        uses: ./.github/actions/setup-build-environment
-
-      - name: Build Firmwares
-        env:
-          FIRMWARE_VERSION: ${{ env.GIT_TAG_VERSION }}
-        run: /usr/bin/env bash build.sh build-companion-firmwares
-
-      - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: companion-firmwares
-          path: out
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: Companion Firmware ${{ env.GIT_TAG_VERSION }}
-          body: ""
-          draft: true
-          files: out/*
+  build-companion-firmwares:
+    uses: ./.github/workflows/firmware-builder.yml
+    with:
+      firmware_type: 'companion'
+      release_title_prefix: 'Companion Firmware'

--- a/.github/workflows/build-repeater-firmwares.yml
+++ b/.github/workflows/build-repeater-firmwares.yml
@@ -10,33 +10,8 @@ on:
       - 'repeater-*'
 
 jobs:
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Clone Repo
-        uses: actions/checkout@v6
-
-      - name: Setup Build Environment
-        uses: ./.github/actions/setup-build-environment
-
-      - name: Build Firmwares
-        env:
-          FIRMWARE_VERSION: ${{ env.GIT_TAG_VERSION }}
-        run: /usr/bin/env bash build.sh build-repeater-firmwares
-
-      - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: repeater-firmwares
-          path: out
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: Repeater Firmware ${{ env.GIT_TAG_VERSION }}
-          body: ""
-          draft: true
-          files: out/*
+  build-repeater-firmwares:
+    uses: ./.github/workflows/firmware-builder.yml
+    with:
+      firmware_type: 'repeater'
+      release_title_prefix: 'Repeater Firmware'

--- a/.github/workflows/build-room-server-firmwares.yml
+++ b/.github/workflows/build-room-server-firmwares.yml
@@ -10,33 +10,8 @@ on:
       - 'room-server-*'
 
 jobs:
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Clone Repo
-        uses: actions/checkout@v6
-
-      - name: Setup Build Environment
-        uses: ./.github/actions/setup-build-environment
-
-      - name: Build Firmwares
-        env:
-          FIRMWARE_VERSION: ${{ env.GIT_TAG_VERSION }}
-        run: /usr/bin/env bash build.sh build-room-server-firmwares
-
-      - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: room-server-firmwares
-          path: out
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: Room Server Firmware ${{ env.GIT_TAG_VERSION }}
-          body: ""
-          draft: true
-          files: out/*
+  build-room-server-firmwares:
+    uses: ./.github/workflows/firmware-builder.yml
+    with:
+      firmware_type: 'room-server'
+      release_title_prefix: 'Room Server Firmware'

--- a/.github/workflows/firmware-builder.yml
+++ b/.github/workflows/firmware-builder.yml
@@ -1,0 +1,90 @@
+name: Firmware Builder
+
+on:
+  workflow_call:
+    inputs:
+      firmware_type:
+        required: true
+        type: string
+      release_title_prefix:
+        required: true
+        type: string
+
+jobs:
+
+  generate-build-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.get-build-targets.outputs.targets }}
+    steps:
+
+      - name: Clone Repo
+        uses: actions/checkout@v6
+
+      - name: Setup Build Environment
+        uses: ./.github/actions/setup-build-environment
+
+      - name: Get Build Targets
+        id: get-build-targets
+        run: |
+          # get list of firmwares to build
+          TARGET_LIST=$(/usr/bin/env bash build.sh get-${{ inputs.firmware_type }}-firmwares-to-build)
+          
+          # convert targets separated by new line into a json array string
+          JSON_ARRAY=$(echo "$TARGET_LIST" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          
+          # use json array as targets result
+          echo "targets=$JSON_ARRAY" >> $GITHUB_OUTPUT
+
+  build:
+    needs: generate-build-matrix
+    runs-on: ubuntu-latest
+    continue-on-error: true # don't fail entire build if one board fails to build
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.generate-build-matrix.outputs.targets) }}
+      fail-fast: false # don't cancel other builds if one board fails to build
+    steps:
+
+      - name: Clone Repo
+        uses: actions/checkout@v6
+
+      - name: Setup Build Environment
+        uses: ./.github/actions/setup-build-environment
+
+      - name: Build Firmware
+        env:
+          FIRMWARE_VERSION: ${{ env.GIT_TAG_VERSION }}
+        run: /usr/bin/env bash build.sh build-firmware ${{ matrix.target }}
+
+      - name: Upload Workflow Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: "${{ matrix.target }}"
+          path: out
+
+  create-release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') # only create release for tagged builds
+    steps:
+
+      - name: Clone Repo
+        uses: actions/checkout@v6
+
+      - name: Setup Build Environment
+        uses: ./.github/actions/setup-build-environment
+
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+          path: out
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v3
+        with:
+          name: "${{ inputs.release_title_prefix }} ${{ env.GIT_TAG_VERSION }}"
+          body: ""
+          draft: true
+          files: out/*

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# exit when any command fails
+set -e
+
 global_usage() {
   cat - <<EOF
 Usage:
@@ -275,4 +278,11 @@ elif [[ $1 == "build-repeater-firmwares" ]]; then
   build_repeater_firmwares
 elif [[ $1 == "build-room-server-firmwares" ]]; then
   build_room_server_firmwares
+elif [[ $1 == "get-companion-firmwares-to-build" ]]; then
+  get_pio_envs_ending_with_string "_companion_radio_usb"
+  get_pio_envs_ending_with_string "_companion_radio_ble"
+elif [[ $1 == "get-repeater-firmwares-to-build" ]]; then
+  get_pio_envs_ending_with_string "_repeater"
+elif [[ $1 == "get-room-server-firmwares-to-build" ]]; then
+  get_pio_envs_ending_with_string "_room_server"
 fi


### PR DESCRIPTION
This PR reworks our automated build/release flow on GitHub Actions.

It migrates to using a matrix build, where all variants can be built at the same time.
The original system built firmwares sequentially, which resulted in long running build times.
For example, our companion firmware builds took over 2 hours.

<img width="1293" height="246" alt="Screenshot 2026-07-07 at 2 12 56 PM" src="https://github.com/user-attachments/assets/34e37d6c-cdf3-47e7-a884-51fd3d1827fd" />

With this refactor, all firmwares are built within 20 minutes.

<img width="1301" height="255" alt="Screenshot 2026-07-07 at 3 32 16 AM" src="https://github.com/user-attachments/assets/e6b15c32-d9a6-4c71-b091-0d0d66cf9ad4" />

Another bonus of this refactor, is GitHub Actions will now show a green/red build status icon for each build variant.
This will make it easier to determine which variants are failing to build.
Previously, we had to search for error strings in the monolith build job logs.

<img width="1351" height="731" alt="Screenshot 2026-07-07 at 1 48 03 AM" src="https://github.com/user-attachments/assets/068bbe77-57f7-48c5-a603-83ded567338d" />

Build assets will be available directly on the job, and can be downloaded as a zip, extracted and then flashed via the Custom Firmware option in our webflasher.

<img width="1431" height="889" alt="Screenshot 2026-07-07 at 2 15 48 PM" src="https://github.com/user-attachments/assets/515e29f5-574a-44b0-ab86-a4062589ae6b" />

This will also allow us to do things like manual build runs for a special branch that needs user testing, or for automated nightly builds of the dev branch.

Firmware built via GitHub Actions that isn't tagged with a release version will have the firmware version set to the branch name, suffixed with the commit hash.

For example: `dev-abc123` or `main-def456`. This makes it easy to know which special build you're running, as this is the string returned by the firmware when running the `ver` CLI command.

<img width="400" alt="Screenshot_20260707_135152_MeshCore" src="https://github.com/user-attachments/assets/fb1548c9-93d6-46be-a594-ec272a16fdf5" />

---

One edge case to this refactor, is that GitHub Actions limits the maximum amount of matrix jobs to 256.
Currently, we have ~144 companion firmware variants/envs, and this will only increase over time.

However, one mitigation to this issue, is that we could merge USB/BLE/WiFi firmwares into one, which would significantly drop the amount of variants to build.

For example, we only have 84 repeater variants and 70 room server variants.