### PR TITLE
ThinkNode M6 repeater: disable leftover MESH_DEBUG/GPS_NMEA_DEBUG

### DIFF
--- a/variants/thinknode_m6/platformio.ini
+++ b/variants/thinknode_m6/platformio.ini
@@ -48,8 +48,8 @@ build_flags =
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
 ;  -D MESH_PACKET_LOGGING=1
-  -D MESH_DEBUG=1
-  -D GPS_NMEA_DEBUG=1
+;  -D MESH_DEBUG=1
+;  -D GPS_NMEA_DEBUG=1
 build_src_filter = ${ThinkNode_M6.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 lib_deps =


### PR DESCRIPTION
The ThinkNode M6 is the only board whose `simple_repeater` env ships with `MESH_DEBUG=1` and `GPS_NMEA_DEBUG=1` enabled.

- `MESH_DEBUG=1` triggers a **5-second boot delay** in `examples/simple_repeater/main.cpp` and enables verbose per-packet serial prints on the hot RX/TX path.
- `GPS_NMEA_DEBUG=1` echoes **every** GPS UART character to the serial console (`src/helpers/sensors/MicroNMEALocationProvider.h`).

Every sibling repeater env (M1, M3, t1000-e, RAK, Heltec) ships these off, and the M6 `room_server` env in the same file already has them commented out — so these are copy/port leftovers rather than intended defaults. This PR comments them out to match the rest of the tree; no functional code changes.
