### PR TITLE
Heltec T114 - nRF52840 DC-DC Regulator

### DIFF
--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -33,7 +33,7 @@ void T114Board::initiateShutdown(uint8_t reason) {
 #endif // NRF52_POWER_MANAGEMENT
 
 void T114Board::begin() {
-  NRF52Board::begin();
+  NRF52BoardDCDC::begin();
 
   pinMode(PIN_VBAT_READ, INPUT);
 


### PR DESCRIPTION
- Enable DC-DC regulator on nRF52840 for Heltec T114 board (idle current reduced from ~12mA to ~9mA)