### PR TITLE
Fix Git error during project configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,7 @@ platform_packages =
   ; use internal fork that includes patch to ble stack to prevent firmware lockup during rapid connect/disconnect
   ; https://github.com/meshcore-dev/MeshCore/pull/1177
   ; https://github.com/meshcore-dev/MeshCore/pull/1295
-  framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301
+  framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301665b40959682252911e57b11df3ee651a
 extra_scripts = create-uf2.py
 build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM
@@ -99,7 +99,7 @@ lib_deps =
 extends = arduino_base
 upload_protocol = picotool
 board_build.core = earlephilhower
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#4e22a0d ; framework-arduinopico @ 1.50600.0+sha.6a1d13e9
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#4e22a0dcdd94eead72fdf56ea59a3d7c8aa2f379 ; framework-arduinopico @ 1.50600.0+sha.6a1d13e9
 build_flags = ${arduino_base.build_flags}
   -D RP2040_PLATFORM
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -85,7 +85,7 @@ platform_packages =
   ; use internal fork that includes patch to ble stack to prevent firmware lockup during rapid connect/disconnect
   ; https://github.com/meshcore-dev/MeshCore/pull/1177
   ; https://github.com/meshcore-dev/MeshCore/pull/1295
-  framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301
+  framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301665b40959682252911e57b11df3ee651a
   platformio/toolchain-gccarmnoneeabi@^1.140201.0
 extra_scripts = create-uf2.py
 build_flags = ${arduino_base.build_flags}


### PR DESCRIPTION
Previously project configuration would fail with "fatal: couldn't find remote ref d541301" (git v2.55.0)

This affected almost all platformio commands too. E.g.

```
 *  Executing task: platformio run --environment RAK_3401_repeater 

Processing RAK_3401_repeater (board: rak3401; platform: nordicnrf52; framework: arduino)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Tool Manager: Installing git+https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301
git version 2.55.0
hint: Using 'master' as the name for the initial branch. This default branch name
hint: will change to "main" in Git 3.0. To configure the initial branch name
hint: to use in all of your new repositories, which will suppress this warning,
hint: call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
hint:
hint: Disable this message with "git config set advice.defaultBranchName false"
Initialized empty Git repository in /root/.platformio/.cache/tmp/pkg-installing-wokqua5c/.git/
fatal: couldn't find remote ref d541301
VCSBaseException: VCS: Could not process command ['git', 'fetch', '--depth=1', 'origin', 'd541301']
```

Per https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-refspec, the <src> argument needs to be either a ref (read: branch or tag) or a "**fully spelled** hex object name". The error appears to have been caused by the partial hex.

This requirement is also mentioned in this SO answer: https://stackoverflow.com/a/30701724

After this change, project configuration now succeeds.