### PR TITLE
fix  repeater watchdog

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -160,9 +160,6 @@ void loop() {
   external_watchdog.loop();
 #endif
   if (the_mesh.getNodePrefs()->powersaving_enabled && !the_mesh.hasPendingWork()) {
-#ifdef HAS_EXTERNAL_WATCHDOG
-    external_watchdog.feed();
-#endif
 #if defined(NRF52_PLATFORM)
     board.sleep(0); // nrf ignores seconds param, sleeps whenever possible
 #else


### PR DESCRIPTION
Whether on the nRF or other platforms, the maximum sleep duration with `powersaving_enabled` currently stands at 30 seconds; however, the watchdog is serviced with a one-minute lead time, providing more than enough margin. Therefore, the watchdog service call within the loop is being removed to reduce power consumption.