### PR TITLE
Proposal: Introduce shutdownPeripherals in NRF52Board to prepare for shutdown

### DIFF
--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -298,7 +298,7 @@ float NRF52Board::getMCUTemperature() {
   return temp * 0.25f; // Convert to *C
 }
 
-void NRF52Board::powerOff() {
+void NRF52Board::shutdownPeripherals() {
   // Power off the display if any
 #ifdef DISPLAY_CLASS
   display.turnOff();
@@ -318,6 +318,10 @@ void NRF52Board::powerOff() {
   // Flush serial buffers
   Serial.flush();
   delay(100);
+}
+
+void NRF52Board::powerOff() {
+  shutdownPeripherals();
 
   // Enter SYSTEMOFF
   uint8_t sd_enabled = 0;

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -50,6 +50,7 @@ public:
   virtual uint8_t getStartupReason() const override { return startup_reason; }
   virtual float getMCUTemperature() override;
   virtual void reboot() override { NVIC_SystemReset(); }
+  virtual void shutdownPeripherals();
   virtual void powerOff() override;
   virtual bool getBootloaderVersion(char* version, size_t max_len) override;
   virtual bool startOTAUpdate(const char *id, char reply[]) override;

--- a/variants/lilygo_techo/TechoBoard.h
+++ b/variants/lilygo_techo/TechoBoard.h
@@ -23,8 +23,8 @@ public:
     return "LilyGo T-Echo";
   }
 
-  void powerOff() override {
-    NRF52Board::powerOff();
+  void shutdownPeripherals() override {
+    NRF52Board::shutdownPeripherals();
     #ifdef LED_RED
     digitalWrite(LED_RED, HIGH);
     #endif


### PR DESCRIPTION
Following #2895 which solved poweroff issues from repeater commandline on some variants (T-Echo is one of them) I wondered about the construct where poweroff in the variant was called before shutting down the specific peripherals of the boards

Obviously this specific shutdown code was never reached and I thing this was placed after the call to shutdown because it's mainly peripheral gating in there and it cuts power from some peripherals that are shut down in the `poweroff` function. In this case, the gates should be closed after the peripherals are correctly down

My idea is to add a `shutdownPeripherals` function, ideally the variants should overload this one instead of `poweroff` which calls it. This way one can let generic shutdown happen and then do specific shutdown to a board before CPU shutdown.

@ripplebiz @IoTThinks what do you think ? 

`shutdownPeripherals` could even be promoted to `MainBoard` I think but I just wanted to illustrate the idea and keep the PR simple