### PR TITLE
fix(RegionMap): load() returns actual read success instead of hardcoded true

### DIFF
--- a/src/helpers/RegionMap.cpp
+++ b/src/helpers/RegionMap.cpp
@@ -93,13 +93,15 @@ bool RegionMap::load(FILESYSTEM* _fs, const char* path) {
         while (num_regions < MAX_REGION_ENTRIES) {
           auto r = &regions[num_regions];
 
-          success = file.read((uint8_t *) &r->id, sizeof(r->id)) == sizeof(r->id);
+          int n = file.read((uint8_t *) &r->id, sizeof(r->id));
+          if (n == 0) break;  // clean EOF
+          success = (n == sizeof(r->id));
           success = success && file.read((uint8_t *) &r->parent, sizeof(r->parent)) == sizeof(r->parent);
           success = success && file.read((uint8_t *) r->name, sizeof(r->name)) == sizeof(r->name);
           success = success && file.read((uint8_t *) &r->flags, sizeof(r->flags)) == sizeof(r->flags);
           success = success && file.read(pad, sizeof(pad)) == sizeof(pad);
 
-          if (!success) break; // EOF
+          if (!success) break;  // partial read or corruption
 
           if (r->id >= next_id) {    // make sure next_id is valid
             next_id = r->id + 1;
@@ -108,7 +110,7 @@ bool RegionMap::load(FILESYSTEM* _fs, const char* path) {
         }
       }
       file.close();
-      return true;
+      return success;
     }
   }
   return false;  // failed


### PR DESCRIPTION
Companion fix to #2372, which fixed the same \`return true\` hardcoding
in save(). load() has the same issue — it ignores read failures and
always returns true regardless of what happened during the read loop.

(Note: #1891 originally reported this on load(), but was closed when
#2372 landed — that PR only touched save(). This PR addresses the
load() side.)

Fix distinguishes:
- Clean EOF (read() returns 0 bytes on the id field) → normal end of
  a variable-length region list, success unaffected
- Partial/corrupted record (fewer bytes than expected mid-record) →
  real failure, success=false

Verified on Wio Tracker L1 Pro (companion firmware): wrote 3 regions
via \`region put\`, rebooted, confirmed all 3 persisted correctly after
reboot — the clean-EOF path in load() does not regress normal loads.