### PR TITLE
Dynamic CAD sensitivity

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -213,6 +213,7 @@ public:
   void removeNeighbor(const uint8_t* pubkey, int key_len) override;
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
+  mesh::Radio* getRadio() override { return _radio; }
   void formatPacketStatsReply(char *reply) override;
   void startRegionsLoad() override;
   bool saveRegions() override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -216,6 +216,7 @@ public:
   void removeNeighbor(const uint8_t* pubkey, int key_len) override;
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
+  mesh::Radio* getRadio() override { return _radio; }
   void formatPacketStatsReply(char *reply) override;
   void startRegionsLoad() override;
   bool saveRegions() override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -215,6 +215,7 @@ public:
   }
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
+  mesh::Radio* getRadio() override { return _radio; }
   void formatPacketStatsReply(char *reply) override;
   void startRegionsLoad() override;
   bool saveRegions() override;

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -216,6 +216,7 @@ public:
   }
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
+  mesh::Radio* getRadio() override { return _radio; }
   void formatPacketStatsReply(char *reply) override;
   void startRegionsLoad() override;
   bool saveRegions() override;

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -73,6 +73,7 @@ public:
   }
   void formatStatsReply(char *reply) override;
   void formatRadioStatsReply(char *reply) override;
+  mesh::Radio* getRadio() override { return _radio; }
   void formatPacketStatsReply(char *reply) override;
   mesh::LocalIdentity& getSelfId() override { return self_id; }
   void saveIdentity(const mesh::LocalIdentity& new_id) override;

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -67,6 +67,14 @@ public:
 
   virtual void setCADEnabled(bool enable) { }
 
+  /**
+   * \brief  query CAD auto-calibration state.
+   * \param  peak_offset  current detPeak offset above the radio's default
+   * \param  hits/count   ambient CAD detections in the last evaluated probe window
+   * \returns false if this radio doesn't support CAD detPeak tuning.
+  */
+  virtual bool getCADCalibState(uint8_t& peak_offset, uint8_t& hits, uint8_t& count) const { return false; }
+
   virtual void resetAGC() { }
 
   virtual bool isInRecvMode() const = 0;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -27,7 +27,7 @@ uint8_t Mesh::getExtraAckTransmitCount() const {
 }
 
 uint32_t Mesh::getCADFailRetryDelay() const {
-  return _rng->nextInt(1, 4)*120;
+  return 120 + _rng->nextInt(0, 241);   // continuous 120..360ms, so nearby nodes don't retry in lock-step
 }
 
 int Mesh::searchPeersByHash(const uint8_t* hash) {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -793,7 +793,13 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (memcmp(config, "int.thresh", 10) == 0) {
     sprintf(reply, "> %d", (uint32_t) _prefs->interference_threshold);
   } else if (memcmp(config, "cad", 3) == 0) {
-    sprintf(reply, "> %s", _prefs->cad_enabled ? "on" : "off");
+    uint8_t peak_offset, hits, count;
+    mesh::Radio* radio = _callbacks->getRadio();
+    if (_prefs->cad_enabled && radio != NULL && radio->getCADCalibState(peak_offset, hits, count)) {
+      sprintf(reply, "> on (detPeak +%d, ambient %d/%d)", (int)peak_offset, (int)hits, (int)count);
+    } else {
+      sprintf(reply, "> %s", _prefs->cad_enabled ? "on" : "off");
+    }
   } else if (memcmp(config, "agc.reset.interval", 18) == 0) {
     sprintf(reply, "> %d", ((uint32_t) _prefs->agc_reset_interval) * 4);
   } else if (memcmp(config, "multi.acks", 10) == 0) {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -181,6 +181,14 @@ uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
 }
 
 void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* reply) {
+    if (strcmp(command, "get cad") == 0) {   // enrich with live CAD calibration state
+      uint8_t peak_offset, hits, count;
+      mesh::Radio* radio = _callbacks->getRadio();
+      if (_prefs->getRadioPrefs()->isCadEnabled() && radio != NULL && radio->getCADCalibState(peak_offset, hits, count)) {
+        sprintf(reply, "> on (detPeak +%d, ambient %d/%d)", (int)peak_offset, (int)hits, (int)count);
+        return;
+      }
+    }
     if (_prefs->getRadioPrefs()->handleCommand(command, sender_timestamp, reply)) {   // is a radio CLI command?
       if (_prefs->getRadioPrefs()->isDirty()) { savePrefs(); }
       return;

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -206,6 +206,7 @@ public:
   virtual void eraseLogFile() = 0;
   virtual void dumpLogFile() = 0;
   virtual void setTxPower(int8_t power_dbm) = 0;
+  virtual mesh::Radio* getRadio() { return NULL; }
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual void removeNeighbor(const uint8_t* pubkey, int key_len) {
     // no op by default

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -254,6 +254,7 @@ public:
   virtual void eraseLogFile() = 0;
   virtual void dumpLogFile() = 0;
   virtual void setTxPower(int8_t power_dbm) = 0;
+  virtual mesh::Radio* getRadio() { return NULL; }
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual void removeNeighbor(const uint8_t* pubkey, int key_len) {
     // no op by default

--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -34,6 +34,7 @@ public:
     return packetScoreInt(snr, sf, packet_len);
   }
   uint8_t getSpreadingFactor() const override { return ((CustomLLCC68 *)_radio)->spreadingFactor; }
+  uint8_t getCADDetPeakBase() const override { return getSpreadingFactor() + 13; }  // Semtech DS.SX1261-2 recommended detPeak
 
   void doResetAGC() override { sx126xResetAGC((SX126x *)_radio); }
 

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -42,6 +42,12 @@ public:
   float getLastSNR() const override { return ((CustomLR1110 *)_radio)->getSNR(); }
 
   uint8_t getSpreadingFactor() const override { return ((CustomLR1110 *)_radio)->getSpreadingFactor(); }
+  uint8_t getCADDetPeakBase() const override {
+    // RadioLib LR11x0 default detPeak per SF5..12 (different scale than SX126x)
+    static const uint8_t detPeakValues[8] = { 48, 48, 50, 55, 55, 59, 61, 65 };
+    uint8_t sf = getSpreadingFactor();
+    return (sf >= 5 && sf <= 12) ? detPeakValues[sf - 5] : 0;
+  }
   
   bool setRxBoostedGainMode(bool en) override {
     return ((CustomLR1110 *)_radio)->setRxBoostedGainMode(en) == RADIOLIB_ERR_NONE;

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -34,6 +34,7 @@ public:
     return packetScoreInt(snr, sf, packet_len);
   }
   uint8_t getSpreadingFactor() const override { return ((CustomSTM32WLx *)_radio)->spreadingFactor; }
+  uint8_t getCADDetPeakBase() const override { return getSpreadingFactor() + 13; }  // Semtech DS.SX1261-2 recommended detPeak
 
   void doResetAGC() override { sx126xResetAGC((SX126x *)_radio, getRxBoostedGainMode()); }
 };

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -37,6 +37,7 @@ public:
     return packetScoreInt(snr, sf, packet_len);
   }
   uint8_t getSpreadingFactor() const override { return ((CustomSX1262 *)_radio)->spreadingFactor; }
+  uint8_t getCADDetPeakBase() const override { return getSpreadingFactor() + 13; }  // Semtech DS.SX1261-2 recommended detPeak
   virtual void powerOff() override {
     ((CustomSX1262 *)_radio)->sleep(false);
   }

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -37,6 +37,7 @@ public:
     return packetScoreInt(snr, sf, packet_len);
   }
   uint8_t getSpreadingFactor() const override { return ((CustomSX1268 *)_radio)->spreadingFactor; }
+  uint8_t getCADDetPeakBase() const override { return getSpreadingFactor() + 13; }  // Semtech DS.SX1261-2 recommended detPeak
 
   bool setRxBoostedGainMode(bool en) override {
     return ((CustomSX1268 *)_radio)->setRxBoostedGainMode(en) == RADIOLIB_ERR_NONE;

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -14,10 +14,11 @@
 // ambient CAD auto-calibration: probe CAD periodically while idle, and raise/lower detPeak
 // so ambient activity (sub-decode-threshold distant traffic, interference) stops tripping LBT
 #define CAD_PROBE_INTERVAL     4000   // millis between ambient CAD probes
-#define CAD_PROBE_WINDOW         32   // probes per evaluation window
-#define CAD_PROBE_RAISE_HITS     10   // >= ~30% ambient detect rate -> desensitize
-#define CAD_PROBE_LOWER_HITS      3   // <= ~10% ambient detect rate -> re-sensitize
-#define CAD_PEAK_OFFSET_MAX      10
+#define CAD_PROBE_INTERVAL_QUIET 16000  // slower probing while offset is 0 and channel is clean
+#define CAD_PROBE_WINDOW         16   // probes per evaluation window
+#define CAD_PROBE_RAISE_HITS      5   // >= ~30% ambient detect rate -> desensitize
+#define CAD_PROBE_LOWER_HITS      2   // <= ~12% ambient detect rate -> re-sensitize
+#define CAD_PEAK_OFFSET_MAX       6
 
 static volatile uint8_t state = STATE_IDLE;
 
@@ -49,6 +50,7 @@ void RadioLibWrapper::begin() {
   _cad_probe_count = _cad_probe_hits = 0;
   _cad_last_count = _cad_last_hits = 0;
   _last_cad_probe = 0;
+  _cad_probe_interval = CAD_PROBE_INTERVAL;
 
   // start average out some samples
   _num_floor_samples = 0;
@@ -116,7 +118,7 @@ void RadioLibWrapper::loop() {
   }
 
   if (_cad_enabled && state == STATE_RX && getCADDetPeakBase() > 0
-      && millis() - _last_cad_probe >= CAD_PROBE_INTERVAL) {
+      && millis() - _last_cad_probe >= _cad_probe_interval) {
     _last_cad_probe = millis();
     if (!isReceivingPacket()) {
       int16_t result = performChannelScan();
@@ -130,6 +132,7 @@ void RadioLibWrapper::loop() {
       } else if (result == RADIOLIB_LORA_DETECTED || result == RADIOLIB_PREAMBLE_DETECTED) {
         _cad_probe_count++;
         _cad_probe_hits++;
+        _cad_probe_interval = CAD_PROBE_INTERVAL;   // activity -> resume fast probing
       }
       // else: scan error, don't count the sample
 
@@ -143,9 +146,13 @@ void RadioLibWrapper::loop() {
         _cad_probe_count = _cad_probe_hits = 0;
       } else if (_cad_probe_count >= CAD_PROBE_WINDOW) {
         if (_cad_probe_hits <= CAD_PROBE_LOWER_HITS && _cad_peak_offset > 0) {
-          _cad_peak_offset--;
+          // step down twice as fast when the window was completely clean
+          _cad_peak_offset -= (_cad_probe_hits == 0 && _cad_peak_offset >= 2) ? 2 : 1;
           MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
               (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        if (_cad_probe_hits == 0 && _cad_peak_offset == 0) {
+          _cad_probe_interval = CAD_PROBE_INTERVAL_QUIET;   // idle channel, probe less often
         }
         _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
         _cad_probe_count = _cad_probe_hits = 0;

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -11,6 +11,14 @@
 #define NUM_NOISE_FLOOR_SAMPLES  64
 #define SAMPLING_THRESHOLD  14
 
+// ambient CAD auto-calibration: probe CAD periodically while idle, and raise/lower detPeak
+// so ambient activity (sub-decode-threshold distant traffic, interference) stops tripping LBT
+#define CAD_PROBE_INTERVAL     4000   // millis between ambient CAD probes
+#define CAD_PROBE_WINDOW         32   // probes per evaluation window
+#define CAD_PROBE_RAISE_HITS     10   // >= ~30% ambient detect rate -> desensitize
+#define CAD_PROBE_LOWER_HITS      3   // <= ~10% ambient detect rate -> re-sensitize
+#define CAD_PEAK_OFFSET_MAX      10
+
 static volatile uint8_t state = STATE_IDLE;
 
 // this function is called when a complete packet
@@ -37,6 +45,10 @@ void RadioLibWrapper::begin() {
   _noise_floor = 0;
   _threshold = 0;
   _cad_enabled = false;
+  _cad_peak_offset = 0;
+  _cad_probe_count = _cad_probe_hits = 0;
+  _cad_last_count = _cad_last_hits = 0;
+  _last_cad_probe = 0;
 
   // start average out some samples
   _num_floor_samples = 0;
@@ -101,6 +113,44 @@ void RadioLibWrapper::loop() {
     _floor_sample_sum = 0;
 
     MESH_DEBUG_PRINTLN("RadioLibWrapper: noise_floor = %d", (int)_noise_floor);
+  }
+
+  if (_cad_enabled && state == STATE_RX && getCADDetPeakBase() > 0
+      && millis() - _last_cad_probe >= CAD_PROBE_INTERVAL) {
+    _last_cad_probe = millis();
+    if (!isReceivingPacket()) {
+      int16_t result = performChannelScan();
+      // CAD-done DIO interrupt sets STATE_INT_READY via setFlag() ISR. Clear it
+      // before restarting RX so recvRaw() doesn't try to read a non-existent packet.
+      state = STATE_IDLE;
+      startRecv();
+
+      if (result == RADIOLIB_CHANNEL_FREE) {
+        _cad_probe_count++;
+      } else if (result == RADIOLIB_LORA_DETECTED || result == RADIOLIB_PREAMBLE_DETECTED) {
+        _cad_probe_count++;
+        _cad_probe_hits++;
+      }
+      // else: scan error, don't count the sample
+
+      if (_cad_probe_hits >= CAD_PROBE_RAISE_HITS) {   // ambient rate too high, don't wait out the window
+        if (_cad_peak_offset < CAD_PEAK_OFFSET_MAX) {
+          _cad_peak_offset++;
+          MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
+              (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
+        _cad_probe_count = _cad_probe_hits = 0;
+      } else if (_cad_probe_count >= CAD_PROBE_WINDOW) {
+        if (_cad_probe_hits <= CAD_PROBE_LOWER_HITS && _cad_peak_offset > 0) {
+          _cad_peak_offset--;
+          MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
+              (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
+        _cad_probe_count = _cad_probe_hits = 0;
+      }
+    }
   }
 }
 
@@ -187,6 +237,21 @@ void RadioLibWrapper::onSendFinished() {
 }
 
 int16_t RadioLibWrapper::performChannelScan() {
+  uint8_t peak_base = getCADDetPeakBase();
+  if (_cad_peak_offset > 0 && peak_base > 0) {
+    ChannelScanConfig_t cfg = {
+      .cad = {
+        .symNum = 0xFF,    // 0xFF -> radio-specific default (RADIOLIB_*_CAD_PARAM_DEFAULT)
+        .detPeak = (uint8_t)(peak_base + _cad_peak_offset),
+        .detMin = 0xFF,
+        .exitMode = 0xFF,
+        .timeout = 0,
+        .irqFlags = RADIOLIB_IRQ_CAD_DEFAULT_FLAGS,
+        .irqMask = RADIOLIB_IRQ_CAD_DEFAULT_MASK,
+      },
+    };
+    return _radio->scanChannel(cfg);
+  }
   return _radio->scanChannel();
 }
 

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -14,10 +14,11 @@
 // ambient CAD auto-calibration: probe CAD periodically while idle, and raise/lower detPeak
 // so ambient activity (sub-decode-threshold distant traffic, interference) stops tripping LBT
 #define CAD_PROBE_INTERVAL     4000   // millis between ambient CAD probes
-#define CAD_PROBE_WINDOW         32   // probes per evaluation window
-#define CAD_PROBE_RAISE_HITS     10   // >= ~30% ambient detect rate -> desensitize
-#define CAD_PROBE_LOWER_HITS      3   // <= ~10% ambient detect rate -> re-sensitize
-#define CAD_PEAK_OFFSET_MAX      10
+#define CAD_PROBE_INTERVAL_QUIET 16000  // slower probing while offset is 0 and channel is clean
+#define CAD_PROBE_WINDOW         16   // probes per evaluation window
+#define CAD_PROBE_RAISE_HITS      5   // >= ~30% ambient detect rate -> desensitize
+#define CAD_PROBE_LOWER_HITS      2   // <= ~12% ambient detect rate -> re-sensitize
+#define CAD_PEAK_OFFSET_MAX       6
 
 static volatile uint8_t state = STATE_IDLE;
 
@@ -49,6 +50,7 @@ void RadioLibWrapper::begin() {
   _cad_probe_count = _cad_probe_hits = 0;
   _cad_last_count = _cad_last_hits = 0;
   _last_cad_probe = 0;
+  _cad_probe_interval = CAD_PROBE_INTERVAL;
 
   // start average out some samples
   _num_floor_samples = 0;
@@ -121,7 +123,7 @@ void RadioLibWrapper::loop() {
   }
 
   if (_cad_enabled && state == STATE_RX && getCADDetPeakBase() > 0
-      && millis() - _last_cad_probe >= CAD_PROBE_INTERVAL) {
+      && millis() - _last_cad_probe >= _cad_probe_interval) {
     _last_cad_probe = millis();
     if (!isReceivingPacket()) {
       int16_t result = performChannelScan();
@@ -135,6 +137,7 @@ void RadioLibWrapper::loop() {
       } else if (result == RADIOLIB_LORA_DETECTED || result == RADIOLIB_PREAMBLE_DETECTED) {
         _cad_probe_count++;
         _cad_probe_hits++;
+        _cad_probe_interval = CAD_PROBE_INTERVAL;   // activity -> resume fast probing
       }
       // else: scan error, don't count the sample
 
@@ -148,9 +151,13 @@ void RadioLibWrapper::loop() {
         _cad_probe_count = _cad_probe_hits = 0;
       } else if (_cad_probe_count >= CAD_PROBE_WINDOW) {
         if (_cad_probe_hits <= CAD_PROBE_LOWER_HITS && _cad_peak_offset > 0) {
-          _cad_peak_offset--;
+          // step down twice as fast when the window was completely clean
+          _cad_peak_offset -= (_cad_probe_hits == 0 && _cad_peak_offset >= 2) ? 2 : 1;
           MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
               (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        if (_cad_probe_hits == 0 && _cad_peak_offset == 0) {
+          _cad_probe_interval = CAD_PROBE_INTERVAL_QUIET;   // idle channel, probe less often
         }
         _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
         _cad_probe_count = _cad_probe_hits = 0;

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -11,6 +11,14 @@
 #define NUM_NOISE_FLOOR_SAMPLES  64
 #define SAMPLING_THRESHOLD  14
 
+// ambient CAD auto-calibration: probe CAD periodically while idle, and raise/lower detPeak
+// so ambient activity (sub-decode-threshold distant traffic, interference) stops tripping LBT
+#define CAD_PROBE_INTERVAL     4000   // millis between ambient CAD probes
+#define CAD_PROBE_WINDOW         32   // probes per evaluation window
+#define CAD_PROBE_RAISE_HITS     10   // >= ~30% ambient detect rate -> desensitize
+#define CAD_PROBE_LOWER_HITS      3   // <= ~10% ambient detect rate -> re-sensitize
+#define CAD_PEAK_OFFSET_MAX      10
+
 static volatile uint8_t state = STATE_IDLE;
 
 // this function is called when a complete packet
@@ -37,6 +45,10 @@ void RadioLibWrapper::begin() {
   _noise_floor = 0;
   _threshold = 0;
   _cad_enabled = false;
+  _cad_peak_offset = 0;
+  _cad_probe_count = _cad_probe_hits = 0;
+  _cad_last_count = _cad_last_hits = 0;
+  _last_cad_probe = 0;
 
   // start average out some samples
   _num_floor_samples = 0;
@@ -106,6 +118,44 @@ void RadioLibWrapper::loop() {
     #ifdef MESH_DEBUG_NOISE_FLOOR
     MESH_DEBUG_PRINTLN("RadioLibWrapper: noise_floor = %d", (int)_noise_floor);
     #endif
+  }
+
+  if (_cad_enabled && state == STATE_RX && getCADDetPeakBase() > 0
+      && millis() - _last_cad_probe >= CAD_PROBE_INTERVAL) {
+    _last_cad_probe = millis();
+    if (!isReceivingPacket()) {
+      int16_t result = performChannelScan();
+      // CAD-done DIO interrupt sets STATE_INT_READY via setFlag() ISR. Clear it
+      // before restarting RX so recvRaw() doesn't try to read a non-existent packet.
+      state = STATE_IDLE;
+      startRecv();
+
+      if (result == RADIOLIB_CHANNEL_FREE) {
+        _cad_probe_count++;
+      } else if (result == RADIOLIB_LORA_DETECTED || result == RADIOLIB_PREAMBLE_DETECTED) {
+        _cad_probe_count++;
+        _cad_probe_hits++;
+      }
+      // else: scan error, don't count the sample
+
+      if (_cad_probe_hits >= CAD_PROBE_RAISE_HITS) {   // ambient rate too high, don't wait out the window
+        if (_cad_peak_offset < CAD_PEAK_OFFSET_MAX) {
+          _cad_peak_offset++;
+          MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
+              (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
+        _cad_probe_count = _cad_probe_hits = 0;
+      } else if (_cad_probe_count >= CAD_PROBE_WINDOW) {
+        if (_cad_probe_hits <= CAD_PROBE_LOWER_HITS && _cad_peak_offset > 0) {
+          _cad_peak_offset--;
+          MESH_DEBUG_PRINTLN("RadioLibWrapper: CAD ambient %d/%d, detPeak offset -> %d",
+              (int)_cad_probe_hits, (int)_cad_probe_count, (int)_cad_peak_offset);
+        }
+        _cad_last_hits = _cad_probe_hits; _cad_last_count = _cad_probe_count;
+        _cad_probe_count = _cad_probe_hits = 0;
+      }
+    }
   }
 }
 
@@ -192,6 +242,21 @@ void RadioLibWrapper::onSendFinished() {
 }
 
 int16_t RadioLibWrapper::performChannelScan() {
+  uint8_t peak_base = getCADDetPeakBase();
+  if (_cad_peak_offset > 0 && peak_base > 0) {
+    ChannelScanConfig_t cfg = {
+      .cad = {
+        .symNum = 0xFF,    // 0xFF -> radio-specific default (RADIOLIB_*_CAD_PARAM_DEFAULT)
+        .detPeak = (uint8_t)(peak_base + _cad_peak_offset),
+        .detMin = 0xFF,
+        .exitMode = 0xFF,
+        .timeout = 0,
+        .irqFlags = RADIOLIB_IRQ_CAD_DEFAULT_FLAGS,
+        .irqMask = RADIOLIB_IRQ_CAD_DEFAULT_MASK,
+      },
+    };
+    return _radio->scanChannel(cfg);
+  }
   return _radio->scanChannel();
 }
 

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -24,6 +24,7 @@ protected:
   uint8_t _cad_peak_offset;
   uint8_t _cad_probe_count, _cad_probe_hits;
   uint8_t _cad_last_count, _cad_last_hits;
+  uint16_t _cad_probe_interval;
   unsigned long _last_cad_probe;
 
   void idle();

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -21,6 +21,10 @@ protected:
   uint16_t _num_floor_samples;
   int32_t _floor_sample_sum;
   uint8_t _preamble_sf;
+  uint8_t _cad_peak_offset;
+  uint8_t _cad_probe_count, _cad_probe_hits;
+  uint8_t _cad_last_count, _cad_last_hits;
+  unsigned long _last_cad_probe;
 
   void idle();
   void startRecv();
@@ -57,6 +61,18 @@ public:
   void updatePreamble(uint8_t sf) { _preamble_sf = sf; _radio->setPreambleLength(preambleLengthForSF(sf)); }
   PacketMillis calcMaxPacketMillis(uint8_t sf, float bw, uint8_t cr, uint8_t preambleSymbols);
   virtual int16_t performChannelScan();
+  virtual uint8_t getCADDetPeakBase() const { return 0; }   // 0 = CAD detPeak tuning not supported
+
+  bool getCADCalibState(uint8_t& peak_offset, uint8_t& hits, uint8_t& count) const override {
+    if (getCADDetPeakBase() == 0) return false;
+    peak_offset = _cad_peak_offset;
+    if (_cad_last_count > 0) {
+      hits = _cad_last_hits; count = _cad_last_count;
+    } else {   // no probe window evaluated yet, report the one in progress
+      hits = _cad_probe_hits; count = _cad_probe_count;
+    }
+    return true;
+  }
 
   int getNoiseFloor() const override { return _noise_floor; }
   void triggerNoiseFloorCalibrate(int threshold) override;


### PR DESCRIPTION
Probe every 4 seconds to measure actual channel activity. If channel seems busy we adjust CAD to be less sensitive. If channel seems empty maximum CAD sensitivity.

Build here: https://mcimages.weebl.me/?commitId=dynamic-cad

Based on conversation in #1727 - this should make a busier node be less senitive to preambles. Tagging @recrof and @syssi would be interesting to see how this changes behavior.

You can use get cad and it will show stats for actual preambles detected during idle periods.