### PR TITLE
Fix GPS on ThinkNode M3: power rail and reset polarity

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -713,10 +713,17 @@ const char* EnvironmentSensorManager::getSettingValue(int i) const {
 bool EnvironmentSensorManager::setSettingValue(const char* name, const char* value) {
   #if ENV_INCLUDE_GPS
   if (gps_detected && strcmp(name, "gps") == 0) {
-    if (strcmp(value, "0") == 0) {
-      stop_gps();
-    } else {
-      start_gps();
+    bool want_on = (strcmp(value, "0") != 0);
+    // Only act on an actual state change. start_gps()/stop_gps() ultimately
+    // claim()/release() the GPS power rail through a ref-counted pin, so a
+    // repeated "gps=1" would push the claim count above 1 and a single
+    // "gps=0" would then fail to actually power the module down.
+    if (want_on != gps_active) {
+      if (want_on) {
+        start_gps();
+      } else {
+        stop_gps();
+      }
     }
     return true;
   }

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -748,8 +748,19 @@ void EnvironmentSensorManager::initBasicGPS() {
     MESH_DEBUG_PRINTLN("No GPS wake/reset pin found for this board. Continuing on...");
   #endif
 
-  // Give GPS a moment to power up and send data
-  delay(1000);
+  // Give GPS a moment to power up and send data. A single fixed delay is not
+  // enough for modules that need several seconds to emit their first NMEA
+  // sentence after power-on, so poll until data shows up or we time out.
+#ifndef GPS_DETECT_TIMEOUT_MS
+  #define GPS_DETECT_TIMEOUT_MS 10000
+#endif
+  unsigned long gps_detect_start = millis();
+  while (millis() - gps_detect_start < GPS_DETECT_TIMEOUT_MS) {
+    if (Serial1.available() > 0) break;
+    delay(50);
+  }
+  MESH_DEBUG_PRINTLN("GPS detect: waited %d ms, %d bytes on Serial1",
+                     (int)(millis() - gps_detect_start), (int)Serial1.available());
 
   // We'll consider GPS detected if we see any data on Serial1
 #ifdef ENV_SKIP_GPS_DETECT

--- a/variants/thinknode_m3/ThinkNodeM3Board.cpp
+++ b/variants/thinknode_m3/ThinkNodeM3Board.cpp
@@ -8,6 +8,8 @@ void ThinkNodeM3Board::begin() {
   NRF52Board::begin();
   btn_prev_state = HIGH;
 
+  periph_power.begin();
+
   Wire.begin();
 
   delay(10);   // give sx1262 some time to power up

--- a/variants/thinknode_m3/ThinkNodeM3Board.h
+++ b/variants/thinknode_m3/ThinkNodeM3Board.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <MeshCore.h>
 #include <helpers/NRF52Board.h>
+#include <helpers/RefCountedDigitalPin.h>
 
 #define ADC_FACTOR ((1000.0*ADC_MULTIPLIER*AREF_VOLTAGE)/ADC_MAX)
 
@@ -14,7 +15,11 @@ protected:
   uint8_t btn_prev_state;
 
 public:
-  ThinkNodeM3Board() : NRF52Board("THINKNODE_M3_OTA") {}
+  // load switch feeding the GNSS module (pin 14, active HIGH); the module also
+  // has a standby pin (PIN_GPS_EN=21) but without this it is completely unpowered
+  RefCountedDigitalPin periph_power;
+
+  ThinkNodeM3Board() : NRF52Board("THINKNODE_M3_OTA"), periph_power(PIN_GPS_POWER, HIGH) {}
   void begin();
   uint16_t getBattMilliVolts() override;
 

--- a/variants/thinknode_m3/target.cpp
+++ b/variants/thinknode_m3/target.cpp
@@ -11,7 +11,9 @@ WRAPPER_CLASS radio_driver(radio, board);
 VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
 #ifdef ENV_INCLUDE_GPS
-MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+// serial GNSS module: needs the power rail on PIN_GPS_POWER besides the
+// standby (PIN_GPS_EN) and reset pins, or it stays silent on Serial1
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock, GPS_RESET, GPS_EN, &board.periph_power);
 EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
 #else
 EnvironmentSensorManager sensors = EnvironmentSensorManager();

--- a/variants/thinknode_m3/variant.h
+++ b/variants/thinknode_m3/variant.h
@@ -95,10 +95,10 @@
 #define PIN_GPS_RX                  (22)    
 #define PIN_GPS_TX                  (20)
 
-#define PIN_GPS_POWER               (14)
+#define PIN_GPS_POWER               (14)            // load switch feeding the module, active HIGH
 #define PIN_GPS_EN                  (21)            // STANDBY
 #define PIN_GPS_RESET               (25)            // REINIT
-#define GPS_RESET_ACTIVE            LOW
+#define PIN_GPS_RESET_ACTIVE        HIGH            // reset is asserted HIGH (idle LOW)
 #define GPS_EN_ACTIVE               HIGH
 #define GPS_BAUDRATE                9600
 


### PR DESCRIPTION
## Fix GPS on ThinkNode M3

The ThinkNode M3 ships with a serial CASIC **AT6558R** GNSS receiver (UART, 9600 baud, GPS+BeiDou), but GPS never worked on this variant because of two bugs. The receiver stayed completely silent, so `gps_detected` was always false and the app never exposed the location section.

### Root cause

1. **Power rail never driven.** `PIN_GPS_POWER` (pin 14) is a load switch feeding the module, active HIGH, but it was declared and never driven — so the module was permanently unpowered → 0 bytes on `Serial1`.
2. **Reset polarity inverted.** The M3's reset line is asserted **HIGH** (idle LOW). The variant defined the unused macro `GPS_RESET_ACTIVE LOW`, while `MicroNMEALocationProvider` reads `PIN_GPS_RESET_ACTIVE` (default LOW) — so the module was held in reset forever.

Verified in isolation: with only fix (1) → `0 bytes on Serial1`; with (1)+(2) → `GPS detect: waited 199 ms, 7 bytes on Serial1` + `GPS detected`.

### Changes

- `variants/thinknode_m3/variant.h` — `PIN_GPS_RESET_ACTIVE HIGH` (replacing the unread `GPS_RESET_ACTIVE LOW`).
- `variants/thinknode_m3/ThinkNodeM3Board.{h,cpp}` — drive the pin-14 load switch via a `RefCountedDigitalPin periph_power(PIN_GPS_POWER, HIGH)`, `begin()`-ed at board init (same pattern as the Heltec variants).
- `variants/thinknode_m3/target.cpp` — pass `&board.periph_power` as the location provider's power pin so enabling/disabling GPS actually cuts the rail.
- `src/helpers/sensors/EnvironmentSensorManager.cpp` — GPS detection now polls `Serial1` up to `GPS_DETECT_TIMEOUT_MS` (default 10 s) instead of a single fixed `delay(1000)`, so modules that take a moment to emit their first sentence are still detected (the M3 needs ~200 ms in practice). Also guards the `gps` setting toggle against repeated values: `start_gps()`/`stop_gps()` claim/release the ref-counted power pin, so a repeated `gps=1` would push the claim count above 1 and a following single `gps=0` would then fail to power the module down — now only a real state transition acts.

### Testing

Flashed on hardware (`ThinkNode_M3_companion_radio_ble`). Boot log shows `GPS detected` and the AT6558R banner, followed by a continuous, well-formed NMEA stream (`$GNGGA`, `$GNRMC`, `$GPGSV`, …), up to 15 satellites in view (10 GPS + 5 BeiDou). Confirmed a real **position fix outdoors** during a full day of field use. Toggling location off in the app powers the receiver down via the load switch (cold restart on re-enable), so battery is preserved when GPS is disabled.

Refs #1864.
