### PR TITLE
Fix bonded BLE reconnects on ESP32

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -103,10 +103,9 @@ void SerialBLEInterface::onMtuChanged(BLEServer* pServer, esp_ble_gatts_cb_param
 
 void SerialBLEInterface::onDisconnect(BLEServer* pServer) {
   BLE_DEBUG_PRINTLN("onDisconnect()");
+  deviceConnected = false;
   if (_isEnabled) {
     adv_restart_time = millis() + ADVERT_RESTART_DELAY;
-
-    // loop() will detect this on next loop, and set deviceConnected to false
   }
 }
 
@@ -214,8 +213,6 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
     }
     return len;
   }
-
-  if (pServer->getConnectedCount() == 0)  deviceConnected = false;
 
   if (deviceConnected != oldDeviceConnected) {
     if (!deviceConnected) {    // disconnecting


### PR DESCRIPTION
## Summary

- make ESP32 BLE connection state event-driven
- clear the usable connection flag in the disconnect callback
- stop overwriting successful authentication with a lagging server connection count

## Root cause

On some bonded Android reconnects, `onAuthenticationComplete()` ran before the BLE server updated its internal connected count. The authentication callback set `deviceConnected`, but `checkRecvFrame()` immediately observed a stale count of zero and cleared it permanently. The BLE link remained connected while `writeFrame()` refused to send responses.

## Scope

This keeps successful authentication as the event that enables frame writes and uses the existing disconnect callback as the event that disables them. Advertising restart timing, pairing requirements, frame queues, and protocol behavior are unchanged.

## Validation

- `git diff --check`
- `pio run -e Xiao_S3_WIO_companion_radio_ble`
- rigorous Fable adversarial review: approved with no actionable findings

Fixes #2963

