### PR TITLE
fix: Restrict bridge.source args to logRx and logTx 🧁 🧁 

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -26,7 +26,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ## Operational
 
 ### Reboot the node
-**Usage:** 
+**Usage:**
 - `reboot`
 
 **Note:** No reply is sent.
@@ -51,7 +51,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### Sync the clock with the remote device
-**Usage:** 
+**Usage:**
 - `clock sync`
 
 ---
@@ -63,7 +63,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### Set the time to a specific timestamp
-**Usage:** 
+**Usage:**
 - `time <epoch_seconds>`
 
 **Parameters:**
@@ -72,7 +72,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### Send a flood advert
-**Usage:** 
+**Usage:**
 - `advert`
 
 ---
@@ -102,7 +102,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ## Neighbors (Repeater Only)
 
 ### List nearby neighbors
-**Usage:** 
+**Usage:**
 - `neighbors`
 
 **Note:** The output of this command is limited to the 8 most recent adverts.
@@ -112,10 +112,10 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### Remove a neighbor
-**Usage:** 
+**Usage:**
 - `neighbor.remove <pubkey_prefix>`
 
-**Parameters:** 
+**Parameters:**
 - `pubkey_prefix`: The public key of the node to remove from the neighbors list. This can be a short prefix or the full key. All neighbors matching the provided prefix will be removed.
 
 **Note:** You can remove all neighbors by sending a space character as the prefix. The space indicates an empty prefix, which matches all existing neighbors.
@@ -124,7 +124,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ### Discover zero hop neighbors
 
-**Usage:** 
+**Usage:**
 - `discover.neighbors`
 
 ---
@@ -137,7 +137,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### System Stats - Battery, Uptime, Queue Length and Debug Flags
-**Usage:** 
+**Usage:**
 - `stats-core`
 
 **Serial Only:** Yes
@@ -234,7 +234,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### Change the radio parameters for a set duration
-**Usage:** 
+**Usage:**
 - `tempradio <freq>,<bw>,<sf>,<cr>,<timeout_mins>`
 
 **Parameters:**
@@ -435,7 +435,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `powersaving on`
 - `powersaving off`
 
-**Parameters:** 
+**Parameters:**
 - `on`: enable power saving
 - `off`: disable power saving
 
@@ -469,13 +469,13 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
   - `0`: 1 Byte hash size (256 unique ids)[64 max flood]
   - `1`: 2 Byte hash size (65,536 unique ids)[32 max flood]
   - `2`: 3 Byte hash size (16,777,216 unique ids)[21 max flood]
-  - `3`: DO NOT USE (Reserved) 
+  - `3`: DO NOT USE (Reserved)
 
 **Default:** `0`
 
 **Note:** the 'path.hash.mode' sets the low-level ID/hash encoding size used when the repeater adverts. This setting has no impact on what packet ID/hash size this repeater forwards, all sizes should be forwarded on firmware >= 1.14. This feature was added in firmware 1.14
 
-**Temporary Note:** adverts with ID/hash sizes of 2 or 3 bytes may have limited flood propagation in your network while this feature is new as v1.13.0 firmware and older will drop packets with multibyte path ID/hashes as only 1-byte hashes are supported. Consider your install base of firmware >=1.14 has reached a criticality for effective network flooding before implementing higher ID/hash sizes. 
+**Temporary Note:** adverts with ID/hash sizes of 2 or 3 bytes may have limited flood propagation in your network while this feature is new as v1.13.0 firmware and older will drop packets with multibyte path ID/hashes as only 1-byte hashes are supported. Consider your install base of firmware >=1.14 has reached a criticality for effective network flooding before implementing higher ID/hash sizes.
 
 ---
 
@@ -485,17 +485,17 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `set loop.detect <state>`
 
 **Parameters:**
-- `state`: 
+- `state`:
   - `off`: no loop detection is performed
   - `minimal`: packets are dropped if repeater's ID/hash appears 4 or more times (1-byte), 2 or more (2-byte), 1 or more (3-byte)
   - `moderate`: packets are dropped if repeater's ID/hash appears 2 or more times (1-byte), 1 or more (2-byte), 1 or more (3-byte)
   - `strict`: packets are dropped if repeater's ID/hash appears 1 or more times (1-byte), 1 or more (2-byte), 1 or more (3-byte)
-  
+
 **Default:** `off`
 
 **Note:** When it is enabled, repeaters will now reject flood packets which look like they are in a loop. This has been happening recently in some meshes when there is just a single 'bad' repeater firmware out there (probably some forked or custom firmware). If the payload is messed with, then forwarded, the same packet ends up causing a packet storm, repeated up to the max 64 hops. This feature was added in firmware 1.14
 
-**Example:** If preference is `loop.detect minimal`, and a 1-byte path size packet is received, the repeater will see if its own ID/hash is already in the path. If it's already encoded 4 times, it will reject the packet.  If the packet uses 2-byte path size, and repeater's own ID/hash is already encoded 2 times, it rejects. If the packet uses 3-byte path size, and the repeater's own ID/hash is already encoded 1 time, it rejects. 
+**Example:** If preference is `loop.detect minimal`, and a 1-byte path size packet is received, the repeater will see if its own ID/hash is already in the path. If it's already encoded 4 times, it will reject the packet.  If the packet uses 2-byte path size, and repeater's own ID/hash is already encoded 2 times, it rejects. If the packet uses 3-byte path size, and the repeater's own ID/hash is already encoded 1 time, it rejects.
 
 ---
 
@@ -695,12 +695,12 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ### ACL
 
 #### Add, update or remove permissions for a companion
-**Usage:** 
+**Usage:**
 - `setperm <pubkey> <permissions>`
 
 **Parameters:**
 - `pubkey`: Companion public key
-- `permissions`: 
+- `permissions`:
   - `0`: Guest
   - `1`: Read-only
   - `2`: Read-write
@@ -711,7 +711,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### View the current ACL
-**Usage:** 
+**Usage:**
 - `get acl`
 
 **Serial Only:** Yes
@@ -733,7 +733,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ### Region Management (v1.10.+)
 
 #### Bulk-load region lists
-**Usage:** 
+**Usage:**
 - `region load`
 - `region load <name> [flood_flag]`
 
@@ -749,16 +749,16 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### Save any changes to regions made since reboot
-**Usage:** 
+**Usage:**
 - `region save`
 
 ---
 
 #### Allow a region
-**Usage:** 
+**Usage:**
 - `region allowf <name>`
 
-**Parameters:** 
+**Parameters:**
 - `name`: Region name (or `*` for wildcard)
 
 **Note:** Setting on wildcard `*` allows packets without region transport codes
@@ -766,10 +766,10 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### Block a region
-**Usage:** 
+**Usage:**
 - `region denyf <name>`
 
-**Parameters:** 
+**Parameters:**
 - `name`: Region name (or `*` for wildcard)
 
 **Note:** Setting on wildcard `*` drops packets without region transport codes
@@ -777,7 +777,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### Show information for a region
-**Usage:** 
+**Usage:**
 - `region get <name>`
 
 **Parameters:**
@@ -786,7 +786,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### View or change the home region for this node
-**Usage:** 
+**Usage:**
 - `region home`
 - `region home <name>`
 
@@ -796,7 +796,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### View or change the default scope region for this node
-**Usage:** 
+**Usage:**
 - `region default`
 - `region default {name|<null>}`
 
@@ -806,7 +806,7 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 #### Create a new region
-**Usage:** 
+**Usage:**
 - `region put <name> [parent_name]`
 
 **Parameters:**
@@ -857,18 +857,18 @@ region save
 ---
 
 #### Remove a region
-**Usage:** 
+**Usage:**
 - `region remove <name>`
 
 **Parameters:**
 - `name`: Region name
 
-**Note:** Must remove all child regions before the region can be removed 
+**Note:** Must remove all child regions before the region can be removed
 
 ---
 
 #### View all regions
-**Usage:** 
+**Usage:**
 - `region list <filter>`
 
 **Serial Only:** Yes
@@ -881,7 +881,7 @@ region save
 ---
 
 #### Dump all defined regions and flood permissions
-**Usage:** 
+**Usage:**
 - `region`
 
 **Serial Only:** For firmware older than 1.12.0
@@ -906,7 +906,7 @@ region save
 
 **Example 2: Using Wildcard with F Flag**
 ```
-region load 
+region load
 * F
 <blank line to end region load>
 region save
@@ -921,7 +921,7 @@ region save
 
 **Example 3: Using Wildcard Without F Flag**
 ```
-region load 
+region load
 *
 <blank line to end region load>
 region save
@@ -935,7 +935,7 @@ region save
 
 **Example 4: Nested Public Region with F Flag**
 ```
-region load 
+region load
 #Europe F
   #UK
     #London
@@ -956,7 +956,7 @@ region save
 
 **Example 5: Wildcard with Nested Public Regions**
 ```
-region load 
+region load
 * F
   #NorthAmerica
     #USA
@@ -995,13 +995,13 @@ region save
 ---
 
 #### Sync this node's clock with GPS time
-**Usage:** 
+**Usage:**
 - `gps sync`
 
 ---
 
 #### Set this node's location based on the GPS coordinates
-**Usage:** 
+**Usage:**
 - `gps setloc`
 
 ---
@@ -1011,8 +1011,8 @@ region save
 - `gps advert`
 - `gps advert <policy>`
 
-**Parameters:** 
-- `policy`: `none`|`share`|`prefs` 
+**Parameters:**
+- `policy`: `none`|`share`|`prefs`
   - `none`: don't include location in adverts
   - `share`: share gps location (from SensorManager)
   - `prefs`: location stored in node's lat and lon settings
@@ -1034,7 +1034,7 @@ region save
 ---
 
 #### View or change the value of a sensor
-**Usage:** 
+**Usage:**
 - `sensor get <key>`
 - `sensor set <key> <value>`
 
@@ -1081,7 +1081,7 @@ region save
 - `set bridge.source <source>`
 
 **Parameters:**
-- `source`: 
+- `source`:
   - `logRx`: bridges received packets
   - `logTx`: bridges transmitted packets
 
@@ -1112,7 +1112,7 @@ region save
 ---
 
 #### Set the ESP-Now secret
-**Usage:** 
+**Usage:**
 - `get bridge.secret`
 - `set bridge.secret <secret>`
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -474,7 +474,7 @@ void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
 
 void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
 #ifdef WITH_BRIDGE
-  if (_prefs.bridge_pkt_src == 1) {
+  if (_prefs.bridge_pkt_src & BRIDGE_SOURCE_RX) {
     bridge.sendPacket(pkt);
   }
 #endif
@@ -500,7 +500,7 @@ void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
 
 void MyMesh::logTx(mesh::Packet *pkt, int len) {
 #ifdef WITH_BRIDGE
-  if (_prefs.bridge_pkt_src == 0) {
+  if (_prefs.bridge_pkt_src & BRIDGE_SOURCE_TX) {
     bridge.sendPacket(pkt);
   }
 #endif
@@ -897,7 +897,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   // bridge defaults
   _prefs.bridge_enabled = 1;    // enabled
   _prefs.bridge_delay   = 500;  // milliseconds
-  _prefs.bridge_pkt_src = 0;    // logTx
+  _prefs.bridge_pkt_src = BRIDGE_SOURCE_TX;    // logTx
   _prefs.bridge_baud = 115200;  // baud rate
   _prefs.bridge_channel = 1;    // channel 1
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -112,7 +112,7 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     // sanitise bad bridge pref values
     _prefs->bridge_enabled = constrain(_prefs->bridge_enabled, 0, 1);
     _prefs->bridge_delay = constrain(_prefs->bridge_delay, 0, 10000);
-    _prefs->bridge_pkt_src = constrain(_prefs->bridge_pkt_src, 0, 1);
+    _prefs->bridge_pkt_src = constrain(_prefs->bridge_pkt_src, 0, 3);   // log Rx and Tx = 3
     _prefs->bridge_baud = constrain(_prefs->bridge_baud, 9600, BRIDGE_MAX_BAUD);
     _prefs->bridge_channel = constrain(_prefs->bridge_channel, 0, 14);
 
@@ -654,7 +654,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       strcpy(reply, "OK");
     } else {
       strcpy(reply, "Error, max 64");
-    } 
+    }
   } else if (memcmp(config, "flood.max.advert ", 17) == 0) {
     uint8_t m = atoi(&config[17]);
     if (m <= 64) {
@@ -747,9 +747,20 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       strcpy(reply, "Error: delay must be between 0-10000 ms");
     }
   } else if (memcmp(config, "bridge.source ", 14) == 0) {
-    _prefs->bridge_pkt_src = memcmp(&config[14], "rx", 2) == 0;
-    savePrefs();
-    strcpy(reply, "OK");
+    if (memcmp(&config[14], "log", 3) == 0) {
+      if (memcmp(&config[17], "Rx", 2) == 0 || memcmp(&config[17], "rx", 2) == 0) {
+        _prefs->bridge_pkt_src = BRIDGE_SOURCE_RX;
+        strcpy(reply, "OK");
+      } else if (memcmp(&config[17], "Tx", 2) == 0 || memcmp(&config[17], "tx", 2) == 0) {
+        _prefs->bridge_pkt_src = BRIDGE_SOURCE_TX;
+        strcpy(reply, "OK");
+      }
+    }
+    if (memcmp(reply, "OK", 2) == 0) {
+      savePrefs();
+    } else {
+      strcpy(reply, "Error: source must be logRx or logTx.");
+    }
 #endif
 #ifdef WITH_RS232_BRIDGE
   } else if (memcmp(config, "bridge.baud ", 12) == 0) {
@@ -1138,7 +1149,7 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
   } else if (n >= 3 && strcmp(parts[1], "list") == 0) {
     uint8_t mask = 0;
     bool invert = false;
-    
+
     if (strcmp(parts[2], "allowed") == 0) {
       mask = REGION_DENY_FLOOD;
       invert = false;  // list regions that DON'T have DENY flag
@@ -1149,7 +1160,7 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
       strcpy(reply, "Err - use 'allowed' or 'denied'");
       return;
     }
-    
+
     int len = _region_map->exportNamesTo(reply, 160, mask, invert);
     if (len == 0) {
       strcpy(reply, "-none-");

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -8,6 +8,8 @@
 
 #if defined(WITH_RS232_BRIDGE) || defined(WITH_ESPNOW_BRIDGE)
 #define WITH_BRIDGE
+#define BRIDGE_SOURCE_RX  0x01
+#define BRIDGE_SOURCE_TX  0x02
 #endif
 
 #define ADVERT_LOC_NONE       0
@@ -47,7 +49,7 @@ struct NodePrefs { // persisted to file
   // Bridge settings
   uint8_t bridge_enabled; // boolean
   uint16_t bridge_delay;  // milliseconds (default 500 ms)
-  uint8_t bridge_pkt_src; // 0 = logTx, 1 = logRx (default logTx)
+  uint8_t bridge_pkt_src; // 1 = logTx, 2 = logRx (default logTx)
   uint32_t bridge_baud;   // 9600, 19200, 38400, 57600, 115200 (default 115200)
   uint8_t bridge_channel; // 1-14 (ESP-NOW only)
   char bridge_secret[16]; // for XOR encryption of bridge packets (ESP-NOW only)


### PR DESCRIPTION
This change updates the CLI so that the `set bridge.source` will only accept `logRx` and `logTx`. Otherwise an error is produced that specifies that these are the only two choices. 

Previous experience would accept `rx` and anything else was silently ignored and would not switch back to `logTx`. This was contradictory to what is documented in `cli_commands.md` which specified `logRx`/`logTx` and not `rx`.