### PR TITLE
Add StreamSensor allocation for GroupData

### DIFF
--- a/docs/number_allocations.md
+++ b/docs/number_allocations.md
@@ -17,6 +17,7 @@ Once you have a working app/project, you need to be able to demonstrate it exist
 | 0000 - 00FF     | -reserved for internal use- |                                                                   |
 | 0100            | MeshCore Open               | zsylvester@monitormx.com — https://github.com/zjs81/meshcore-open |
 | 0110 - 011F     | Ripple                      | ripple_biz@protonmail.com — https://buymeacoffee.com/ripplebiz    |
+| 0120 - 012F     | StreamSensor                | william@housedillon.com - https://housedillon.com/blog/lora-e5-with-seeed-fusion |
 | FF00 - FFFF     | -reserved for testing/dev-  |                                                                   |
 
 (add rows, inside the range 0100 - FEFF for custom apps)


### PR DESCRIPTION
Adds a small allocation for groupdata packets for the Meshcore firmware for the StreamSensor product.  It was previously a LoRaWAN platform, and we've moved to Meshcore.

Let me know when and how to demonstrate.