### PR TITLE
Fix region command whitespace parsing

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -150,4 +150,20 @@ int Utils::parseTextParts(char* text, const char* parts[], int max_num, char sep
   return num;
 }
 
+int Utils::parseTextPartsSkippingEmpty(char* text, const char* parts[], int max_num, char separator) {
+  int num = 0;
+  char* sp = text;
+  while (*sp && num < max_num) {
+    while (*sp == separator) sp++;
+    if (*sp == '\0') break;
+
+    parts[num++] = sp;
+    while (*sp && *sp != separator) sp++;
+    if (*sp) {
+      *sp++ = 0;
+    }
+  }
+  return num;
+}
+
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -81,6 +81,16 @@ public:
    */
   static int parseTextParts(char* text, const char* parts[], int max_num, char separator=',');
 
+  /**
+   * \brief  parse 'text' into non-empty parts separated by 'separator' char.
+   * \param  text  the text to parse (note is MODIFIED!)
+   * \param  parts  destination array to store pointers to starts of parse parts
+   * \param  max_num  max elements to store in 'parts' array
+   * \param  separator  the separator character; consecutive instances are treated as one
+   * \returns  the number of non-empty parts parsed (in 'parts')
+   */
+  static int parseTextPartsSkippingEmpty(char* text, const char* parts[], int max_num, char separator=',');
+
   static bool isHexChar(char c);
 };
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -1002,7 +1002,7 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
   }
 
   const char* parts[4];
-  int n = mesh::Utils::parseTextParts(command, parts, 4, ' ');
+  int n = mesh::Utils::parseTextPartsSkippingEmpty(command, parts, 4, ' ');
   if (n == 1) {
     _region_map->exportTo(reply, 160);
   } else if (n >= 2 && strcmp(parts[1], "load") == 0) {

--- a/test/test_utils/test_tohex.cpp
+++ b/test/test_utils/test_tohex.cpp
@@ -51,6 +51,53 @@ TEST(UtilsToHex, NullTerminatesOnEmptyInput) {
     EXPECT_EQ('\0', output[0]);
 }
 
+TEST(UtilsParseTextParts, PreservesEmptyPartsByDefault) {
+    char input[] = "region default  ";
+    const char* parts[4];
+
+    int count = Utils::parseTextParts(input, parts, 4, ' ');
+
+    ASSERT_EQ(3, count);
+    EXPECT_STREQ("region", parts[0]);
+    EXPECT_STREQ("default", parts[1]);
+    EXPECT_STREQ("", parts[2]);
+}
+
+TEST(UtilsParseTextParts, SkippingEmptyTreatsTrailingSpacesAsNoArgument) {
+    char input[] = "region default  ";
+    const char* parts[4];
+
+    int count = Utils::parseTextPartsSkippingEmpty(input, parts, 4, ' ');
+
+    ASSERT_EQ(2, count);
+    EXPECT_STREQ("region", parts[0]);
+    EXPECT_STREQ("default", parts[1]);
+}
+
+TEST(UtilsParseTextParts, SkippingEmptyKeepsNamedArgumentBetweenRepeatedSpaces) {
+    char input[] = "region  default  au-nsw  ";
+    const char* parts[4];
+
+    int count = Utils::parseTextPartsSkippingEmpty(input, parts, 4, ' ');
+
+    ASSERT_EQ(3, count);
+    EXPECT_STREQ("region", parts[0]);
+    EXPECT_STREQ("default", parts[1]);
+    EXPECT_STREQ("au-nsw", parts[2]);
+}
+
+TEST(UtilsParseTextParts, KeepsExplicitNullRegionArgument) {
+    char input[] = "region  default  <null>  ";
+    const char* parts[4];
+
+    int count = Utils::parseTextPartsSkippingEmpty(input, parts, 4, ' ');
+
+    ASSERT_EQ(3, count);
+    EXPECT_STREQ("region", parts[0]);
+    EXPECT_STREQ("default", parts[1]);
+    EXPECT_STREQ("<null>", parts[2]);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary

- ignore empty fields caused by repeated or trailing spaces in `region` commands
- preserve the existing parser API and behavior for every other command
- add regression coverage for trailing spaces, repeated spaces around a region name, and explicit `<null>`

## Root cause

The generic text splitter preserves empty fields. For `region default  `, that produced an empty third argument. `findByNamePrefix("")` then matched the last region in the table, after which the default-region handler also cleared its deny-flood flag and persisted the change.

Region commands now opt into a separately named splitter that ignores empty separator fields. Bare `region default`, including trailing spaces, remains the documented read-only query. Clearing the default remains explicit: `region default <null>`.

The original four-argument `Utils::parseTextParts` symbol and behavior are unchanged.

## Impact

Trailing or repeated spaces can no longer select a region accidentally, change its flood policy, or persist an unintended default scope.

Fixes #2992

## Validation

- native test binary: 9/9 tests passed
- `pio test -e native`
- `pio run -e RAK_4631_repeater`
- `pio run -e Station_G2_repeater`
- `git diff --check`
- adversarial review: final ship recommendation after preserving the original parser ABI
