### PR TITLE
ThinkNode M6/M1 room_server: set ROOM_PASSWORD default

### DIFF
--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -58,6 +58,7 @@ build_flags =
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M1.build_src_filter}

--- a/variants/thinknode_m6/platformio.ini
+++ b/variants/thinknode_m6/platformio.ini
@@ -63,6 +63,7 @@ build_flags =
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M6.build_src_filter}


### PR DESCRIPTION
The ThinkNode M6 and M1 `room_server` envs do not define `ROOM_PASSWORD`, so the guest password defaults to empty. A client that sends a blank password then matches and is granted read+write (post) access — i.e. the room ships open.

Every other board that builds a room server (m3, t1000-e, rak_wismesh_tag, heltec_t114, …) sets `-D ROOM_PASSWORD='"hello"'`; M6 and M1 were the only two omitting it. This adds the same default so a freshly flashed M6/M1 room is gated out of the box. Operators can still change it at runtime with `set guest.password`.

No code changes; two `platformio.ini` lines.