### PR TITLE
Initialize external RTC after power loss

### DIFF
--- a/src/helpers/AutoDiscoverRTCClock.cpp
+++ b/src/helpers/AutoDiscoverRTCClock.cpp
@@ -1,4 +1,5 @@
 #include "AutoDiscoverRTCClock.h"
+#include "RTCValidity.h"
 #include "RTClib.h"
 #include <Melopero_RV3028.h>
 #include "RTC_RX8130CE.h"
@@ -30,6 +31,10 @@ void AutoDiscoverRTCClock::begin(TwoWire& wire) {
   #if !defined(DISABLE_DS3231_PROBE)
   if (i2c_probe(wire, DS3231_ADDRESS)) {
     ds3231_success = rtc_3231.begin(&wire);
+    if (ds3231_success && mesh::seedRTCIfLostPower(rtc_3231.lostPower(), _fallback->getCurrentTime(),
+                                                   [](uint32_t time) { rtc_3231.adjust(DateTime(time)); })) {
+      MESH_DEBUG_PRINTLN("DS3231: Lost power, initialized from fallback clock");
+    }
   }
   #endif
 
@@ -44,6 +49,10 @@ void AutoDiscoverRTCClock::begin(TwoWire& wire) {
   if (i2c_probe(wire, PCF8563_ADDRESS)) {
     MESH_DEBUG_PRINTLN("PCF8563: Found");
     rtc_8563_success = rtc_8563.begin(&wire);
+    if (rtc_8563_success && mesh::seedRTCIfLostPower(rtc_8563.lostPower(), _fallback->getCurrentTime(),
+                                                     [](uint32_t time) { rtc_8563.adjust(DateTime(time)); })) {
+      MESH_DEBUG_PRINTLN("PCF8563: Lost power, initialized from fallback clock");
+    }
   }
 
   if (i2c_probe(wire, RX8130CE_ADDRESS)) {

--- a/src/helpers/RTCValidity.h
+++ b/src/helpers/RTCValidity.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace mesh {
+
+template <typename AdjustClock>
+bool seedRTCIfLostPower(bool lost_power, uint32_t fallback_time, AdjustClock adjust_clock) {
+  if (!lost_power) return false;
+  adjust_clock(fallback_time);
+  return true;
+}
+
+}  // namespace mesh

--- a/test/test_rtc_validity/test_rtc_validity.cpp
+++ b/test/test_rtc_validity/test_rtc_validity.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include <helpers/RTCValidity.h>
+
+TEST(RTCValidity, SeedsLostPowerClockFromFallback) {
+  uint32_t adjusted_to = 0;
+
+  bool seeded = mesh::seedRTCIfLostPower(true, 1715770351,
+                                         [&](uint32_t time) { adjusted_to = time; });
+
+  EXPECT_TRUE(seeded);
+  EXPECT_EQ(1715770351u, adjusted_to);
+}
+
+TEST(RTCValidity, PreservesValidBatteryBackedClock) {
+  bool adjusted = false;
+
+  bool seeded = mesh::seedRTCIfLostPower(false, 1715770351,
+                                         [&](uint32_t) { adjusted = true; });
+
+  EXPECT_FALSE(seeded);
+  EXPECT_FALSE(adjusted);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- detect lost-power state for discovered PCF8563 and DS3231 RTCs
- initialize an invalid external RTC from the already-initialized fallback clock
- preserve valid battery-backed RTC time
- add regression tests for both seed and preserve behavior

## Root cause

`AutoDiscoverRTCClock` selected a PCF8563 after successful I2C initialization without checking its voltage-low/lost-power flag. On the XIAO expansion board without an RTC backup battery, a hard power loss could therefore leave untrustworthy clock contents (for example, a date in 2042). The companion's existing backward-time guard would then correctly reject the lower current time, leaving the node stuck on the invalid future timestamp.

## Scope

- no protocol, packet, or storage changes
- existing backward-time guards remain unchanged
- valid external RTCs are unchanged
- DS3231 is included because it exposes the same `lostPower()` state and follows the same discovery path
- RV3028 and RX8130 behavior is unchanged

## Validation

- `pio test -e native` — 15/15 tests passed
- `pio run -e Xiao_S3_WIO_companion_radio_ble` — passed
- `git diff --check` — passed

Fixes #2996
