### PR TITLE
fix(room_server): support RX boosted gain

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -658,6 +658,14 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   _prefs.gps_enabled = 0;
   _prefs.gps_interval = 0;
   _prefs.advert_loc_policy = ADVERT_LOC_PREFS;
+
+#if defined(USE_SX1262) || defined(USE_SX1268)
+#ifdef SX126X_RX_BOOSTED_GAIN
+  _prefs.rx_boosted_gain = SX126X_RX_BOOSTED_GAIN;
+#else
+  _prefs.rx_boosted_gain = 1; // enabled by default;
+#endif
+#endif
   _prefs.radio_fem_rxgain = 1;
 
   next_post_idx = 0;
@@ -700,6 +708,7 @@ void MyMesh::begin(FILESYSTEM *fs) {
 
   radio_driver.setParams(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
   radio_driver.setTxPower(_prefs.tx_power_dbm);
+  radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain);
 
   updateAdvertTimer();
@@ -805,6 +814,10 @@ void MyMesh::dumpLogFile() {
 
 void MyMesh::setTxPower(int8_t power_dbm) {
   radio_driver.setTxPower(power_dbm);
+}
+
+bool MyMesh::setRxBoostedGain(bool enable) {
+  return radio_driver.setRxBoostedGainMode(enable);
 }
 
 void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -206,6 +206,7 @@ public:
 
   void dumpLogFile() override;
   void setTxPower(int8_t power_dbm) override;
+  bool setRxBoostedGain(bool enable) override;
 
   void formatNeighborsReply(char *reply) override {
     strcpy(reply, "not supported");


### PR DESCRIPTION
The room server exposes the shared `radio.rxgain` preference through `CommonCLI`, but unlike the repeater, it does not connect that preference to the radio:

- `rx_boosted_gain` is not given the repeater’s default and remains zero after preference initialization
- the persisted setting is not applied during room-server startup
- `set radio.rxgain on` saves the preference, but returns `Error: unsupported` and does not apply it immediately

This mirrors the repeater implementation: initialize the default under the same radio guards, apply the preference during startup, and override `setRxBoostedGain()` so CLI changes take effect.

Built `Heltec_v3_room_server` (SX1262) and `LilyGo_T3S3_sx1276_room_server` (unsupported-radio fallback).