### PR TITLE
Add companion message TX lifecycle events

### DIFF
--- a/docs/companion_protocol.md
+++ b/docs/companion_protocol.md
@@ -1,6 +1,6 @@
 # Companion Protocol
 
-- **Last Updated**: 2026-03-08
+- **Last Updated**: 2026-07-17
 - **Protocol Version**: Companion Firmware v1.12.0+
 
 > NOTE: This document is still in development. Some information may be inaccurate.
@@ -625,7 +625,7 @@ Byte values are authoritative; names are aliases. When reading firmware source, 
 | 0x03  | PACKET_CONTACT             | Contact information           |
 | 0x04  | PACKET_CONTACT_END         | End of contact list           |
 | 0x05  | PACKET_SELF_INFO           | Device self-information       |
-| 0x06  | PACKET_MSG_SENT            | Message sent confirmation     |
+| 0x06  | PACKET_MSG_SENT            | Message accepted for sending  |
 | 0x07  | PACKET_CONTACT_MSG_RECV    | Contact message (standard)    |
 | 0x08  | PACKET_CHANNEL_MSG_RECV    | Channel message (standard)    |
 | 0x09  | PACKET_CURRENT_TIME        | Current time response         |
@@ -640,6 +640,7 @@ Byte values are authoritative; names are aliases. When reading firmware source, 
 | 0x82  | PACKET_ACK                 | Acknowledgment                |
 | 0x83  | PACKET_MESSAGES_WAITING    | Messages waiting notification |
 | 0x88  | PACKET_LOG_DATA            | RF log data (can be ignored)  |
+| 0x91  | PACKET_SEND_TX_STATUS      | Local radio TX status (v14+)  |
 
 ### Parsing Responses
 
@@ -799,10 +800,39 @@ Bytes 2-5: Tag / Expected ACK (4 bytes, little-endian)
 Bytes 6-9: Suggested Timeout (32-bit little-endian, milliseconds)
 ```
 
+This response means the firmware accepted the message for sending. It does not mean the radio has
+transmitted it or that the recipient received it.
+
+**PACKET_SEND_TX_STATUS** (0x91, app target version 14+):
+```
+Byte 0: 0x91
+Bytes 1-4: Tag / Expected ACK (4 bytes, little-endian)
+Byte 5: Local TX status
+```
+
+Local TX status values:
+
+| Value | Meaning |
+|-------|---------|
+| 0 | The local radio driver reported transmission complete |
+| 1 | The local radio rejected the transmission before it started |
+| 2 | The radio did not report completion before the firmware timeout; the over-air outcome is unknown |
+
+The tag matches the value returned in `PACKET_MSG_SENT`, allowing clients to update the correct
+message. Status 0 only confirms transmission by the local radio; it does not confirm receipt by the
+destination or any intermediate hop. Status 2 must not be presented as definite non-delivery because
+the packet may have been transmitted even though completion was not observed.
+
+Clients supporting protocol version 14 should start the suggested ACK timeout after status 0. If the
+timeout expires without `PACKET_ACK`, the accurate state is "delivery unconfirmed," not "delivery
+failed." Firmware emits no 0x91 frames when the app target version is below 14.
+
 **PACKET_ACK** (0x82):
 ```
 Byte 0: 0x82
-Bytes 1-6: ACK Code (6 bytes, hex)
+Bytes 1-4: ACK Code (4 bytes, little-endian)
+Bytes 5-8: Elapsed time since the message was accepted for sending
+           (32-bit little-endian, milliseconds; includes local queue delay)
 ```
 
 ### Error Codes

--- a/examples/companion_radio/CompanionTxStatus.h
+++ b/examples/companion_radio/CompanionTxStatus.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace companion {
+
+constexpr uint8_t TX_STATUS_PENDING = 0xFF;
+
+inline bool isPendingTxMatch(uint32_t ack, uint8_t tx_status, const uint8_t* stored_hash,
+                             const uint8_t* packet_hash, size_t hash_len) {
+  return ack != 0 && tx_status == TX_STATUS_PENDING &&
+         memcmp(stored_hash, packet_hash, hash_len) == 0;
+}
+
+inline bool shouldPushTxStatus(uint8_t app_target_ver) {
+  return app_target_ver >= 14;
+}
+
+}  // namespace companion

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -126,6 +126,7 @@
 #define PUSH_CODE_CONTROL_DATA          0x8E   // v8+
 #define PUSH_CODE_CONTACT_DELETED       0x8F // used to notify client app of deleted contact when overwriting oldest
 #define PUSH_CODE_CONTACTS_FULL         0x90 // used to notify client app that contacts storage is full
+#define PUSH_CODE_SEND_TX_STATUS        0x91 // v14+, local radio TX outcome for an ACK-tracked message
 
 #define ERR_CODE_UNSUPPORTED_CMD        1
 #define ERR_CODE_NOT_FOUND              2
@@ -414,7 +415,8 @@ void MyMesh::onContactPathUpdated(const ContactInfo &contact) {
 ContactInfo*  MyMesh::processAck(const uint8_t *data) {
   // see if matches any in a table
   for (int i = 0; i < EXPECTED_ACK_TABLE_SIZE; i++) {
-    if (memcmp(data, &expected_ack_table[i].ack, 4) == 0) { // got an ACK from recipient
+    if (expected_ack_table[i].ack != 0 &&
+        memcmp(data, &expected_ack_table[i].ack, 4) == 0) { // got an ACK from recipient
       out_frame[0] = PUSH_CODE_SEND_CONFIRMED;
       memcpy(&out_frame[1], data, 4);
       uint32_t trip_time = _ms->getMillis() - expected_ack_table[i].msg_sent;
@@ -427,6 +429,36 @@ ContactInfo*  MyMesh::processAck(const uint8_t *data) {
     }
   }
   return checkConnectionsAck(data);
+}
+
+void MyMesh::onPacketTxStatus(mesh::Packet* packet, mesh::PacketTxStatus status) {
+  uint8_t packet_hash[MAX_HASH_SIZE];
+  packet->calculatePacketHash(packet_hash);
+
+  for (int i = 0; i < EXPECTED_ACK_TABLE_SIZE; i++) {
+    auto& entry = expected_ack_table[i];
+    if (entry.ack == 0 || memcmp(entry.packet_hash, packet_hash, sizeof(packet_hash)) != 0) continue;
+
+    // A packet may be transmitted more than once by future retry strategies. Once one local TX
+    // completed, a later failed retry must not downgrade the message's state.
+    if (entry.tx_status == mesh::PACKET_TX_COMPLETE || entry.tx_status == status) return;
+
+    entry.tx_status = status;
+    if (app_target_ver >= 14) {
+      out_frame[0] = PUSH_CODE_SEND_TX_STATUS;
+      memcpy(&out_frame[1], &entry.ack, 4);
+      out_frame[5] = status;
+      _serial->writeFrame(out_frame, 6);
+    }
+
+    // startSendRaw() returning false guarantees that this attempt never started. A completion
+    // timeout is deliberately retained because the packet may have gone over the air and a late
+    // ACK can still confirm delivery.
+    if (status == mesh::PACKET_TX_START_FAILED) {
+      entry.ack = 0;
+    }
+    return;
+  }
 }
 
 void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packet *pkt,
@@ -869,6 +901,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   app_target_ver = 0;
   clearPendingReqs();
   next_ack_idx = 0;
+  memset(expected_ack_table, 0, sizeof(expected_ack_table));
   sign_data = NULL;
   dirty_contacts_expiry = 0;
   memset(advert_paths, 0, sizeof(advert_paths));
@@ -1093,14 +1126,14 @@ void MyMesh::handleCmdFrame(size_t len) {
       text[tlen] = 0; // ensure null
       int result;
       uint32_t expected_ack;
+      uint8_t packet_hash[MAX_HASH_SIZE] = {0};
       if (txt_type == TXT_TYPE_CLI_DATA) {
         msg_timestamp = getRTCClock()->getCurrentTimeUnique(); // Use node's RTC instead of app timestamp to avoid tripping replay protection
         result = sendCommandData(*recipient, msg_timestamp, attempt, text, est_timeout);
         expected_ack = 0; // no Ack expected
       } else {
-        result = sendMessage(*recipient, msg_timestamp, attempt, text, expected_ack, est_timeout);
+        result = sendMessage(*recipient, msg_timestamp, attempt, text, expected_ack, est_timeout, packet_hash);
       }
-      // TODO: add expected ACK to table
       if (result == MSG_SEND_FAILED) {
         writeErrFrame(ERR_CODE_TABLE_FULL);
       } else {
@@ -1108,6 +1141,8 @@ void MyMesh::handleCmdFrame(size_t len) {
           expected_ack_table[next_ack_idx].msg_sent = _ms->getMillis(); // add to circular table
           expected_ack_table[next_ack_idx].ack = expected_ack;
           expected_ack_table[next_ack_idx].contact = recipient;
+          memcpy(expected_ack_table[next_ack_idx].packet_hash, packet_hash, sizeof(packet_hash));
+          expected_ack_table[next_ack_idx].tx_status = 0xFF; // queued, no local TX outcome yet
           next_ack_idx = (next_ack_idx + 1) % EXPECTED_ACK_TABLE_SIZE;
         }
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1,4 +1,5 @@
 #include "MyMesh.h"
+#include "CompanionTxStatus.h"
 
 #include <Arduino.h> // needed for PlatformIO
 #include <Mesh.h>
@@ -437,14 +438,13 @@ void MyMesh::onPacketTxStatus(mesh::Packet* packet, mesh::PacketTxStatus status)
 
   for (int i = 0; i < EXPECTED_ACK_TABLE_SIZE; i++) {
     auto& entry = expected_ack_table[i];
-    if (entry.ack == 0 || memcmp(entry.packet_hash, packet_hash, sizeof(packet_hash)) != 0) continue;
-
-    // A packet may be transmitted more than once by future retry strategies. Once one local TX
-    // completed, a later failed retry must not downgrade the message's state.
-    if (entry.tx_status == mesh::PACKET_TX_COMPLETE || entry.tx_status == status) return;
+    // Identical resends can share a packet hash. A terminal callback belongs to the oldest
+    // still-pending entry, not an earlier timed-out attempt whose outcome remains unknown.
+    if (!companion::isPendingTxMatch(entry.ack, entry.tx_status, entry.packet_hash, packet_hash,
+                                     sizeof(packet_hash))) continue;
 
     entry.tx_status = status;
-    if (app_target_ver >= 14) {
+    if (companion::shouldPushTxStatus(app_target_ver)) {
       out_frame[0] = PUSH_CODE_SEND_TX_STATUS;
       memcpy(&out_frame[1], &entry.ack, 4);
       out_frame[5] = status;
@@ -1142,7 +1142,7 @@ void MyMesh::handleCmdFrame(size_t len) {
           expected_ack_table[next_ack_idx].ack = expected_ack;
           expected_ack_table[next_ack_idx].contact = recipient;
           memcpy(expected_ack_table[next_ack_idx].packet_hash, packet_hash, sizeof(packet_hash));
-          expected_ack_table[next_ack_idx].tx_status = 0xFF; // queued, no local TX outcome yet
+          expected_ack_table[next_ack_idx].tx_status = companion::TX_STATUS_PENDING;
           next_ack_idx = (next_ack_idx + 1) % EXPECTED_ACK_TABLE_SIZE;
         }
 

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -5,7 +5,7 @@
 #include "AbstractUITask.h"
 
 /*------------ Frame Protocol --------------*/
-#define FIRMWARE_VER_CODE 13
+#define FIRMWARE_VER_CODE 14
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"
@@ -118,6 +118,7 @@ protected:
   void sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis=0) override;
 
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
+  void onPacketTxStatus(mesh::Packet* packet, mesh::PacketTxStatus status) override;
   bool isAutoAddEnabled() const override;
   bool shouldAutoAddContactType(uint8_t type) const override;
   bool shouldOverwriteWhenFull() const override;
@@ -245,6 +246,8 @@ private:
     unsigned long msg_sent;
     uint32_t ack;
     ContactInfo* contact;
+    uint8_t packet_hash[MAX_HASH_SIZE];
+    uint8_t tx_status;
   };
   #define EXPECTED_ACK_TABLE_SIZE 8
   AckTableEntry expected_ack_table[EXPECTED_ACK_TABLE_SIZE]; // circular table

--- a/platformio.ini
+++ b/platformio.ini
@@ -167,5 +167,7 @@ build_src_filter =
   -<*>
   +<../src/Utils.cpp>
   +<../src/Packet.cpp>
+  +<../src/Dispatcher.cpp>
+  +<../src/helpers/StaticPoolPacketManager.cpp>
 lib_deps =
   google/googletest @ 1.17.0

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -106,6 +106,7 @@ void Dispatcher::loop() {
       }
 
       _radio->onSendFinished();
+      onPacketTxStatus(outbound, PACKET_TX_COMPLETE);
       logTx(outbound, 2 + outbound->getPathByteLen() + outbound->payload_len);
       if (outbound->isRouteFlood()) {
         n_sent_flood++;
@@ -118,6 +119,7 @@ void Dispatcher::loop() {
       MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): WARNING: outbound packed send timed out!", getLogDateTime());
 
       _radio->onSendFinished();
+      onPacketTxStatus(outbound, PACKET_TX_TIMEOUT);
       logTxFail(outbound, 2 + outbound->getPathByteLen() + outbound->payload_len);
 
       releasePacket(outbound);  // return to pool
@@ -330,6 +332,7 @@ void Dispatcher::checkSend() {
       if (!success) {
         MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): ERROR: send start failed!", getLogDateTime());
 
+        onPacketTxStatus(outbound, PACKET_TX_START_FAILED);
         logTxFail(outbound, outbound->getRawLength());
   
         releasePacket(outbound);  // return to pool

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -102,6 +102,12 @@ public:
 
 typedef uint32_t  DispatcherAction;
 
+enum PacketTxStatus : uint8_t {
+  PACKET_TX_COMPLETE = 0,
+  PACKET_TX_START_FAILED = 1,
+  PACKET_TX_TIMEOUT = 2
+};
+
 #define ACTION_RELEASE           (0)
 #define ACTION_MANUAL_HOLD       (1)
 #define ACTION_RETRANSMIT(pri)   (((uint32_t)1 + (pri))<<24)
@@ -161,6 +167,7 @@ protected:
   virtual void logRx(Packet* packet, int len, float score) { }   // hooks for custom logging
   virtual void logTx(Packet* packet, int len) { }
   virtual void logTxFail(Packet* packet, int len) { }
+  virtual void onPacketTxStatus(Packet* packet, PacketTxStatus status) { }
   virtual const char* getLogDateTime() { return ""; }
 
   virtual float getAirtimeBudgetFactor() const;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -439,9 +439,15 @@ mesh::Packet* BaseChatMesh::composeMsgPacket(const ContactInfo& recipient, uint3
   return createDatagram(PAYLOAD_TYPE_TXT_MSG, recipient.id, recipient.getSharedSecret(self_id), temp, len);
 }
 
-int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout) {
+int  BaseChatMesh::sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt,
+                               const char* text, uint32_t& expected_ack, uint32_t& est_timeout,
+                               uint8_t* packet_hash) {
   mesh::Packet* pkt = composeMsgPacket(recipient, timestamp, attempt, text, expected_ack);
   if (pkt == NULL) return MSG_SEND_FAILED;
+
+  if (packet_hash) {
+    pkt->calculatePacketHash(packet_hash);
+  }
 
   uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
 

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -155,7 +155,8 @@ protected:
 public:
   mesh::Packet* createSelfAdvert(const char* name);
   mesh::Packet* createSelfAdvert(const char* name, double lat, double lon);
-  int  sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout);
+  int  sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text,
+                   uint32_t& expected_ack, uint32_t& est_timeout, uint8_t* packet_hash=NULL);
   int  sendCommandData(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& est_timeout);
   bool sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len);
   bool sendGroupData(mesh::GroupChannel& channel, uint8_t* path, uint8_t path_len, uint16_t data_type, const uint8_t* data, int data_len);

--- a/test/test_companion_tx_status/test_companion_tx_status.cpp
+++ b/test/test_companion_tx_status/test_companion_tx_status.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include <Dispatcher.h>
+#include "../../examples/companion_radio/CompanionTxStatus.h"
+
+TEST(CompanionTxStatus, MatchesPendingEntry) {
+  const uint8_t stored_hash[] = {1, 2, 3, 4};
+  const uint8_t packet_hash[] = {1, 2, 3, 4};
+
+  EXPECT_TRUE(companion::isPendingTxMatch(42, companion::TX_STATUS_PENDING, stored_hash,
+                                          packet_hash, sizeof(packet_hash)));
+}
+
+TEST(CompanionTxStatus, SkipsTimedOutDuplicateAndMatchesNewPendingEntry) {
+  const uint8_t packet_hash[] = {1, 2, 3, 4};
+
+  EXPECT_FALSE(companion::isPendingTxMatch(42, mesh::PACKET_TX_TIMEOUT, packet_hash,
+                                           packet_hash, sizeof(packet_hash)));
+  EXPECT_TRUE(companion::isPendingTxMatch(42, companion::TX_STATUS_PENDING, packet_hash,
+                                          packet_hash, sizeof(packet_hash)));
+}
+
+TEST(CompanionTxStatus, SkipsClearedAckAndDifferentHash) {
+  const uint8_t stored_hash[] = {1, 2, 3, 4};
+  const uint8_t different_hash[] = {4, 3, 2, 1};
+
+  EXPECT_FALSE(companion::isPendingTxMatch(0, companion::TX_STATUS_PENDING, stored_hash,
+                                           stored_hash, sizeof(stored_hash)));
+  EXPECT_FALSE(companion::isPendingTxMatch(42, companion::TX_STATUS_PENDING, stored_hash,
+                                           different_hash, sizeof(stored_hash)));
+}
+
+TEST(CompanionTxStatus, PushesOnlyForProtocolV14AndNewer) {
+  EXPECT_FALSE(companion::shouldPushTxStatus(13));
+  EXPECT_TRUE(companion::shouldPushTxStatus(14));
+  EXPECT_TRUE(companion::shouldPushTxStatus(15));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_dispatcher/test_dispatcher_tx.cpp
+++ b/test/test_dispatcher/test_dispatcher_tx.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include "Dispatcher.h"
+#include "helpers/StaticPoolPacketManager.h"
+
+class TestClock : public mesh::MillisecondClock {
+public:
+  unsigned long now = 0;
+
+  unsigned long getMillis() override { return now; }
+};
+
+class TestRadio : public mesh::Radio {
+public:
+  bool start_success = true;
+  bool send_complete = false;
+  int start_count = 0;
+  int finish_count = 0;
+
+  int recvRaw(uint8_t*, int) override { return 0; }
+  uint32_t getEstAirtimeFor(int) override { return 10; }
+  float packetScore(float, int) override { return 0; }
+  bool startSendRaw(const uint8_t*, int) override {
+    start_count++;
+    return start_success;
+  }
+  bool isSendComplete() override { return send_complete; }
+  void onSendFinished() override { finish_count++; }
+  bool isInRecvMode() const override { return true; }
+};
+
+class TestDispatcher : public mesh::Dispatcher {
+public:
+  int status_count = 0;
+  int free_count_at_status = -1;
+  mesh::PacketTxStatus last_status = mesh::PACKET_TX_COMPLETE;
+
+  TestDispatcher(TestRadio& radio, TestClock& clock, mesh::PacketManager& manager)
+      : mesh::Dispatcher(radio, clock, manager), manager(manager) {}
+
+protected:
+  mesh::DispatcherAction onRecvPacket(mesh::Packet*) override { return ACTION_RELEASE; }
+  void onPacketTxStatus(mesh::Packet*, mesh::PacketTxStatus status) override {
+    status_count++;
+    free_count_at_status = manager.getFreeCount();
+    last_status = status;
+  }
+
+private:
+  mesh::PacketManager& manager;
+};
+
+static mesh::Packet* queueTestPacket(TestDispatcher& dispatcher) {
+  mesh::Packet* packet = dispatcher.obtainNewPacket();
+  if (!packet) return NULL;
+
+  packet->header = PAYLOAD_TYPE_TXT_MSG << PH_TYPE_SHIFT;
+  packet->path_len = 0;
+  packet->payload[0] = 0x42;
+  packet->payload_len = 1;
+  dispatcher.sendPacket(packet, 0);
+  return packet;
+}
+
+TEST(DispatcherTxStatus, ReportsCompletionBeforeReleasingPacket) {
+  TestClock clock;
+  TestRadio radio;
+  StaticPoolPacketManager manager(1);
+  TestDispatcher dispatcher(radio, clock, manager);
+  dispatcher.begin();
+
+  ASSERT_NE(nullptr, queueTestPacket(dispatcher));
+  clock.now = 1;
+  dispatcher.loop();
+  EXPECT_EQ(1, radio.start_count);
+  EXPECT_EQ(0, dispatcher.status_count);
+
+  radio.send_complete = true;
+  clock.now = 2;
+  dispatcher.loop();
+
+  EXPECT_EQ(1, dispatcher.status_count);
+  EXPECT_EQ(mesh::PACKET_TX_COMPLETE, dispatcher.last_status);
+  EXPECT_EQ(0, dispatcher.free_count_at_status);
+  EXPECT_EQ(1, radio.finish_count);
+  EXPECT_EQ(1, manager.getFreeCount());
+}
+
+TEST(DispatcherTxStatus, DistinguishesStartFailure) {
+  TestClock clock;
+  TestRadio radio;
+  radio.start_success = false;
+  StaticPoolPacketManager manager(1);
+  TestDispatcher dispatcher(radio, clock, manager);
+  dispatcher.begin();
+
+  ASSERT_NE(nullptr, queueTestPacket(dispatcher));
+  clock.now = 1;
+  dispatcher.loop();
+
+  EXPECT_EQ(1, dispatcher.status_count);
+  EXPECT_EQ(mesh::PACKET_TX_START_FAILED, dispatcher.last_status);
+  EXPECT_EQ(0, dispatcher.free_count_at_status);
+  EXPECT_EQ(0, radio.finish_count);
+  EXPECT_EQ(1, manager.getFreeCount());
+}
+
+TEST(DispatcherTxStatus, ReportsCompletionTimeoutAsUnknownOutcome) {
+  TestClock clock;
+  TestRadio radio;
+  StaticPoolPacketManager manager(1);
+  TestDispatcher dispatcher(radio, clock, manager);
+  dispatcher.begin();
+
+  ASSERT_NE(nullptr, queueTestPacket(dispatcher));
+  clock.now = 1;
+  dispatcher.loop();
+  ASSERT_EQ(1, radio.start_count);
+
+  clock.now = 17;  // estimated airtime is 10 ms; dispatcher timeout is 1.5x
+  dispatcher.loop();
+
+  EXPECT_EQ(1, dispatcher.status_count);
+  EXPECT_EQ(mesh::PACKET_TX_TIMEOUT, dispatcher.last_status);
+  EXPECT_EQ(0, dispatcher.free_count_at_status);
+  EXPECT_EQ(1, radio.finish_count);
+  EXPECT_EQ(1, manager.getFreeCount());
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- add a version-gated companion push event for the local radio TX outcome of ACK-tracked direct messages
- correlate queued messages to Dispatcher TX callbacks using the full packet hash internally and the existing expected-ACK tag on the companion wire
- bind each terminal callback only to a still-pending entry so identical resends cannot downgrade an earlier unknown outcome
- distinguish local TX completion, definite start failure, and completion timeout/unknown outcome
- preserve the existing send-accepted response and end-to-end ACK confirmation
- document protocol v14 and add native Dispatcher and companion-correlation lifecycle tests

## Why

An ACK timeout does not prove that a direct message was not delivered: the message may have reached the recipient while only the returning ACK was lost. Today clients cannot also tell whether the message was still queued or whether the local radio actually completed its transmission.

This adds the missing local lifecycle signal so v14 clients can start the ACK timer after radio TX completion and present an expired ACK wait as **delivery unconfirmed**, rather than definite failure.

## Protocol

Protocol v14 adds `PACKET_SEND_TX_STATUS` (`0x91`):

```text
Byte 0:    0x91
Bytes 1-4: expected ACK / message tag
Byte 5:    local TX status
```

Statuses are:

- `0`: the local radio driver reported transmission complete
- `1`: the local radio rejected the transmission before it started
- `2`: completion was not reported before the firmware timeout; the over-air outcome is unknown

The timeout status deliberately retains the expected-ACK entry so a late ACK can still confirm delivery. Terminal callbacks only consume still-pending entries, so an identical resend cannot overwrite an earlier timeout/unknown outcome.

## Compatibility and scope

- no LoRa packet or routing wire-format changes
- no ACK generation, retry, or routing behavior changes
- no new frames for clients negotiating protocol v13 or lower
- limited to plaintext, ACK-tracked contact direct messages; CLI and channel messages are unchanged
- fixed-size storage only; no dynamic allocation is introduced
- companion apps must adopt protocol v14 to expose the richer UI lifecycle

## Validation

Rebased onto current `dev` (`8c987c86`) and rerun:

- `pio test -e native`: 20/20 tests passed
- `pio run -e Heltec_v3_companion_radio_ble`: passed (ESP32)
- `pio run -e RAK_4631_companion_radio_ble`: passed (nRF52)
- `pio run -e wio-e5_companion_radio_usb`: passed (STM32)
- `git diff --check`: clean
- `pio run -e waveshare_rp2040_lora_companion_radio_usb`: current-`dev` baseline failure in `CustomSX1262.h` (`PacketMillis` is not visible at the include site). The same failure reproduces on untouched base commit `8c987c86`; this PR does not modify the affected radio-wrapper files.
- external Fable adversarial review: initial duplicate-resend lifecycle finding corrected; follow-up verdict **Go**

Refs #1834

Design discussion: https://github.com/meshcore-dev/MeshCore/issues/1834#issuecomment-5001328544
