### PR TITLE
Allow .envrc to integrate into existing direnv environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
-use nix
+source_up 
+nix-shell --version >/dev/null 2>&1 && use nix


### PR DESCRIPTION
The existing .envrc sets up the Nix environment which is nice, but not all of us use Nix.

This change will make setting up the Nix environment conditional upon finding nix-shell. This way if the direnv is being executed outside of the Nix environment direnv will not fail.

In addition, the source_up stdlib call is used to process all parent .envrc files.

Closed #3256