### PR TITLE
Feed external hardware watchdog on Heltec Tower V2 (aka MeshTower V2)

### DIFF
--- a/variants/heltec_tower_v2/HeltecTowerV2Board.cpp
+++ b/variants/heltec_tower_v2/HeltecTowerV2Board.cpp
@@ -58,6 +58,20 @@ void HeltecTowerV2Board::begin() {
   pinMode(PIN_GPS_STANDBY, OUTPUT);
   digitalWrite(PIN_GPS_STANDBY, HIGH);
   loRaFEMControl.init();
+
+#ifdef HAS_HARDWARE_WATCHDOG
+  pinMode(HARDWARE_WATCHDOG_DONE, OUTPUT);
+  digitalWrite(HARDWARE_WATCHDOG_DONE, LOW);
+  pinMode(HARDWARE_WATCHDOG_WAKE, INPUT);
+
+  watchdog_timer.begin(60000, [](TimerHandle_t xTimerID) {
+    (void)xTimerID;
+    MESH_DEBUG_PRINTLN("PWRMGT: Fed hardware watchdog (t=%lu ms)", millis());
+    digitalWrite(HARDWARE_WATCHDOG_DONE, HIGH);
+    digitalWrite(HARDWARE_WATCHDOG_DONE, LOW);
+  });
+  watchdog_timer.start();
+#endif
 }
 
 void HeltecTowerV2Board::onBeforeTransmit() {

--- a/variants/heltec_tower_v2/HeltecTowerV2Board.h
+++ b/variants/heltec_tower_v2/HeltecTowerV2Board.h
@@ -21,4 +21,8 @@ public:
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override;
   void powerOff() override;
+#ifdef HAS_HARDWARE_WATCHDOG
+private:
+  SoftwareTimer watchdog_timer;
+#endif
 };


### PR DESCRIPTION
**Update: Based on some of the feedback in the comments, I've created an alternate fix here: https://github.com/meshcore-dev/MeshCore/pull/2936. I believe the alternate fix is more robust, but it's also more code. This PR is a quick-fix. I wrote it this way because it minimizes the amount of code maintainers need to read.**

**Update 2: Closed in favor of https://github.com/meshcore-dev/MeshCore/pull/2936**

Like clockwork, my MeshTower V2 restarts approximately every 9 minutes and 30 seconds. The `variant.h` for this device gives a clue as to why:
https://github.com/meshcore-dev/MeshCore/blob/fec88e13009fe215e1bebcc09a6c85196ff6ac0c/variants/heltec_tower_v2/variant.h#L85-L88

Both pins and a timeout for a watchdog are defined, but never used. After one of these reboots, I can see this over the serial port, which is consistent with an external watchdog device resetting the MCU. 

```
DEBUG: PWRMGT: Reset = Reset Pin (0x1)
```

This feeds the doggo and toggles the DONE pin every 60 seconds inside of a `SoftwareTimer` to prevent the watchdog from resetting the device.

It would probably be better to feed the watchdog inside the `main.cpp` but there's no existing hook for this as far as I can tell. Simply spinning up a timer for this specific board and making no big architecture changes seemed like the easier and less controversial change. Let me know if you have thoughts.

## Testing
I flashed this to my device and verified the device hasn't rebooted with an uptime of 13 minutes, an uptime never before reached on this device.

If you'd like to test this yourself, here are build instructions for a repeater:

```bash
# Checkout my PR
git fetch origin pull/2904/head:pr-2904
git checkout pr-2904

# Build with a custom version string and serial debug logging turned on
PLATFORMIO_BUILD_FLAGS='-D FIRMWARE_VERSION=\"v1.16.0-watchdog-fix\" -D MESH_DEBUG=1' pio run -e Heltec_tower_v2_repeater
```

Head over to https://meshcore.io/flasher and use the "Custom firmware" option to flash `.pio/build/Heltec_tower_v2_repeater/firmware.zip`

If there are issues, you can run `ver` on the repeater CLI to verify `v1.16.0-watchdog-fix` is the version string. That verifies that you flashed your build.

You can connect to the repeater over serial and look for something like `DEBUG: PWRMGT: Fed hardware watchdog (t=541020 ms)` to verify that the fix is actually running. How to connect is platform specific. On Linux, you can use screen:

```
# Substitute in the correct /dev/... path.
screen /dev/serial/by-id/usb-Heltec_HT-n5262_5F3611E4949BEF11-if00 115200
```

cc @Quency-D who PR'd the original support for this device. https://github.com/meshcore-dev/MeshCore/pull/2752