### PR TITLE
Add power source (battery/solar/mains) to node adverts

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -323,6 +323,20 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+#### View or change this node's power source
+**Usage:**
+- `get power.source`
+- `set power.source <source>`
+
+**Parameters:**
+- `source`: One of `unknown`, `battery`, `solar`, `mains`
+
+**Default:** `unknown`
+
+**Note:** Broadcast in the node's advert; costs 0 extra bytes at `unknown`, 2 bytes otherwise. Only applies to repeater, room server, and sensor firmware, not companion radio.
+
+---
+
 #### View or change this node's identity (Private Key)
 **Usage:**
 - `get prv.key`

--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -40,7 +40,7 @@ Appdata
 | flags         | 1               | specifies which of the fields are present, see below  |
 | latitude      | 4 (optional)    | decimal latitude multiplied by 1000000, integer       |
 | longitude     | 4 (optional)    | decimal longitude multiplied by 1000000, integer      |
-| feature 1     | 2  (optional)   | reserved for future use                               |
+| feature 1     | 2  (optional)   | capability flags; bits 0-1 = power source, see below  |
 | feature 2     | 2  (optional)   | reserved for future use                               |
 | name          | rest of appdata | name of the node                                      |
 
@@ -53,9 +53,16 @@ Appdata Flags
 | `0x03` | is room server | advert is for a room server           |
 | `0x04` | is sensor      | advert is for a sensor server         |
 | `0x10` | has location   | appdata contains lat/long information |
-| `0x20` | has feature 1  | Reserved for future use.              |
+| `0x20` | has feature 1  | appdata contains feature 1, see below                 |
 | `0x40` | has feature 2  | Reserved for future use.              |
 | `0x80` | has name       | appdata contains a node name          |
+
+Feature 1
+
+| Bits     | Mask     | Name           | Description                                        |
+|----------|----------|----------------|-----------------------------------------------------|
+| 0-1      | `0x0003` | power source   | `0`=unknown, `1`=battery, `2`=solar, `3`=mains/grid  |
+| 2-15     | -        | reserved       | for future use                                     |
 
 # Acknowledgement
 

--- a/src/helpers/AdvertDataHelpers.h
+++ b/src/helpers/AdvertDataHelpers.h
@@ -12,9 +12,15 @@
 //FUTURE: 5..15
 
 #define ADV_LATLON_MASK       0x10
-#define ADV_FEAT1_MASK        0x20   // FUTURE
+#define ADV_FEAT1_MASK        0x20   // feat1 bits 0-1 = power source, see ADV_FEAT1_POWER_*
 #define ADV_FEAT2_MASK        0x40   // FUTURE
 #define ADV_NAME_MASK         0x80
+
+#define ADV_FEAT1_POWER_MASK      0x0003
+#define ADV_FEAT1_POWER_UNKNOWN   0x0000
+#define ADV_FEAT1_POWER_BATTERY   0x0001
+#define ADV_FEAT1_POWER_SOLAR     0x0002
+#define ADV_FEAT1_POWER_MAINS     0x0003
 
 class AdvertDataBuilder {
   uint8_t _type;
@@ -54,6 +60,8 @@ public:
   uint8_t getType() const { return _flags & 0x0F; }
   uint16_t getFeat1() const { return _extra1; }
   uint16_t getFeat2() const { return _extra2; }
+
+  uint8_t getPowerSource() const { return _extra1 & ADV_FEAT1_POWER_MASK; }
 
   bool hasName() const { return _name[0] != 0; }
   const char* getName() const { return _name; }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -93,7 +93,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));             // 292
     file.read((uint8_t *)&_prefs->radio_fem_rxgain, sizeof(_prefs->radio_fem_rxgain));             // 293
     file.read((uint8_t *)&_prefs->cad_enabled, sizeof(_prefs->cad_enabled));                       // 294
-    // next: 295
+    file.read((uint8_t *)&_prefs->node_power_flags, sizeof(_prefs->node_power_flags));             // 295
+    // next: 296
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -125,6 +126,7 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->rx_boosted_gain = constrain(_prefs->rx_boosted_gain, 0, 1); // boolean
     _prefs->radio_fem_rxgain = constrain(_prefs->radio_fem_rxgain, 0, 1); // boolean
     _prefs->cad_enabled = constrain(_prefs->cad_enabled, 0, 1); // boolean
+    _prefs->node_power_flags = constrain(_prefs->node_power_flags, 0, 3);
 
     file.close();
   }
@@ -190,7 +192,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));             // 292
     file.write((uint8_t *)&_prefs->radio_fem_rxgain, sizeof(_prefs->radio_fem_rxgain));             // 293
     file.write((uint8_t *)&_prefs->cad_enabled, sizeof(_prefs->cad_enabled));                       // 294
-    // next: 295
+    file.write((uint8_t *)&_prefs->node_power_flags, sizeof(_prefs->node_power_flags));             // 295
+    // next: 296
 
     file.close();
   }
@@ -208,12 +211,15 @@ void CommonCLI::savePrefs() {
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
   if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name);
+    builder.setFeat1(_prefs->node_power_flags);
     return builder.encodeTo(app_data);
   } else if (_prefs->advert_loc_policy == ADVERT_LOC_SHARE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _sensors->node_lat, _sensors->node_lon);
+    builder.setFeat1(_prefs->node_power_flags);
     return builder.encodeTo(app_data);
   } else {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
+    builder.setFeat1(_prefs->node_power_flags);
     return builder.encodeTo(app_data);
   }
 }
@@ -571,6 +577,21 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     _prefs->disable_fwd = memcmp(&config[7], "off", 3) == 0;
     savePrefs();
     strcpy(reply, _prefs->disable_fwd ? "OK - repeat is now OFF" : "OK - repeat is now ON");
+  } else if (memcmp(config, "power.source ", 13) == 0) {
+    const char* v = &config[13];
+    uint8_t src;
+    if (memcmp(v, "unknown", 7) == 0) src = ADV_FEAT1_POWER_UNKNOWN;
+    else if (memcmp(v, "battery", 7) == 0) src = ADV_FEAT1_POWER_BATTERY;
+    else if (memcmp(v, "solar", 5) == 0) src = ADV_FEAT1_POWER_SOLAR;
+    else if (memcmp(v, "mains", 5) == 0) src = ADV_FEAT1_POWER_MAINS;
+    else src = 0xFF;
+    if (src == 0xFF) {
+      strcpy(reply, "Error, must be: unknown, battery, solar, or mains");
+    } else {
+      _prefs->node_power_flags = src;
+      savePrefs();
+      strcpy(reply, "OK");
+    }
   } else if (memcmp(config, "radio.rxgain ", 13) == 0) {
     bool enabled = memcmp(&config[13], "on", 2) == 0;
     _prefs->rx_boosted_gain = enabled;
@@ -833,6 +854,12 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", _prefs->node_name);
   } else if (memcmp(config, "repeat", 6) == 0) {
     sprintf(reply, "> %s", _prefs->disable_fwd ? "off" : "on");
+  } else if (memcmp(config, "power.source", 12) == 0) {
+    uint8_t src = _prefs->node_power_flags;
+    const char* name = src == ADV_FEAT1_POWER_SOLAR ? "solar"
+                      : src == ADV_FEAT1_POWER_MAINS ? "mains"
+                      : src == ADV_FEAT1_POWER_BATTERY ? "battery" : "unknown";
+    sprintf(reply, "> %s", name);
   } else if (memcmp(config, "lat", 3) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lat));
   } else if (memcmp(config, "lon", 3) == 0) {

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -65,6 +65,7 @@ struct NodePrefs { // persisted to file
   uint8_t path_hash_mode;   // which path mode to use when sending
   uint8_t loop_detect;
   uint8_t cad_enabled;      // hardware Channel Activity Detection before TX (boolean)
+  uint8_t node_power_flags;
 };
 
 class CommonCLICallbacks {


### PR DESCRIPTION
Right now people stick emojis in their node names to show whether a device is on battery, solar, or mains. That's not machine-readable and it counts towards their message length leaving less room for actual messages. This change adds a power.source capability field to the advert so power source gets signaled properly instead.

Did not add it to companions adverts although that might be a future improvement if there is consensus on this.