### PR TITLE
Add RAK13800 Ethernet Companion targets with multi-client TCP support

### DIFF
--- a/FLASHING.md
+++ b/FLASHING.md
@@ -1,0 +1,42 @@
+# Flashing Notes
+
+## RAK4631 + RAK13800/W5100S Ethernet Companion
+
+This board-support layer is a follow-up to the Ethernet foundation merged in #1983. It keeps the framed MeshCore Companion TCP API and does not switch to raw line mode, MQTT, or the repeater CLI.
+
+Use the canonical Ethernet companion targets when flashing Crow or validating the RAK13800 wiring:
+
+- `RAK_RAK13800_companion_radio_eth`
+- `RAK_RAK13800_companion_radio_eth_static_diag`
+
+Compatibility aliases are still present for older workflows:
+
+- `RAK_4631_companion_radio_ethernet`
+- `RAK_4631_companion_radio_eth_clean`
+- `RAK_4631_companion_radio_eth_static_diag`
+
+## Build Targets
+
+```bash
+pio run -e RAK_RAK13800_companion_radio_eth
+pio run -e RAK_RAK13800_companion_radio_eth_static_diag
+```
+
+## Connection Details
+
+- Ethernet uses the framed MeshCore Companion TCP protocol.
+- Do not use the repeater CLI target for companion validation.
+- Do not use raw line mode.
+- Crow-compatible target port: `4403`
+- Upstream #1983 default port: `5000`
+
+## Static Diagnostic Target
+
+`RAK_RAK13800_companion_radio_eth_static_diag` boots with:
+
+- IP `10.245.94.47`
+- Gateway `10.245.94.33`
+- DNS `10.245.94.33`
+- Subnet `255.255.255.224`
+
+It is intended for repeatable Ethernet bring-up and Companion protocol validation.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For developers:
 - Install [PlatformIO](https://docs.platformio.org) in [Visual Studio Code](https://code.visualstudio.com).
 - Clone and open the MeshCore repository in Visual Studio Code.
 - See the example applications you can modify and run:
-  - [Companion Radio](./examples/companion_radio) - For use with an external chat app, over BLE, USB or Wi-Fi.
+  - [Companion Radio](./examples/companion_radio) - For use with an external chat app, over BLE, USB, Wi-Fi, or framed Ethernet on RAK4631 + RAK13800/W5100S. This is MeshCore Companion support, not Meshtastic.
   - [KISS Modem](./examples/kiss_modem) - Serial KISS protocol bridge for host applications. ([protocol docs](./docs/kiss_modem_protocol.md))
   - [Simple Repeater](./examples/simple_repeater) - Extends network coverage by relaying messages.
   - [Simple Room Server](./examples/simple_room_server) - A simple BBS server for shared Posts.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,0 +1,48 @@
+# Validation Notes
+
+## Build Checks
+
+Run:
+
+```bash
+pio run -e RAK_RAK13800_companion_radio_eth
+pio run -e RAK_RAK13800_companion_radio_eth_static_diag
+pio run -e RAK_4631_companion_radio_ethernet || true
+pio run -e RAK_4631_repeater_ethernet || true
+pio run -e RAK_4631_room_server_ethernet || true
+```
+
+## Static Checks
+
+```bash
+grep -R "server.available" -n src/helpers/nrf52 examples variants || true
+grep -R "server.accept" -n src/helpers/nrf52 examples variants || true
+grep -R "ETHERNET_RAW_LINE" -n variants examples src || true
+```
+
+Expected:
+
+- Companion Ethernet accept paths use `server.accept()`
+- No Companion Ethernet target defines `ETHERNET_RAW_LINE`
+- `server.available()` is not used for TCP client acceptance
+- The canonical companion target uses TCP port `4403`
+
+## Smoke Tests
+
+```bash
+python3 scripts/meshcore_companion_tcp_smoke_test.py DEVICE_IP 4403
+python3 scripts/meshcore_companion_multi_client_test.py DEVICE_IP 4403
+```
+
+## Static Diagnostic Hardware Test
+
+Flash `RAK_RAK13800_companion_radio_eth_static_diag` and verify:
+
+- Serial output shows Ethernet initialized
+- IP `10.245.94.47`
+- Subnet `255.255.255.224`
+- Gateway `10.245.94.33`
+- TCP server listening on `4403`
+- Ping, TCP connect, and neighbor resolution succeed
+- Companion smoke tests pass
+- Both TCP clients remain connected during the multi-client test

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -827,6 +827,7 @@ For companion radios, you can set these radios' transmit power in the smartphone
 ### 7.8. Q: How do I use Ethernet with a RAK4631?
  **A:**
 MeshCore supports Ethernet on RAK4631 boards using the [RAK13800](https://docs.rakwireless.com/product-categories/wisblock/rak13800/datasheet/) WisBlock Ethernet module (based on the W5100S chip).
+This companion Ethernet support builds on the Ethernet foundation merged in pull request #1983.
 
 **Hardware required:**
 - RAK4631 WisBlock Core
@@ -838,12 +839,21 @@ MeshCore supports Ethernet on RAK4631 boards using the [RAK13800](https://docs.r
 Flash one of the Ethernet-enabled firmware variants:
 - `RAK_4631_repeater_ethernet` - Repeater with Ethernet CLI access
 - `RAK_4631_room_server_ethernet` - Room server with Ethernet CLI access
-- `RAK_4631_companion_radio_ethernet` - Companion radio over Ethernet (replaces BLE)
+- `RAK_RAK13800_companion_radio_eth` - Companion radio over Ethernet using the framed MeshCore Companion TCP API
+- `RAK_RAK13800_companion_radio_eth_static_diag` - Companion radio with a repeatable static validation IP
+- `RAK_4631_companion_radio_ethernet` - Compatibility alias for the canonical RAK13800 target
+
+**Important**
+- This is not Meshtastic.
+- Companion Ethernet is not the repeater CLI target.
+- Companion Ethernet is not MQTT.
+- Companion Ethernet does not use raw line mode.
 
 **Connecting:**
 - The device obtains an IP address via DHCP automatically on boot.
 - For repeaters and room servers, connect to the device on TCP port 23 using any TCP client (e.g. `nc <ip> 23` or PuTTY in raw mode). This gives you the same CLI available over serial/USB.
-- For companion radio firmware, the Ethernet interface replaces BLE as the transport to companion apps. Connect on TCP port 5000 (same as the WiFi companion radio).
+- For companion radio firmware, the Ethernet interface replaces BLE as the transport to companion apps. Connect to `DEVICE_IP:4403` for the MeshCore Crow-compatible target. Upstream #1983 defaults to TCP port 5000, but this repo's Crow validation target overrides it to 4403.
+- The framed Companion TCP transport uses `'<'+uint16_le_length+payload` from client to radio and `'>'+uint16_le_length+payload` from radio to client.
 - Use the `eth.status` CLI command to check connection status and see the assigned IP address.
 
 ---

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -933,6 +933,10 @@ void MyMesh::begin(bool has_display) {
   // load persisted prefs
   _store->loadPrefs(_prefs, sensors.node_lat, sensors.node_lon);
 
+#ifdef FORCE_CLIENT_REPEAT
+  _prefs.client_repeat = FORCE_CLIENT_REPEAT;
+#endif
+
   // sanitise bad pref values
   _prefs.rx_delay_base = constrain(_prefs.rx_delay_base, 0, 20.0f);
   _prefs.airtime_factor = constrain(_prefs.airtime_factor, 0, 9.0f);

--- a/scripts/meshcore_companion_multi_client_test.py
+++ b/scripts/meshcore_companion_multi_client_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+import socket
+import struct
+import sys
+
+
+def recv_exact(sock, size):
+    buf = bytearray()
+    while len(buf) < size:
+        chunk = sock.recv(size - len(buf))
+        if not chunk:
+            raise RuntimeError("connection closed while waiting for data")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def send_frame(sock, payload):
+    sock.sendall(b"<" + struct.pack("<H", len(payload)) + payload)
+
+
+def recv_frame(sock, timeout):
+    sock.settimeout(timeout)
+    header = recv_exact(sock, 3)
+    if header[0:1] != b">":
+        raise RuntimeError(f"unexpected frame header {header!r}")
+    payload_len = struct.unpack("<H", header[1:3])[0]
+    payload = recv_exact(sock, payload_len)
+    return payload
+
+
+def assert_socket_open(sock, label):
+    sock.settimeout(0.1)
+    try:
+        peek = sock.recv(1, socket.MSG_PEEK)
+    except socket.timeout:
+        return
+    if peek == b"":
+        raise RuntimeError(f"{label} was closed")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("host")
+    parser.add_argument("port", type=int)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    args = parser.parse_args()
+
+    client_a = socket.create_connection((args.host, args.port), timeout=args.timeout)
+    client_b = socket.create_connection((args.host, args.port), timeout=args.timeout)
+
+    try:
+        send_frame(client_a, bytes([0x01] + [0x00] * 7))
+        recv_frame(client_a, args.timeout)
+        send_frame(client_b, bytes([0x01] + [0x00] * 7))
+        recv_frame(client_b, args.timeout)
+
+        send_frame(client_a, bytes([0x16, 0x03]))
+        reply_a = recv_frame(client_a, args.timeout)
+        if not reply_a or reply_a[0] != 0x0D:
+            raise RuntimeError(f"client A expected DEVICE_QUERY response 0x0d, got {reply_a[:1]!r}")
+
+        assert_socket_open(client_a, "client A before client B command")
+
+        send_frame(client_b, bytes([0x16, 0x03]))
+        reply_b = recv_frame(client_b, args.timeout)
+        if not reply_b or reply_b[0] != 0x0D:
+            raise RuntimeError(f"client B expected DEVICE_QUERY response 0x0d, got {reply_b[:1]!r}")
+
+        assert_socket_open(client_a, "client A after client B command")
+        assert_socket_open(client_b, "client B after client B command")
+
+        send_frame(client_a, bytes([0x16, 0x03]))
+        reply_a_again = recv_frame(client_a, args.timeout)
+        if not reply_a_again or reply_a_again[0] != 0x0D:
+            raise RuntimeError(f"client A second DEVICE_QUERY failed, got {reply_a_again[:1]!r}")
+
+        print("PASS")
+        return 0
+    finally:
+        client_a.close()
+        client_b.close()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/meshcore_companion_tcp_smoke_test.py
+++ b/scripts/meshcore_companion_tcp_smoke_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import argparse
+import socket
+import struct
+import sys
+
+
+def recv_exact(sock, size):
+    buf = bytearray()
+    while len(buf) < size:
+        chunk = sock.recv(size - len(buf))
+        if not chunk:
+            raise RuntimeError("connection closed while waiting for data")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def send_frame(sock, payload):
+    sock.sendall(b"<" + struct.pack("<H", len(payload)) + payload)
+
+
+def recv_frame(sock, timeout):
+    sock.settimeout(timeout)
+    header = recv_exact(sock, 3)
+    if header[0:1] != b">":
+        raise RuntimeError(f"unexpected frame header {header!r}")
+    payload_len = struct.unpack("<H", header[1:3])[0]
+    payload = recv_exact(sock, payload_len)
+    return payload
+
+
+def read_device_info(payload):
+    if len(payload) < 82 or payload[0] != 0x0D:
+        return None
+    manufacturer = payload[20:60].split(b"\x00", 1)[0].decode("utf-8", "replace")
+    version = payload[60:80].split(b"\x00", 1)[0].decode("utf-8", "replace")
+    return manufacturer, version
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("host")
+    parser.add_argument("port", type=int)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    args = parser.parse_args()
+
+    with socket.create_connection((args.host, args.port), timeout=args.timeout) as sock:
+        send_frame(sock, bytes([0x01] + [0x00] * 7))
+        start_reply = recv_frame(sock, args.timeout)
+        if not start_reply or start_reply[0] != 0x05:
+            raise RuntimeError(f"expected APP_START response 0x05, got {start_reply[:1]!r}")
+
+        send_frame(sock, bytes([0x16, 0x03]))
+        device_reply = recv_frame(sock, args.timeout)
+        if not device_reply or device_reply[0] != 0x0D:
+            raise RuntimeError(f"expected DEVICE_QUERY response 0x0d, got {device_reply[:1]!r}")
+
+        decoded = read_device_info(device_reply)
+        if decoded:
+            manufacturer, version = decoded
+            print(f"manufacturer={manufacturer}")
+            print(f"firmware={version}")
+        else:
+            print("DEVICE_QUERY response decoded partially")
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/src/helpers/nrf52/SerialEthernetInterface.cpp
+++ b/src/helpers/nrf52/SerialEthernetInterface.cpp
@@ -18,8 +18,27 @@ SPIClass ETHERNET_SPI_PORT(NRF_SPIM1, PIN_SPI1_MISO, PIN_SPI1_SCK, PIN_SPI1_MOSI
 #define RECV_STATE_LEN1_FOUND  2
 #define RECV_STATE_LEN2_FOUND  3
 
-bool SerialEthernetInterface::begin() {
+void SerialEthernetInterface::clearClientState(int idx) {
+  if (idx < 0 || idx >= MAX_ETH_CLIENTS) {
+    return;
+  }
+  clients[idx].stop();
+  rx_header[idx].state = RECV_STATE_IDLE;
+  rx_header[idx].frame_len = 0;
+  rx_header[idx].rx_len = 0;
+  memset(rx_header[idx].rx_buf, 0, sizeof(rx_header[idx].rx_buf));
+}
 
+static bool anyClientConnected(EthernetClient clients[]) {
+  for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+    if (clients[i] && clients[i].connected()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool SerialEthernetInterface::begin() {
   ETHERNET_DEBUG_PRINTLN("Ethernet initializing");
 
   // WB_IO2 (power enable) is already driven HIGH by early constructor
@@ -27,8 +46,8 @@ bool SerialEthernetInterface::begin() {
   // Skip hardware reset — the W5100S comes out of power-on reset cleanly,
   // and toggling reset kills the PHY link which breaks POE power.
 #ifdef PIN_ETHERNET_RESET
-        pinMode(PIN_ETHERNET_RESET, OUTPUT);
-        digitalWrite(PIN_ETHERNET_RESET, HIGH);
+  pinMode(PIN_ETHERNET_RESET, OUTPUT);
+  digitalWrite(PIN_ETHERNET_RESET, HIGH);
 #endif
 
   uint8_t mac[6];
@@ -46,32 +65,30 @@ bool SerialEthernetInterface::begin() {
   Ethernet.init(ETHERNET_SPI_PORT, PIN_ETHERNET_SS);
 
   // Use static IP if build flags are defined, otherwise DHCP
-  #if defined(ETHERNET_STATIC_IP) && defined(ETHERNET_STATIC_GATEWAY) && defined(ETHERNET_STATIC_SUBNET) && defined(ETHERNET_STATIC_DNS)
+#if defined(ETHERNET_STATIC_IP) && defined(ETHERNET_STATIC_GATEWAY) && defined(ETHERNET_STATIC_SUBNET) && defined(ETHERNET_STATIC_DNS)
   IPAddress ip(ETHERNET_STATIC_IP);
   IPAddress gateway(ETHERNET_STATIC_GATEWAY);
   IPAddress subnet(ETHERNET_STATIC_SUBNET);
   IPAddress dns(ETHERNET_STATIC_DNS);
   Ethernet.begin(mac, ip, dns, gateway, subnet);
-  #else
+#else
   ETHERNET_DEBUG_PRINTLN("Begin");
   if (Ethernet.begin(mac) == 0) {
     ETHERNET_DEBUG_PRINTLN("Begin failed.");
 
     // DHCP failed -- let's figure out why
-    if (Ethernet.hardwareStatus() == EthernetNoHardware)  // Check for Ethernet hardware present.
-    {
+    if (Ethernet.hardwareStatus() == EthernetNoHardware) {
       ETHERNET_DEBUG_PRINTLN("Ethernet hardware not found.");
       return false;
     }
-    if (Ethernet.linkStatus() == LinkOFF)     // No physical connection
-    {
+    if (Ethernet.linkStatus() == LinkOFF) {
       ETHERNET_DEBUG_PRINTLN("Ethernet cable not connected.");
       return false;
     }
     ETHERNET_DEBUG_PRINTLN("Ethernet: DHCP failed for unknown reason.");
     return false;
   }
-  #endif
+#endif
   ETHERNET_DEBUG_PRINTLN("Ethernet begin complete");
   ETHERNET_DEBUG_PRINT_IP("IP", Ethernet.localIP());
   ETHERNET_DEBUG_PRINT_IP("Subnet", Ethernet.subnetMask());
@@ -79,6 +96,11 @@ bool SerialEthernetInterface::begin() {
 
   server.begin();   // start listening for clients
   ETHERNET_DEBUG_PRINTLN("Ethernet: listening on TCP port: %d", ETHERNET_TCP_PORT);
+
+  clearBuffers();
+  _last_rx = -1;
+  _rr = 0;
+  deviceConnected = false;
 
   return true;
 }
@@ -95,35 +117,83 @@ void SerialEthernetInterface::disable() {
 }
 
 size_t SerialEthernetInterface::writeFrame(const uint8_t src[], size_t len) {
-  if (len > MAX_FRAME_SIZE) {
-    ETHERNET_DEBUG_PRINTLN("writeFrame(), frame too big, len=%d\n", len);
+  if (!_isEnabled || len == 0) {
     return 0;
   }
 
-  if (deviceConnected && len > 0) {
-    if (send_queue_len >= FRAME_QUEUE_SIZE) {
-      ETHERNET_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
-      return 0;
-    }
-
-    send_queue[send_queue_len].len = len;  // add to send queue
-    memcpy(send_queue[send_queue_len].buf, src, len);
-    send_queue_len++;
-
-    return len;
+  if (len > MAX_FRAME_SIZE) {
+    ETHERNET_DEBUG_PRINTLN("writeFrame(), frame too big, len=%d", len);
+    return 0;
   }
-  return 0;
+
+  const bool broadcast = src[0] >= 0x80;
+  if (!broadcast && (_last_rx < 0 || _last_rx >= MAX_ETH_CLIENTS)) {
+    return 0;
+  }
+
+  if (send_queue_len >= ETH_FRAME_QUEUE_SIZE) {
+    ETHERNET_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
+    return 0;
+  }
+
+  Frame& frame = send_queue[send_queue_len];
+  frame.len = len;
+  frame.target = broadcast ? -1 : (int8_t)_last_rx;
+  frame.broadcast = broadcast;
+  memcpy(frame.buf, src, len);
+  send_queue_len++;
+
+  return len;
 }
 
 bool SerialEthernetInterface::isWriteBusy() const {
   return false;
 }
 
+static bool parseClientByte(SerialEthernetInterface::FrameHeader& rx, uint8_t c, uint8_t dest[]) {
+  switch (rx.state) {
+    case RECV_STATE_IDLE:
+      if (c == '<') {
+        rx.state = RECV_STATE_HDR_FOUND;
+      }
+      break;
+    case RECV_STATE_HDR_FOUND:
+      rx.frame_len = (uint8_t)c;
+      rx.state = RECV_STATE_LEN1_FOUND;
+      break;
+    case RECV_STATE_LEN1_FOUND:
+      rx.frame_len |= ((uint16_t)c) << 8;
+      rx.rx_len = 0;
+      rx.state = rx.frame_len > 0 ? RECV_STATE_LEN2_FOUND : RECV_STATE_IDLE;
+      break;
+    default:
+      if (rx.rx_len < MAX_FRAME_SIZE) {
+        rx.rx_buf[rx.rx_len] = c;
+      }
+      rx.rx_len++;
+      if (rx.rx_len >= rx.frame_len) {
+        if (rx.frame_len > MAX_FRAME_SIZE) {
+          rx.frame_len = MAX_FRAME_SIZE;
+        }
+        memcpy(dest, rx.rx_buf, rx.frame_len);
+        rx.state = RECV_STATE_IDLE;
+        return true;
+      }
+      break;
+  }
+  return false;
+}
+
+static void sendFrameToClient(EthernetClient& client, const uint8_t* frame, size_t len) {
+  uint8_t pkt[3 + MAX_FRAME_SIZE];
+  pkt[0] = '>';
+  pkt[1] = (uint8_t)(len & 0xFF);
+  pkt[2] = (uint8_t)((len >> 8) & 0xFF);
+  memcpy(&pkt[3], frame, len);
+  client.write(pkt, 3 + len);
+}
+
 size_t SerialEthernetInterface::checkRecvFrame(uint8_t dest[]) {
-  // Use accept() (not available()) so we only see newly-accepted sockets.
-  // available() also returns existing connected sockets that have data,
-  // which would cause us to treat each inbound packet as a "new client"
-  // and stop() the underlying socket — disconnecting the companion.
   auto newClient = server.accept();
   if (newClient) {
     IPAddress new_ip = newClient.remoteIP();
@@ -136,118 +206,89 @@ size_t SerialEthernetInterface::checkRecvFrame(uint8_t dest[]) {
         new_ip[3],
         new_port);
 
-    deviceConnected = false;
-    if (client) {
-      ETHERNET_DEBUG_PRINTLN("Closing previous client");
-      client.stop();
-    }
-    _state = RECV_STATE_IDLE;
-    _frame_len = 0;
-    _rx_len = 0;
-    client = newClient;
-    ETHERNET_DEBUG_PRINTLN("Switched to new client");
-  }
-
-  if (client.connected()) {
-    if (!deviceConnected) {
-      ETHERNET_DEBUG_PRINTLN(
-          "Got connection %u.%u.%u.%u:%u",
-          client.remoteIP()[0],
-          client.remoteIP()[1],
-          client.remoteIP()[2],
-          client.remoteIP()[3],
-          client.remotePort());
-      deviceConnected = true;
-    }
-  } else {
-    if (deviceConnected) {
-      deviceConnected = false;
-      ETHERNET_DEBUG_PRINTLN("Disconnected");
-    }
-  }
-
-  if (deviceConnected) {
-    if (send_queue_len > 0) {   // first, check send queue
-
-      _last_write = millis();
-      int len = send_queue[0].len;
-
-#if ETHERNET_RAW_LINE
-      ETHERNET_DEBUG_PRINTLN("TX line len=%d", len);
-      client.write(send_queue[0].buf, len);
-      client.write("\r\n", 2);
-#else
-      uint8_t pkt[3+len]; // use same header as serial interface so client can delimit frames
-      pkt[0] = '>';
-      pkt[1] = (len & 0xFF);  // LSB
-      pkt[2] = (len >> 8);    // MSB
-      memcpy(&pkt[3], send_queue[0].buf, send_queue[0].len);
-      ETHERNET_DEBUG_PRINTLN("Sending frame len=%d", len);
-      #if ETHERNET_DEBUG_LOGGING && ARDUINO
-      ETHERNET_DEBUG_PRINTLN("TX frame len=%d", len);
-      #endif
-      client.write(pkt, 3 + len);
-#endif
-      send_queue_len--;
-      for (int i = 0; i < send_queue_len; i++) {   // delete top item from queue
-        send_queue[i] = send_queue[i + 1];
+    int slot = -1;
+    for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+      if (!clients[i] || !clients[i].connected()) {
+        slot = i;
+        break;
       }
-    } else {
-      while (client.available()) {
-        int c = client.read();
-        if (c < 0) break;
+    }
 
-#if ETHERNET_RAW_LINE
-        if (c == '\r' || c == '\n') {
-          if (_rx_len == 0) {
-            continue;
-          }
-          uint16_t out_len = _rx_len;
-          if (out_len > MAX_FRAME_SIZE) {
-            out_len = MAX_FRAME_SIZE;
-          }
-          memcpy(dest, _rx_buf, out_len);
-          _rx_len = 0;
-          return out_len;
+    if (slot >= 0) {
+      clients[slot].stop();
+      clients[slot] = newClient;
+      rx_header[slot].state = RECV_STATE_IDLE;
+      rx_header[slot].frame_len = 0;
+      rx_header[slot].rx_len = 0;
+      _last_rx = slot;
+      deviceConnected = true;
+      ETHERNET_DEBUG_PRINTLN("Accepted client in slot %d", slot);
+    } else {
+      ETHERNET_DEBUG_PRINTLN("All client slots full, rejecting new connection");
+      newClient.stop();
+    }
+  }
+
+  deviceConnected = anyClientConnected(clients);
+
+  for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+    if (!clients[i]) {
+      continue;
+    }
+    if (!clients[i].connected()) {
+      if (_last_rx == i) {
+        _last_rx = -1;
+      }
+      clearClientState(i);
+      continue;
+    }
+  }
+
+  if (!deviceConnected) {
+    return 0;
+  }
+
+  if (send_queue_len > 0) {
+    _last_write = millis();
+    Frame& frame = send_queue[0];
+    bool sent = false;
+
+    if (frame.broadcast) {
+      for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+        if (clients[i] && clients[i].connected()) {
+          sendFrameToClient(clients[i], frame.buf, frame.len);
+          sent = true;
         }
-        if (_rx_len < MAX_FRAME_SIZE) {
-          _rx_buf[_rx_len] = (uint8_t)c;
-          _rx_len++;
-        }
-#else
-        switch (_state) {
-          case RECV_STATE_IDLE:
-            if (c == '<') {
-              _state = RECV_STATE_HDR_FOUND;
-            }
-            break;
-          case RECV_STATE_HDR_FOUND:
-            _frame_len = (uint8_t)c;
-            _state = RECV_STATE_LEN1_FOUND;
-            break;
-          case RECV_STATE_LEN1_FOUND:
-            _frame_len |= ((uint16_t)c) << 8;
-            _rx_len = 0;
-            _state = _frame_len > 0 ? RECV_STATE_LEN2_FOUND : RECV_STATE_IDLE;
-            break;
-          default:
-            if (_rx_len < MAX_FRAME_SIZE) {
-              _rx_buf[_rx_len] = (uint8_t)c;
-            }
-            _rx_len++;
-            if (_rx_len >= _frame_len) {
-              if (_frame_len > MAX_FRAME_SIZE) {
-                _frame_len = MAX_FRAME_SIZE;
-              }
-              #if ETHERNET_DEBUG_LOGGING && ARDUINO
-              ETHERNET_DEBUG_PRINTLN("RX frame len=%d", _frame_len);
-              #endif
-              memcpy(dest, _rx_buf, _frame_len);
-              _state = RECV_STATE_IDLE;
-              return _frame_len;
-            }
-        }
-#endif
+      }
+    } else if (frame.target >= 0 && frame.target < MAX_ETH_CLIENTS && clients[frame.target] && clients[frame.target].connected()) {
+      sendFrameToClient(clients[frame.target], frame.buf, frame.len);
+      sent = true;
+    } else {
+      ETHERNET_DEBUG_PRINTLN("Dropping queued frame for disconnected client");
+    }
+
+    send_queue_len--;
+    for (int i = 0; i < send_queue_len; i++) {
+      send_queue[i] = send_queue[i + 1];
+    }
+
+    if (!sent) {
+      return 0;
+    }
+  }
+
+  for (int offset = 0; offset < MAX_ETH_CLIENTS; offset++) {
+    int idx = (_rr + offset) % MAX_ETH_CLIENTS;
+    if (!clients[idx] || !clients[idx].connected()) {
+      continue;
+    }
+    while (clients[idx].available()) {
+      int c = clients[idx].read();
+      if (c < 0) break;
+      if (parseClientByte(rx_header[idx], (uint8_t)c, dest)) {
+        _last_rx = idx;
+        _rr = (idx + 1) % MAX_ETH_CLIENTS;
+        return rx_header[idx].frame_len;
       }
     }
   }

--- a/src/helpers/nrf52/SerialEthernetInterface.h
+++ b/src/helpers/nrf52/SerialEthernetInterface.h
@@ -7,47 +7,66 @@
 #ifndef ETHERNET_TCP_PORT
   #define ETHERNET_TCP_PORT 5000
 #endif
-// define ETHERNET_RAW_LINE=1 to use raw line-based CLI instead of framed packets
+
+#ifndef MAX_ETH_CLIENTS
+  #define MAX_ETH_CLIENTS 3
+#endif
+
+#ifndef ETH_FRAME_QUEUE_SIZE
+  #define ETH_FRAME_QUEUE_SIZE 16
+#endif
 
 class SerialEthernetInterface : public BaseSerialInterface {
-  bool deviceConnected;
-  bool _isEnabled;
-  unsigned long _last_write;
-  uint8_t _state;
-  uint16_t _frame_len;
-  uint16_t _rx_len;
-  uint8_t _rx_buf[MAX_FRAME_SIZE];
+public:
+  struct FrameHeader {
+    uint8_t state;
+    uint16_t frame_len;
+    uint16_t rx_len;
+    uint8_t rx_buf[MAX_FRAME_SIZE];
+  };
 
-  EthernetServer server;
-  EthernetClient client;
-
+private:
   struct Frame {
-    uint8_t len;
+    uint16_t len;
+    int8_t target;
+    bool broadcast;
     uint8_t buf[MAX_FRAME_SIZE];
   };
 
-  #define FRAME_QUEUE_SIZE 4
-  int send_queue_len;
-  Frame send_queue[FRAME_QUEUE_SIZE];
+  bool deviceConnected;
+  bool _isEnabled;
+  unsigned long _last_write;
+  int _last_rx;
+  int _rr;
 
+  EthernetServer server;
+  EthernetClient clients[MAX_ETH_CLIENTS];
+  FrameHeader rx_header[MAX_ETH_CLIENTS];
+
+  int send_queue_len;
+  Frame send_queue[ETH_FRAME_QUEUE_SIZE];
+
+  void clearClientState(int idx);
   void clearBuffers() {
     send_queue_len = 0;
-    _state = 0;
-    _frame_len = 0;
-    _rx_len = 0;
+    for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+      clearClientState(i);
+    }
   }
 
-  protected:
+protected:
 
-  public:
-    SerialEthernetInterface() : server(EthernetServer(ETHERNET_TCP_PORT)) {
+public:
+    SerialEthernetInterface() : server(ETHERNET_TCP_PORT) {
         deviceConnected = false;
         _isEnabled = false;
         _last_write = 0;
+        _last_rx = -1;
+        _rr = 0;
         send_queue_len = 0;
-        _state = 0;
-        _frame_len = 0;
-        _rx_len = 0;
+        for (int i = 0; i < MAX_ETH_CLIENTS; i++) {
+          clearClientState(i);
+        }
     }
     bool begin();
 

--- a/variants/rak4631/RAK4631Board.h
+++ b/variants/rak4631/RAK4631Board.h
@@ -33,6 +33,10 @@ public:
   }
 
   const char* getManufacturerName() const override {
+#if defined(ETHERNET_ENABLED)
+    return "RAK 4631 / RAK13800 + W5100S";
+#else
     return "RAK 4631";
+#endif
   }
 };

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -175,7 +175,7 @@ lib_deps =
   densaugeo/base64 @ ~1.4.0
 
 
-[env:RAK_4631_companion_radio_ethernet]
+[RAK_RAK13800_companion_radio_eth_base]
 extends = rak4631
 board_build.ldscript = boards/nrf52840_s140_v6.ld
 board_upload.maximum_size = 712704
@@ -187,12 +187,14 @@ build_flags =
   -D PIN_USER_BTN=9
   -D PIN_USER_BTN_ANA=31
   -D DISPLAY_CLASS=SSD1306Display
-  -D MAX_CONTACTS=350
+  -D MAX_CONTACTS=128
   -D MAX_GROUP_CHANNELS=40
   -D ETHERNET_ENABLED=1
+  -D ETHERNET_TCP_PORT=4403
+  -D ETHERNET_DEBUG_LOGGING=0
+  -D FORCE_CLIENT_REPEAT=0
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
-;  -D ETHERNET_DEBUG_LOGGING=1
 build_src_filter = ${rak4631.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
@@ -201,6 +203,32 @@ lib_deps =
   ${rak4631.lib_deps}
   densaugeo/base64 @ ~1.4.0
   https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+
+[env:RAK_RAK13800_companion_radio_eth]
+extends = RAK_RAK13800_companion_radio_eth_base
+
+[RAK_RAK13800_companion_radio_eth_static_diag_base]
+extends = RAK_RAK13800_companion_radio_eth_base
+build_flags =
+  ${RAK_RAK13800_companion_radio_eth_base.build_flags}
+  -D MAX_CONTACTS=128
+  -D ETHERNET_DEBUG_LOGGING=1
+  -D ETHERNET_STATIC_IP=10,245,94,47
+  -D ETHERNET_STATIC_GATEWAY=10,245,94,33
+  -D ETHERNET_STATIC_DNS=10,245,94,33
+  -D ETHERNET_STATIC_SUBNET=255,255,255,224
+
+[env:RAK_RAK13800_companion_radio_eth_static_diag]
+extends = RAK_RAK13800_companion_radio_eth_static_diag_base
+
+[env:RAK_4631_companion_radio_eth_clean]
+extends = RAK_RAK13800_companion_radio_eth_base
+
+[env:RAK_4631_companion_radio_eth_static_diag]
+extends = RAK_RAK13800_companion_radio_eth_static_diag_base
+
+[env:RAK_4631_companion_radio_ethernet]
+extends = RAK_RAK13800_companion_radio_eth_base
 
 
 [env:RAK_4631_companion_radio_ble]

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -209,6 +209,8 @@ extends = RAK_RAK13800_companion_radio_eth_base
 
 [RAK_RAK13800_companion_radio_eth_static_diag_base]
 extends = RAK_RAK13800_companion_radio_eth_base
+build_unflags =
+  -D ETHERNET_DEBUG_LOGGING=0
 build_flags =
   ${RAK_RAK13800_companion_radio_eth_base.build_flags}
   -D MAX_CONTACTS=128


### PR DESCRIPTION
This PR is now rebased on top of the Ethernet support merged in #1983.

It adds the RAK13800 Ethernet Companion board-support layer and upgrades the Companion Ethernet transport from single-client behavior to multi-client framed Companion TCP.

## Headline changes

### Multi-client framed Companion TCP

This PR updates `SerialEthernetInterface` so multiple Companion TCP clients can remain connected at the same time.

The transport now supports:

* `MAX_ETH_CLIENTS`, defaulting to 3
* per-client connection slots
* per-client receive parser state
* round-robin receive polling
* `_last_rx` tracking for command response routing
* broadcast delivery for push frames
* slot-only disconnect cleanup
* rejection of only the new client when all slots are full

This avoids the old failure mode where a second connection or incoming packet could close the live Companion socket.

### Framed Companion API preserved

This is still MeshCore Companion framing, not CLI/raw-line mode:

```text
client -> radio: '<' + uint16_le(length) + payload
radio -> client: '>' + uint16_le(length) + payload
```

This PR intentionally does not enable raw line mode for the Companion target.

## RAK13800 board-support targets

Adds canonical RAK13800 Ethernet Companion targets:

* `RAK_RAK13800_companion_radio_eth`
* `RAK_RAK13800_companion_radio_eth_static_diag`

Keeps compatibility aliases for older names:

* `RAK_4631_companion_radio_eth_clean`
* `RAK_4631_companion_radio_eth_static_diag`
* `RAK_4631_companion_radio_ethernet`

## Crow / gateway settings

The RAK13800 Companion target uses:

* `ETHERNET_ENABLED=1`
* `ETHERNET_TCP_PORT=4403`
* `FORCE_CLIENT_REPEAT=0`
* `MAX_CONTACTS=128`
* framed Companion packets
* no raw-line CLI mode

The static diagnostic target adds:

* IP: `10.245.94.47`
* gateway: `10.245.94.33`
* DNS: `10.245.94.33`
* subnet: `255.255.255.224`
* debug logging enabled

## Device model

Ethernet builds report:

```text
RAK 4631 / RAK13800 + W5100S
```

Normal RAK4631 builds continue to report the normal RAK4631 model string.

## What this is not

* Not the repeater CLI target
* Not raw-line Ethernet CLI
* Not MQTT
* Not Meshtastic

This is the framed MeshCore Companion API over Ethernet TCP, with multi-client support for RAK4631 + RAK13800/W5100S hardware.

## Validation

Added Companion TCP smoke-test scripts for:

* normal framed Companion TCP
* multi-client Companion TCP behavior

Expected validation:

```bash
pio run -e RAK_RAK13800_companion_radio_eth
pio run -e RAK_RAK13800_companion_radio_eth_static_diag

python3 scripts/meshcore_companion_tcp_smoke_test.py 10.245.94.47 4403
python3 scripts/meshcore_companion_multi_client_test.py 10.245.94.47 4403
```

Expected static diagnostic hardware result:

* device reachable at `10.245.94.47/27`
* TCP `4403` open
* `APP_START` receives a response
* `DEVICE_QUERY` receives response code `0x0d`
* two Companion TCP clients can remain connected simultaneously
