### PR TITLE
Enable hardware USB serial on Heltec V4

### DIFF
--- a/boards/heltec_v4.json
+++ b/boards/heltec_v4.json
@@ -9,7 +9,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
-      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],


### PR DESCRIPTION
## Summary

- select the ESP32-S3 hardware USB Serial/JTAG peripheral for Heltec V4
- restore working `Serial` transport for USB companion firmware and meshcli
- align the V4 board definition with the in-repo V4 R8 and PlatformIO Heltec V3 definitions

## Root cause

The Heltec V4 board definition selected `ARDUINO_USB_MODE=0`, which maps `Serial` to the TinyUSB CDC stack. On this board, USB companion firmware is usable through meshcli when `ARDUINO_USB_MODE=1` selects the hardware USB Serial/JTAG peripheral.

## Scope

This is a board-level correction because every Heltec V4 firmware variant uses the same physical USB serial console, and no V4 environment in the repository uses TinyUSB-only MSC, HID, or custom descriptor functionality.

## Validation

- `jq empty boards/heltec_v4.json`
- `git diff --check`
- `pio run -e heltec_v4_companion_radio_usb`
- `pio run -e heltec_v4_companion_radio_ble`
- rigorous Fable adversarial review: approved with no actionable findings

Fixes #2734

