### PR TITLE
Fix Xiao nRF52840 repeater compile failure

### DIFF
--- a/variants/xiao_nrf52/XiaoNrf52Board.h
+++ b/variants/xiao_nrf52/XiaoNrf52Board.h
@@ -47,7 +47,7 @@ public:
 
 #ifdef PIN_USER_BTN
     // configure button press to wake up when in powered off state
-    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(g_ADigitalPinMap[PIN_USER_BTN]), NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_LOW);
+    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(g_ADigitalPinMap[PIN_USER_BTN]), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
 #endif
 
     NRF52Board::powerOff();

--- a/variants/xiao_nrf52/target.cpp
+++ b/variants/xiao_nrf52/target.cpp
@@ -4,6 +4,7 @@
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true, true);
 #endif
 
 XiaoNrf52Board board;

--- a/variants/xiao_nrf52/target.h
+++ b/variants/xiao_nrf52/target.h
@@ -11,7 +11,9 @@
 
 #ifdef DISPLAY_CLASS
   #include <helpers/ui/NullDisplayDriver.h>
+  #include <helpers/ui/MomentaryButton.h>
   extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
 #endif
 
 extern XiaoNrf52Board board;


### PR DESCRIPTION
Compile fails due to user_btn not declared in board target.

Fix:
- Add MomentaryButton declaration for user_btn in variants/xiao_nrf52/target.cpp
- Add momentary button helper include in variants/xiao_nrf52/target.h
- Add extern linkage for MomentaryButton -> user_btn in variants/xiao_nrf52/target.h