### PR TITLE
Fix nRF52 builds broken by unconditional RAK Ethernet include

### DIFF
--- a/src/helpers/nrf52/SerialEthernetInterface.cpp
+++ b/src/helpers/nrf52/SerialEthernetInterface.cpp
@@ -1,3 +1,5 @@
+#ifdef ETHERNET_ENABLED
+
 #include "SerialEthernetInterface.h"
 #include "EthernetMac.h"
 #include <SPI.h>
@@ -262,3 +264,5 @@ bool SerialEthernetInterface::isConnected() const {
 void SerialEthernetInterface::loop() {
   Ethernet.maintain();
 }
+
+#endif // ETHERNET_ENABLED

--- a/src/helpers/nrf52/SerialEthernetInterface.h
+++ b/src/helpers/nrf52/SerialEthernetInterface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef ETHERNET_ENABLED
+
 #include "helpers/BaseSerialInterface.h"
 #include <SPI.h>
 #include <RAK13800_W5100S.h>
@@ -76,3 +78,5 @@ class SerialEthernetInterface : public BaseSerialInterface {
   #define ETHERNET_DEBUG_PRINTLN(...) {}
   #define ETHERNET_DEBUG_PRINT_IP(...) {}
 #endif
+
+#endif // ETHERNET_ENABLED


### PR DESCRIPTION
## Problem

Since #1983 merged, **all non-Ethernet nRF52 targets fail to build** (reported in #2985 for Heltec T114, but it affects every nRF52 board):

```
In file included from src/helpers/nrf52/SerialEthernetInterface.cpp:1:
src/helpers/nrf52/SerialEthernetInterface.h:5: fatal error: RAK13800_W5100S.h: No such file or directory
```

## Root cause

PlatformIO compiles **every** `.cpp` under `src/`, regardless of whether it's referenced. `src/helpers/nrf52/SerialEthernetInterface.cpp` includes `SerialEthernetInterface.h`, which unconditionally does `#include <RAK13800_W5100S.h>` — a library only present in the RAK4631 Ethernet env's `lib_deps`. Any other nRF52 board compiles the file, can't find the library, and fails.

The RAK4631 Ethernet envs weren't affected because they define `ETHERNET_ENABLED` **and** provide the W5100S library, so the breakage only shows on other nRF52 variants that share the `src/` tree.

## Fix

Wrap the contents of both `SerialEthernetInterface.h` and `SerialEthernetInterface.cpp` in `#ifdef ETHERNET_ENABLED`, so on non-Ethernet builds they become empty translation units and never reach the `RAK13800_W5100S.h` include. RAK4631 Ethernet envs define `ETHERNET_ENABLED` and are unchanged.

Thanks to @enigmaspb for the diagnosis and proposed fix in #2985.

## Verification

Local `pio run`, before → after:

| Environment | Before | After |
|---|---|---|
| `Heltec_t114_without_display_companion_radio_usb` | FAILED | **SUCCESS** |
| `RAK_4631_companion_radio_ethernet` | SUCCESS | **SUCCESS** |

Fixes #2985