### PR TITLE
Fix BLE receive queue task synchronization 🤖🤖

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -118,12 +118,17 @@ void SerialBLEInterface::onWrite(BLECharacteristic* pCharacteristic, esp_ble_gat
 
   if (len > MAX_FRAME_SIZE) {
     BLE_DEBUG_PRINTLN("ERROR: onWrite(), frame too big, len=%d", len);
-  } else if (recv_queue_len >= FRAME_QUEUE_SIZE) {
-    BLE_DEBUG_PRINTLN("ERROR: onWrite(), recv_queue is full!");
   } else {
-    recv_queue[recv_queue_len].len = len;
-    memcpy(recv_queue[recv_queue_len].buf, rxValue, len);
-    recv_queue_len++;
+    bool queued = false;
+    portENTER_CRITICAL(&recv_queue_mux);
+    if (recv_queue_len < FRAME_QUEUE_SIZE) {
+      recv_queue[recv_queue_len].len = len;
+      memcpy(recv_queue[recv_queue_len].buf, rxValue, len);
+      recv_queue_len++;
+      queued = true;
+    }
+    portEXIT_CRITICAL(&recv_queue_mux);
+    if (!queued) BLE_DEBUG_PRINTLN("ERROR: onWrite(), recv_queue is full!");
   }
 }
 
@@ -202,16 +207,19 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
     }
   }
 
-  if (recv_queue_len > 0) {   // check recv queue
-    size_t len = recv_queue[0].len;   // take from top of queue
+  size_t len = 0;
+  portENTER_CRITICAL(&recv_queue_mux);
+  if (recv_queue_len > 0) {
+    len = recv_queue[0].len;
     memcpy(dest, recv_queue[0].buf, len);
-
-    BLE_DEBUG_PRINTLN("readBytes: sz=%d, hdr=%d", len, (uint32_t) dest[0]);
-
     recv_queue_len--;
-    for (int i = 0; i < recv_queue_len; i++) {   // delete top item from queue
+    for (int i = 0; i < recv_queue_len; i++) {
       recv_queue[i] = recv_queue[i + 1];
     }
+  }
+  portEXIT_CRITICAL(&recv_queue_mux);
+  if (len > 0) {
+    BLE_DEBUG_PRINTLN("readBytes: sz=%d, hdr=%d", len, (uint32_t) dest[0]);
     return len;
   }
 

--- a/src/helpers/esp32/SerialBLEInterface.h
+++ b/src/helpers/esp32/SerialBLEInterface.h
@@ -26,10 +26,16 @@ class SerialBLEInterface : public BaseSerialInterface, BLESecurityCallbacks, BLE
   #define FRAME_QUEUE_SIZE  4
   int recv_queue_len;
   Frame recv_queue[FRAME_QUEUE_SIZE];
+  portMUX_TYPE recv_queue_mux = portMUX_INITIALIZER_UNLOCKED;
   int send_queue_len;
   Frame send_queue[FRAME_QUEUE_SIZE];
 
-  void clearBuffers() { recv_queue_len = 0; send_queue_len = 0; }
+  void clearBuffers() {
+    portENTER_CRITICAL(&recv_queue_mux);
+    recv_queue_len = 0;
+    portEXIT_CRITICAL(&recv_queue_mux);
+    send_queue_len = 0;
+  }
 
 protected:
   // BLESecurityCallbacks methods


### PR DESCRIPTION
## Summary

- protect callback-to-loop receive queue publication and drain with an ESP32 critical section
- publish each frame only after its bytes are copied
- protect receive reset in `clearBuffers()`
- keep BLE logging and send-queue operations outside the receive critical section

The BLE characteristic callback and Arduino loop can run on different FreeRTOS tasks. Previously they concurrently read, shifted, and changed `recv_queue`/`recv_queue_len` without a memory or ownership boundary.

Hardware validation is still required with high-rate companion writes across repeated connect/disconnect cycles. This change preserves the four-frame FIFO and public interface.

Fixes #2923
