### PR TITLE
UI task: poweroff of radio and display moved to board

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -697,9 +697,6 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    // still necessary until all boards are refactored to use poweroff
-    _display->turnOff();
-    radio_driver.powerOff();
     // Power off board including radio, display, GPS and components
     _board->powerOff();
   }

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -307,8 +307,6 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    _display->turnOff();
-    radio_driver.powerOff();
     // Power off board including radio, display, GPS and components
     _board->powerOff();
   }

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -566,8 +566,6 @@ void UITask::shutdown(bool restart){
   if (restart) {
     _board->reboot();
   } else {
-    _display->turnOff();
-    radio_driver.powerOff();
     // Power off board including radio, display, GPS and components
     _board->powerOff();
   }

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -146,8 +146,6 @@ void UITask::loop() {
     digitalWrite(LED_PIN, LED_STATE_ON); // switch on the led until poweroff
 #endif
     if (millis() > _powering_off_at) {
-      _display->turnOff();
-      radio_driver.powerOff();
       _board->powerOff();  // should not return
     }
   }


### PR DESCRIPTION
This removes duplicate call of screen and radio shutdown (which leads to more power draw after)