### PR TITLE
Add support for Elecrow ThinkNode M9

### DIFF
--- a/boards/thinknode_m9.json
+++ b/boards/thinknode_m9.json
@@ -1,0 +1,57 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=0",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "qio_opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "ELECROW-ThinkNode-M9"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "elecrow-thinknode-m9",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 524288,
+    "maximum_size": 16777216,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.elecrow.com/thinknode-m1-meshtastic-lora-signal-transceiver-powered-by-nrf52840-with-154-screen-support-gps.html",
+  "vendor": "ELECROW"
+}

--- a/src/helpers/AutoDiscoverRTCClock.cpp
+++ b/src/helpers/AutoDiscoverRTCClock.cpp
@@ -42,6 +42,7 @@ void AutoDiscoverRTCClock::begin(TwoWire& wire) {
   }
 
   if (i2c_probe(wire, PCF8563_ADDRESS)) {
+    MESH_DEBUG_PRINTLN("PCF8563: Found");
     rtc_8563_success = rtc_8563.begin(&wire);
   }
 

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -18,6 +18,14 @@
   #define SCALE_Y  2.109375f   // 135 / 64
 #endif
 
+#ifdef DISPLAY_SCALE_X
+  #define SCALE_X DISPLAY_SCALE_X
+#endif
+
+#ifdef DISPLAY_SCALE_Y
+  #define SCALE_Y DISPLAY_SCALE_Y
+#endif
+
 bool ST7789Display::begin() {
   if(!_isOn) {
     pinMode(PIN_TFT_VDD_CTL, OUTPUT);
@@ -32,6 +40,9 @@ bool ST7789Display::begin() {
 
     display.init();
     display.landscapeScreen();
+    #ifdef DISPLAY_FLIP_VERTICALLY
+    display.flipScreenVertically();
+    #endif
     display.displayOn();
     setCursor(0,0);
 
@@ -49,6 +60,9 @@ void ST7789Display::turnOn() {
     // Re-initialize the display
     display.init();
     display.displayOn();
+    #ifdef DISPLAY_FLIP_VERTICALLY
+    display.flipScreenVertically();
+    #endif
     delay(20);
 
     // Now turn on the backlight

--- a/src/helpers/ui/ST7789Display.h
+++ b/src/helpers/ui/ST7789Display.h
@@ -14,8 +14,10 @@ class ST7789Display : public DisplayDriver {
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:
-#ifdef HELTEC_VISION_MASTER_T190
+#if defined(HELTEC_VISION_MASTER_T190)
   ST7789Display() : DisplayDriver(128, 64), display(&SPI, PIN_TFT_RST, PIN_TFT_DC, PIN_TFT_CS, GEOMETRY_RAWMODE, 320, 170,PIN_TFT_SDA,-1,PIN_TFT_SCL) {_isOn = false;}
+#elif defined(THINKNODE_M9)
+  ST7789Display() : DisplayDriver(128, 64), display(&SPI, ST7789_RESET, ST7789_RS, ST7789_CS, GEOMETRY_RAWMODE, 320, 240, ST7789_SDA, ST7789_MISO, ST7789_SCK) {_isOn = false;}
 #else
   ST7789Display() : DisplayDriver(128, 64), display(&SPI1, PIN_TFT_RST, PIN_TFT_DC, PIN_TFT_CS, GEOMETRY_RAWMODE, 240, 135) {_isOn = false;}
 #endif

--- a/variants/thinknode_m9/ThinkNodeM9Board.cpp
+++ b/variants/thinknode_m9/ThinkNodeM9Board.cpp
@@ -1,0 +1,23 @@
+#include "ThinkNodeM9Board.h"
+
+void ThinkNodeM9Board::begin() {
+
+  // power on screen
+  pinMode(VEXT_ENABLE, OUTPUT);
+  digitalWrite(VEXT_ENABLE, VEXT_ON_VALUE);
+
+  ESP32Board::begin();
+
+}
+
+void ThinkNodeM9Board::powerOff()  {
+  enterDeepSleep(0);
+}
+
+uint32_t ThinkNodeM9Board::getIRQGpio() {
+  return LORA_DIO0;
+}
+
+const char* ThinkNodeM9Board::getManufacturerName() const {
+  return "Elecrow ThinkNode M9";
+}

--- a/variants/thinknode_m9/ThinkNodeM9Board.h
+++ b/variants/thinknode_m9/ThinkNodeM9Board.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+
+class ThinkNodeM9Board : public ESP32Board {
+
+public:
+  void begin();
+  void powerOff() override;
+  const char* getManufacturerName() const override;
+  uint32_t getIRQGpio() override;
+};

--- a/variants/thinknode_m9/pins_arduino.h
+++ b/variants/thinknode_m9/pins_arduino.h
@@ -1,0 +1,64 @@
+// Need this file for ESP32-S3
+// No need to modify this file, changes to pins imported from variant.h
+// Most is similar to https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include <variant.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+// Serial
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Default SPI will be mapped to Radio
+static const uint8_t SS = LORA_CS;
+static const uint8_t SCK = SPI_SCK;
+static const uint8_t MOSI = SPI_MOSI;
+static const uint8_t MISO = SPI_MISO;
+
+// The default Wire will be mapped to PMU and RTC
+static const uint8_t SCL = I2C_SCL;
+static const uint8_t SDA = I2C_SDA;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/thinknode_m9/platformio.ini
+++ b/variants/thinknode_m9/platformio.ini
@@ -1,0 +1,160 @@
+[ThinkNode_M9]
+extends = esp32_base
+board = thinknode_m9
+board_check = true
+board_build.partitions = default_16MB.csv
+upload_protocol = esptool
+build_flags =
+  ${esp32_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/thinknode_m9
+  -I src/helpers/esp32
+  -I src/helpers/sensors
+  -D THINKNODE_M9
+  -D PIN_BUZZER=9
+  -D PIN_BOARD_SCL=6
+  -D PIN_BOARD_SDA=7
+  -D P_LORA_NSS=39
+  -D P_LORA_RESET=45
+  -D P_LORA_BUSY=41
+  -D P_LORA_SCLK=40
+  -D P_LORA_MISO=38
+  -D P_LORA_MOSI=47
+  -D P_LORA_DIO_1=42
+  -D USE_LR1110
+  -D RF_SWITCH_TABLE
+  -D RADIO_CLASS=CustomLR1110
+  -D WRAPPER_CLASS=CustomLR1110Wrapper
+  -D LR11X0_DIO_AS_RF_SWITCH=true
+  -D LR11X0_DIO3_TCXO_VOLTAGE=3.3
+  -D LORA_TX_POWER=22
+  -D DISPLAY_CLASS=ST7789Display
+  -D DISPLAY_FLIP_VERTICALLY=1
+  -D DISPLAY_SCALE_X=2.5f ; 320 / 128
+  -D DISPLAY_SCALE_Y=3.75f ; 240 / 64
+  -D ST7789
+  -D PIN_TFT_VDD_CTL=-1
+  -D PIN_TFT_LEDA_CTL=17
+  -D PIN_TFT_RST=14
+  -D PIN_GPS_RX=3
+  -D PIN_GPS_TX=2
+  -D PIN_GPS_EN=11
+  -D PIN_GPS_EN_ACTIVE=LOW
+  -D PIN_GPS_RESET=5
+  -D PIN_GPS_RESET_ACTIVE=HIGH
+  -D GPS_BAUD_RATE=115200
+  -D ENV_INCLUDE_GPS=1
+  -D PIN_VBAT_READ=13
+build_src_filter = ${esp32_base.build_src_filter}
+  +<helpers/sensors/EnvironmentSensorManager.cpp>
+  +<helpers/ui/ST7789Display.cpp>
+  +<helpers/ui/OLEDDisplay.cpp>
+  +<helpers/ui/OLEDDisplayFonts.cpp>
+  +<helpers/*.cpp>
+  +<../variants/thinknode_m9>
+lib_deps = ${esp32_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit GFX Library @ ^1.12.1
+
+[env:ThinkNode_M9_repeater_]
+extends = ThinkNode_M9
+build_flags =
+  ${ThinkNode_M9.build_flags}
+  -D ADVERT_NAME='"ThinkNode M9 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  ;-D MESH_PACKET_LOGGING=1
+  ;-D MESH_DEBUG=1
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<../examples/simple_repeater/*.cpp>
+lib_deps =
+  ${ThinkNode_M9.lib_deps}
+  ${esp32_ota.lib_deps}  
+
+[env:ThinkNode_M9_room_server_]
+extends = ThinkNode_M9
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${ThinkNode_M9.build_flags}
+  -D ADVERT_NAME='"ThinkNode M9 Room Server"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${ThinkNode_M9.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:ThinkNode_M9_companion_radio_ble_]
+extends = ThinkNode_M9
+build_flags =
+  ${ThinkNode_M9.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${ThinkNode_M9.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:ThinkNode_M9_companion_radio_usb_]
+extends = ThinkNode_M9
+build_flags =
+  ${ThinkNode_M9.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${ThinkNode_M9.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:ThinkNode_M9_companion_radio_wifi_]
+extends = ThinkNode_M9
+build_flags =
+  ${ThinkNode_M9.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D MESH_PACKET_LOGGING=1
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${ThinkNode_M9.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:ThinkNode_M9_kiss_modem]
+extends = ThinkNode_M9
+build_src_filter = ${ThinkNode_M9.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/thinknode_m9/target.cpp
+++ b/variants/thinknode_m9/target.cpp
@@ -1,0 +1,78 @@
+#include <Arduino.h>
+#include "target.h"
+
+ThinkNodeM9Board board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#ifdef ENV_INCLUDE_GPS
+#include <helpers/sensors/MicroNMEALocationProvider.h>
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+EnvironmentSensorManager sensors = EnvironmentSensorManager();
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+#endif
+
+#ifdef RF_SWITCH_TABLE
+static const uint32_t rfswitch_dios[Module::RFSWITCH_MAX_PINS] = {
+  RADIOLIB_LR11X0_DIO5,
+  RADIOLIB_LR11X0_DIO6,
+  RADIOLIB_NC,
+  RADIOLIB_NC, 
+  RADIOLIB_NC
+};
+
+static const Module::RfSwitchMode_t rfswitch_table[] = {
+  // mode                  DIO5  DIO6
+  {LR11x0::MODE_STBY, {LOW, LOW}}, {LR11x0::MODE_RX, {HIGH, LOW}},
+  {LR11x0::MODE_TX, {HIGH, HIGH}}, {LR11x0::MODE_TX_HP, {LOW, HIGH}},
+  {LR11x0::MODE_TX_HF, {LOW, LOW}}, {LR11x0::MODE_GNSS, {LOW, LOW}},
+  {LR11x0::MODE_WIFI, {LOW, LOW}}, END_OF_MODE_TABLE,
+};
+#endif
+
+#ifndef LORA_CR
+  #define LORA_CR 5
+#endif
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+  
+#ifdef LR11X0_DIO3_TCXO_VOLTAGE
+  float tcxo = LR11X0_DIO3_TCXO_VOLTAGE;
+#else
+  float tcxo = 1.6f;
+#endif
+  
+  int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_LR11X0_LORA_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
+  if (status != RADIOLIB_ERR_NONE) {
+    Serial.print("ERROR: radio init failed: ");
+    Serial.println(status);
+    return false;  // fail
+  }
+  
+  radio.setCRC(2);
+  radio.explicitHeader();
+
+#ifdef RF_SWITCH_TABLE
+  radio.setRfSwitchTable(rfswitch_dios, rfswitch_table);
+#endif
+#ifdef RX_BOOSTED_GAIN
+  radio.setRxBoostedGainMode(RX_BOOSTED_GAIN);
+#endif
+
+  return true;  // success
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/thinknode_m9/target.h
+++ b/variants/thinknode_m9/target.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <ThinkNodeM9Board.h>
+#include <helpers/radiolib/CustomLR1110Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#include <helpers/sensors/LocationProvider.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/ST7789Display.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+
+extern ThinkNodeM9Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();
+

--- a/variants/thinknode_m9/variant.cpp
+++ b/variants/thinknode_m9/variant.cpp
@@ -1,0 +1,7 @@
+#include "variant.h"
+#include <Arduino.h>
+
+
+void initVariant() {
+  
+}

--- a/variants/thinknode_m9/variant.h
+++ b/variants/thinknode_m9/variant.h
@@ -1,0 +1,114 @@
+/*Power*/
+#define VEXT_ENABLE 18
+#define VEXT_ON_VALUE LOW
+#define PIN_GPS_EN 11
+#define GPS_EN_ACTIVE LOW
+
+/*Wire Interface*/
+#define WIRE_INTERFACES_COUNT 2
+// I2C keybuttons
+#define I2C_SCL1 21
+#define I2C_SDA1 20
+#define KB_INT 12
+// I2C peripheral`
+#define I2C_SCL 6
+#define I2C_SDA 7
+
+/*LED*/
+#define PIN_LED 13
+#define KB_LED 46
+
+/*BUZZER*/
+#define PIN_BUZZER 9
+
+/*CHARGE_CHECK*/
+#define DONE 8
+#define EXT_PWR_DETECT 1
+#define EXT_CHRG_DETECT 1
+#define EXT_CHRG_DETECT_VALUE LOW
+/*GPS*/
+#define GPS_L76K
+#define GPS_BAUDRATE 9600
+#define PIN_GPS_RESET 5
+#define PIN_GPS_PPS 4
+#define PIN_GPS_STANDBY 10 // An output to wake GPS, low means allow sleep, high means force wake
+#define GPS_TX_PIN 3
+#define GPS_RX_PIN 2
+#define GPS_THREAD_INTERVAL 50
+
+/*SPI*/
+#define SPI_MOSI 47
+#define SPI_SCK 40
+#define SPI_MISO 38
+
+/*SD Card*/
+#define SDCARD_CS 48
+#define SD_SPI_FREQUENCY 80000000U
+
+/*Screen*/
+// #define USE_ST7789 1
+#define ST7789_CS 16
+#define ST7789_RS 15
+#define ST7789_TE 19
+#define ST7789_SDA SPI_MOSI // MOSI
+#define ST7789_SCK SPI_SCK
+#define ST7789_RESET 14
+#define ST7789_MISO SPI_MISO
+#define ST7789_BUSY -1
+#define ST7789_BL 17
+#define ST7789_SPI_HOST SPI2_HOST
+#define SPI_FREQUENCY 80000000
+#define SPI_READ_FREQUENCY 16000000
+
+#define USE_TFTDISPLAY 1
+#define TFT_CS ST7789_CS
+#define TFT_BL ST7789_BL
+#define TFT_HEIGHT 320
+#define TFT_WIDTH 240
+#define TFT_OFFSET_X 0
+#define TFT_OFFSET_Y 0
+#define TFT_OFFSET_ROTATION 0
+#define TFT_PWM_FREQ 44000
+#define TFT_PWM_CHANNEL 7
+#define TFT_INVERT_LIGHT true
+#define TFT_BACKLIGHT_ON LOW
+#define SCREEN_ROTATE
+#define SCREEN_TRANSITION_FRAMERATE 5
+#define BRIGHTNESS_DEFAULT 128
+
+#define LGFX_PANEL ST7789
+#define DISPLAY_SIZE 320x240
+#define LGFX_ROTATION 0
+#define LGFX_CFG_HOST SPI2_HOST
+#define LGFX_PIN_SCK ST7789_SCK
+#define LGFX_PIN_MOSI ST7789_SDA
+#define LGFX_PIN_DC ST7789_RS
+#define LGFX_PIN_CS ST7789_CS
+#define LGFX_PIN_BL ST7789_BL
+#define LGFX_SCREEN_WIDTH TFT_WIDTH
+#define LGFX_SCREEN_HEIGHT TFT_HEIGHT
+#define LGFX_INVERT_LIGHT true
+#define LGFX_PWM_FREQ 44000
+#define LGFX_PWM_CHANNEL 7
+
+/*Lora radio*/
+#define LORA_SCK SPI_SCK
+#define LORA_MISO SPI_MISO
+#define LORA_MOSI SPI_MOSI
+#define LORA_CS 39
+#define LORA_RESET 45
+#define LORA_DIO0 41
+
+#define USE_LR1110
+#define LR1110_IRQ_PIN 42
+#define LR1110_NRESET_PIN LORA_RESET
+#define LR1110_BUSY_PIN LORA_DIO0
+#define LR1110_SPI_NSS_PIN LORA_CS
+#define LR1110_SPI_SCK_PIN LORA_SCK
+#define LR1110_SPI_MOSI_PIN LORA_MOSI
+#define LR1110_SPI_MISO_PIN LORA_MISO
+#define LR11X0_DIO3_TCXO_VOLTAGE 3.3
+#define LR11X0_DIO_AS_RF_SWITCH
+
+/*RTC*/
+#define PCF8563_RTC 0x51


### PR DESCRIPTION
This PR adds initial support for the Elecrow ThinkNode M9.

Currently, the default companion UI isn't too interesting for this device, and the keyboard has not been wired up, so navigation is not possible.

For now, it's being added in a disabled state, where firmware won't be auto built by our release flow on GitHub Actions. However, users can build the firmware themselves if they want it.

The intention is to provide the base structure that's successfully compiling and running, to allow users to tinker and pave the way for a new companion UI.

I have tested the following firmwares:

- companion_radio_ble
- companion_radio_usb
- companion_radio_wifi
- repeater
- room_server

Note that this device uses a keyboard that sends key events over I2C. You would need to poll I2C each loop, and handle the key events that have been provided. For now, we don't have any input source framework in place for injecting key events from custom keyboards into the existing UITasks.

It would be best to avoid having to setup drivers for all keyboards inside the UITask, and instead have a way to register input sources on the Board object, and allow UITasks to register key event callbacks via the provided Board instance.

This will be left for the future :)