### PR TITLE
Add USB serial bridge transport for repeater firmware

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -14,6 +14,10 @@
 #endif
 
 #ifdef WITH_RS232_BRIDGE
+#ifdef WITH_USB_SERIAL_BRIDGE
+#include <Adafruit_TinyUSB.h>
+extern Adafruit_USBD_CDC bridgeSerial;
+#endif
 #include "helpers/bridges/RS232Bridge.h"
 #define WITH_BRIDGE
 #endif

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -3,6 +3,10 @@
 
 #include "MyMesh.h"
 
+#ifdef WITH_USB_SERIAL_BRIDGE
+Adafruit_USBD_CDC bridgeSerial;
+#endif
+
 #ifdef DISPLAY_CLASS
   #include "UITask.h"
   static UITask ui_task(display);
@@ -36,6 +40,10 @@ static unsigned long userBtnDownAt = 0;
 #endif
 
 void setup() {
+#ifdef WITH_USB_SERIAL_BRIDGE
+  // Register the second CDC interface before Serial mounts the USB device.
+  bridgeSerial.begin(115200);
+#endif
   Serial.begin(115200);
   delay(1000);
 

--- a/src/helpers/bridges/RS232Bridge.cpp
+++ b/src/helpers/bridges/RS232Bridge.cpp
@@ -2,6 +2,10 @@
 
 #include <HardwareSerial.h>
 
+#ifdef WITH_USB_SERIAL_BRIDGE
+#include <Adafruit_TinyUSB.h>
+#endif
+
 #ifdef WITH_RS232_BRIDGE
 
 RS232Bridge::RS232Bridge(NodePrefs *prefs, Stream &serial, mesh::PacketManager *mgr, mesh::RTCClock *rtc)
@@ -9,6 +13,9 @@ RS232Bridge::RS232Bridge(NodePrefs *prefs, Stream &serial, mesh::PacketManager *
 
 void RS232Bridge::begin() {
   BRIDGE_DEBUG_PRINTLN("Initializing at %d baud...\n", _prefs->bridge_baud);
+#ifdef WITH_USB_SERIAL_BRIDGE
+  static_cast<Adafruit_USBD_CDC*>(_serial)->begin(_prefs->bridge_baud);
+#else
 #if !defined(WITH_RS232_BRIDGE_RX) || !defined(WITH_RS232_BRIDGE_TX)
 #error "WITH_RS232_BRIDGE_RX and WITH_RS232_BRIDGE_TX must be defined"
 #endif
@@ -28,6 +35,7 @@ void RS232Bridge::begin() {
 #error RS232Bridge was not tested on the current platform
 #endif
   ((HardwareSerial *)_serial)->begin(_prefs->bridge_baud);
+#endif
 
   // Update bridge state
   _initialized = true;
@@ -35,7 +43,11 @@ void RS232Bridge::begin() {
 
 void RS232Bridge::end() {
   BRIDGE_DEBUG_PRINTLN("Stopping...\n");
+#ifdef WITH_USB_SERIAL_BRIDGE
+  static_cast<Adafruit_USBD_CDC*>(_serial)->end();
+#else
   ((HardwareSerial *)_serial)->end();
+#endif
 
   // Update bridge state
   _initialized = false;

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -95,6 +95,25 @@ build_src_filter = ${rak4631.build_src_filter}
   +<helpers/bridges/RS232Bridge.cpp>
   +<../examples/simple_repeater>
 
+[env:RAK_4631_repeater_bridge_usbserial]
+extends = rak4631
+build_flags =
+  ${rak4631.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"USB Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=bridgeSerial
+  -D WITH_USB_SERIAL_BRIDGE
+  -D CFG_TUD_CDC=2
+  -UENV_INCLUDE_GPS
+build_src_filter = ${rak4631.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<../examples/simple_repeater>
+
 [env:RAK_4631_repeater_bridge_rs232_serial2]
 extends = rak4631
 build_flags =

--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -51,6 +51,22 @@ build_flags =
 build_src_filter = ${SenseCap_Solar.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 
+[env:SenseCap_Solar_repeater_bridge_usbserial]
+extends = SenseCap_Solar
+build_flags =
+  ${SenseCap_Solar.build_flags}
+  -D ADVERT_NAME='"SenseCap Solar USB Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=bridgeSerial
+  -D WITH_USB_SERIAL_BRIDGE
+  -D CFG_TUD_CDC=2
+build_src_filter = ${SenseCap_Solar.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<../examples/simple_repeater/*.cpp>
+
 [env:SenseCap_Solar_room_server]
 extends = SenseCap_Solar
 build_flags =


### PR DESCRIPTION
Adds native USB CDC support to `RS232Bridge` for selected repeater targets with a second USB CDC interface.

Initially, includes these targets:

- RAK4631
- SenseCAP Solar

The existing serial bridge frame format is unchanged; only its physical transport changes.

- USB CDC 0 remains the normal MeshCore CLI/debug `Serial` port.
- USB CDC 1 carries the serial bridge stream.

For all other bridge targets, existing UART behaviour remains unchanged.

Closes #2958

## Testing

Built and bench-tested on physical hardware:

- `RAK_4631_repeater_bridge_usbserial`
- `SenseCap_Solar_repeater_bridge_usbserial`

Verified that the CLI and bridge enumerate as separate USB serial ports and that bridge traffic works over the second port.