### PR TITLE
sensors: fix millis() rollover that stalls GPS time-sync on long-uptime nodes

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -889,11 +889,11 @@ void EnvironmentSensorManager::stop_gps() {
 void EnvironmentSensorManager::loop() {
 
   #if ENV_INCLUDE_GPS
-  static long next_gps_update = 0;
+  static unsigned long next_gps_update = 0;
   if (gps_active) {
     _location->loop();
   }
-  if (millis() > next_gps_update) {
+  if ((long)(millis() - next_gps_update) > 0) {
 
     if(gps_active){
     #ifdef RAK_WISBLOCK_GPS

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -42,14 +42,14 @@ class MicroNMEALocationProvider : public LocationProvider {
     int8_t _claims = 0;
     int _pin_reset;
     int _pin_en;
-    long next_check = 0;
+    unsigned long next_check = 0;
     long time_valid = 0;
     unsigned long _last_time_sync = 0;
     static const unsigned long TIME_SYNC_INTERVAL = 1800000; // Re-sync every 30 minutes
 
 public :
     MicroNMEALocationProvider(Stream& ser, mesh::RTCClock* clock = NULL, int pin_reset = GPS_RESET, int pin_en = GPS_EN,RefCountedDigitalPin* peripher_power=NULL) :
-    _gps_serial(&ser), nmea(_nmeaBuffer, sizeof(_nmeaBuffer)), _pin_reset(pin_reset), _pin_en(pin_en), _clock(clock), _peripher_power(peripher_power) {
+    nmea(_nmeaBuffer, sizeof(_nmeaBuffer)), _clock(clock), _gps_serial(&ser), _peripher_power(peripher_power), _pin_reset(pin_reset), _pin_en(pin_en) {
         if (_pin_reset != -1) {
             pinMode(_pin_reset, OUTPUT);
             digitalWrite(_pin_reset, GPS_RESET_FORCE);
@@ -62,9 +62,7 @@ public :
 
     void claim() {
         _claims++;
-        if (_claims > 0) {
-            if (_peripher_power) _peripher_power->claim();
-        }
+        if (_peripher_power) _peripher_power->claim();
     }
 
     void release() {
@@ -143,7 +141,7 @@ public :
 
         if (!isValid()) time_valid = 0;
 
-        if (millis() > next_check) {
+        if ((long)(millis() - next_check) > 0) {
             next_check = millis() + 1000;
             // Re-enable time sync periodically when GPS has valid fix
             if (!_time_sync_needed && _clock != NULL && (millis() - _last_time_sync) > TIME_SYNC_INTERVAL) {


### PR DESCRIPTION
## Problem

`MicroNMEALocationProvider` and `EnvironmentSensorManager` store a *future* `millis()`
deadline in a signed `long` and compare it with a naive `millis() > deadline`:

```cpp
long next_check = 0;
...
if (millis() > next_check) {
    next_check = millis() + 1000;
    // re-arm 30-min time-sync + set RTC from GPS here
}
```

`millis()` is `uint32_t`. After the ~24.8-day sign flip the stored deadline sits above
the wrapped `millis()`, so `millis() > next_check` stays false and the whole block never
runs again. Because both the periodic re-arm **and** the actual `_clock->setCurrentTime()`
live inside that block, GPS→RTC time-sync (manual *and* automatic) stops permanently until
reboot — matching the "ran for weeks then the clock drifted / node fell off the map"
reports in #2786 (this is distinct from, and complementary to, the missing-clock-in-
constructor cause some boards also have). The same pattern in
`EnvironmentSensorManager::loop()` (`next_gps_update`) freezes the location cache refresh.

## Fix

Use the wrap-safe signed-difference compare already used by `Dispatcher::millisHasNowPassed`
(`(long)(millis() - deadline) > 0`) and make the deadlines `unsigned long`:

- `src/helpers/sensors/MicroNMEALocationProvider.h`: `next_check`
- `src/helpers/sensors/EnvironmentSensorManager.cpp`: `next_gps_update`

Valid for all intervals well under 2^31 ms (here 1 s), on every platform.

Two tiny cleanups ride along in the same file: reorder the `MicroNMEALocationProvider`
constructor init-list to declaration order (silences `-Wreorder`), and drop the always-true
`if (_claims > 0)` guard in `claim()` (it always runs right after `_claims++`).

No functional change beyond fixing the rollover; no API/ABI surface touched (all changed
symbols are private/local).
