### PR TITLE
nrf52_variants: override shutdownPeripherals instead of powerOff for …

### DIFF
--- a/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
+++ b/variants/lilygo_t_impulse_plus/TImpulsePlusBoard.h
@@ -47,9 +47,9 @@ public:
     return "LilyGo T-Impulse-Plus";
   }
 
-  void powerOff() override {
+  void shutdownPeripherals() override {
     // power off system
-    NRF52Board::powerOff();
+    NRF52Board::shutdownPeripherals();
 
     // turn off 3.3v
     digitalWrite(RT9080_EN, LOW);

--- a/variants/lilygo_techo_card/TechoCardBoard.cpp
+++ b/variants/lilygo_techo_card/TechoCardBoard.cpp
@@ -87,11 +87,11 @@ void TechoCardBoard::turnOffLeds() {
     }
 }
 
-void TechoCardBoard::powerOff() {
+void TechoCardBoard::shutdownPeripherals() {
   nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
   turnOffLeds();
   digitalWrite(PIN_PWR_EN, LOW);
-  NRF52Board::powerOff();
+  NRF52Board::shutdownPeripherals();
 }
 
 #endif

--- a/variants/lilygo_techo_card/TechoCardBoard.h
+++ b/variants/lilygo_techo_card/TechoCardBoard.h
@@ -28,7 +28,7 @@ public:
     return "LilyGo T-Echo Card";
   }
 
-  void powerOff() override;
+  void shutdownPeripherals() override;
 
   void toggleTorch();
   void turnOffLeds();

--- a/variants/lilygo_techo_lite/TechoBoard.h
+++ b/variants/lilygo_techo_lite/TechoBoard.h
@@ -21,8 +21,8 @@ public:
     return "LilyGo T-Echo Lite";
   }
 
-  void powerOff() override {
-    NRF52Board::powerOff();
+  void shutdownPeripherals() override {
+    NRF52Board::shutdownPeripherals();
 
     digitalWrite(PIN_VBAT_MEAS_EN, LOW);
     #ifdef LED_RED


### PR DESCRIPTION
This uses shutdown peripherals instead of powerOff so Lora and Display can be shut off before closing the gates to peripherals