### PR TITLE
Fix nRF52 RS232 bridge baud initialization

### DIFF
--- a/src/helpers/bridges/RS232Bridge.cpp
+++ b/src/helpers/bridges/RS232Bridge.cpp
@@ -17,7 +17,11 @@ void RS232Bridge::begin() {
   ((HardwareSerial *)_serial)->setPins(WITH_RS232_BRIDGE_RX, WITH_RS232_BRIDGE_TX);
 #elif defined(NRF52_PLATFORM)
   // Tested with RAK_4631 and T114
-  ((Uart *)_serial)->setPins(WITH_RS232_BRIDGE_RX, WITH_RS232_BRIDGE_TX);
+  Uart *uart = (Uart *)_serial;
+  if (*uart) {
+    uart->end();  // nRF52 begin() ignores baud and pin changes while already started
+  }
+  uart->setPins(WITH_RS232_BRIDGE_RX, WITH_RS232_BRIDGE_TX);
 #elif defined(RP2040_PLATFORM)
   ((SerialUART *)_serial)->setRX(WITH_RS232_BRIDGE_RX);
   ((SerialUART *)_serial)->setTX(WITH_RS232_BRIDGE_TX);


### PR DESCRIPTION
## Summary

- restart an already-active Adafruit nRF52 UART before initializing the RS232 bridge
- reapply the bridge pins after shutdown, then use the existing common `begin(bridge_baud)` path
- leave unopened UARTs and all non-nRF52 platforms on their existing initialization paths

The pinned Adafruit nRF52 core ignores `begin()` while a `Uart` is already active. That can leave a bridge configured for 115200 baud running at an earlier component's baud rate. The active-state check is intentional: this core's `end()` does not guard an unopened UART, so calling it unconditionally is unsafe.

The selected UART belongs exclusively to the bridge after initialization; configurations that would otherwise share it with GPS must disable GPS.

## Validation

- `pio test -e native` (13 tests passed)
- `pio run -e RAK_4631_repeater_bridge_rs232_serial1`
- `pio run -e RAK_4631_repeater_bridge_rs232_serial2`
- `pio run -e Heltec_t114_without_display_repeater_bridge_rs232`
- `pio run -e ProMicro_repeater_bridge_rs232_serial1`
- `pio run -e Heltec_t096_repeater_bridge_rs232`
- adversarial implementation review: no correctness blockers found

The reported RAK3401 configuration has no official PlatformIO RS232 environment in this repository; its register-level and end-to-end hardware validation is documented in the linked issue.

Fixes #3011
