### PR TITLE
Fix direct repeater login timeout

### DIFF
--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1,4 +1,5 @@
 #include <helpers/BaseChatMesh.h>
+#include <helpers/LoginTimeout.h>
 #include <Utils.h>
 
 #ifndef SERVER_RESPONSE_DELAY
@@ -597,7 +598,9 @@ int BaseChatMesh::sendLogin(const ContactInfo& recipient, const char* password, 
       return MSG_SEND_SENT_FLOOD;
     } else {
       sendDirect(pkt, recipient.out_path, recipient.out_path_len);
-      est_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      const uint32_t direct_timeout = calcDirectTimeoutMillisFor(t, recipient.out_path_len);
+      est_timeout = mesh::selectDirectLoginTimeout(recipient.type == ADV_TYPE_REPEATER, direct_timeout,
+                                                   calcFloodTimeoutMillisFor(t));
       return MSG_SEND_SENT_DIRECT;
     }
   }

--- a/src/helpers/LoginTimeout.h
+++ b/src/helpers/LoginTimeout.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace mesh {
+
+// Direct logins to repeaters receive a flood-routed response because the login
+// request does not carry a return path. Both timeout estimates cover a complete
+// exchange, so use the larger estimate rather than adding them together.
+inline uint32_t selectDirectLoginTimeout(bool reply_uses_flood, uint32_t direct_timeout,
+                                         uint32_t flood_timeout) {
+  if (reply_uses_flood && flood_timeout > direct_timeout) return flood_timeout;
+  return direct_timeout;
+}
+
+}  // namespace mesh

--- a/test/test_login_timeout/test_login_timeout.cpp
+++ b/test/test_login_timeout/test_login_timeout.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include <helpers/LoginTimeout.h>
+
+TEST(LoginTimeout, UsesFloodBudgetForRepeaterResponseWhenLonger) {
+  EXPECT_EQ(mesh::selectDirectLoginTimeout(true, 2200, 3700), 3700);
+}
+
+TEST(LoginTimeout, KeepsDirectBudgetWhenItIsLonger) {
+  EXPECT_EQ(mesh::selectDirectLoginTimeout(true, 4200, 3700), 4200);
+}
+
+TEST(LoginTimeout, KeepsDirectBudgetWhenResponseDoesNotFlood) {
+  EXPECT_EQ(mesh::selectDirectLoginTimeout(false, 2200, 3700), 2200);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- account for the flood-routed response to a direct repeater login
- keep the existing direct timeout for rooms and other contact types
- choose the larger end-to-end estimate instead of stacking two round-trip budgets
- add focused regression coverage for the timeout selection

## Why

Repeater login requests do not carry a return path. Even when the request uses a known direct path, the repeater deliberately sends its login response by flood. The companion radio previously advertised only the direct-route timeout to the app, so a valid response could arrive after the app had already timed out.

This keeps the known path for the outbound request and only adjusts the timeout budget for the asymmetric direct-outbound/flood-return exchange.

Fixes #2955

## Validation

- `pio test -e native` (16 tests passed)
- `pio run -e Xiao_S3_companion_radio_usb`
- `git diff --check`
