### PR TITLE
[Feature] Allow repeater firmware to bridge over USB and IP

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -198,9 +198,13 @@ uint8_t MyMesh::handleAnonClockReq(const mesh::Identity& sender, uint32_t sender
     memcpy(&reply_data[4], &now, 4);     // include our clock (for easy clock sync, and packet hash uniqueness)
     reply_data[8] = 0;  // features
 #ifdef WITH_RS232_BRIDGE
-    reply_data[8] |= 0x01;  // is bridge, type UART
+    reply_data[8] |= RS232_BRIDGE;  // is bridge, type UART
 #elif WITH_ESPNOW_BRIDGE
-    reply_data[8] |= 0x03;  // is bridge, type ESP-NOW
+    reply_data[8] |= ESPNOW_BRIDGE;  // is bridge, type ESP-NOW
+#elif WITH_USB_SERIAL_BRIDGE
+    reply_data[8] |= USB_SERIAL_BRIDGE;  // is bridge, type USB serial
+#elif WITH_TCP_BRIDGE
+    reply_data[8] |= TCP_BRIDGE;  // is bridge, type TCP
 #endif
     if (_prefs.disable_fwd) {   // is this repeater currently disabled
       reply_data[8] |= 0x80;  // is disabled
@@ -344,7 +348,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
       int results_offset = 0;
       uint8_t results_buffer[130];
       for(int index = 0; index < count && index + offset < neighbours_count; index++){
-        
+
         // stop if we can't fit another entry in results
         int entry_size = pubkey_prefix_length + 4 + 1;
         if(results_offset + entry_size > sizeof(results_buffer)){
@@ -857,6 +861,12 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
 #if defined(WITH_ESPNOW_BRIDGE)
       , bridge(&_prefs, _mgr, &rtc)
 #endif
+#if defined(WITH_USB_SERIAL_BRIDGE)
+      , bridge(&_prefs, WITH_USB_SERIAL_BRIDGE, _mgr, &rtc)
+#endif
+#if defined(WITH_TCP_BRIDGE)
+      , bridge(&_prefs, _mgr, &rtc, WITH_TCP_BRIDGE)
+#endif
 {
   last_millis = 0;
   uptime_millis = 0;
@@ -1148,7 +1158,7 @@ void MyMesh::formatRadioStatsReply(char *reply) {
 }
 
 void MyMesh::formatPacketStatsReply(char *reply) {
-  StatsFormatHelper::formatPacketStats(reply, radio_driver, getNumSentFlood(), getNumSentDirect(), 
+  StatsFormatHelper::formatPacketStats(reply, radio_driver, getNumSentFlood(), getNumSentDirect(),
                                        getNumRecvFlood(), getNumRecvDirect());
 }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -862,10 +862,10 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
       , bridge(&_prefs, _mgr, &rtc)
 #endif
 #if defined(WITH_USB_SERIAL_BRIDGE)
-      , bridge(&_prefs, WITH_USB_SERIAL_BRIDGE, _mgr, &rtc)
+      , bridge(&_prefs, USB_SERIAL_STREAM, _mgr, &rtc)
 #endif
 #if defined(WITH_TCP_BRIDGE)
-      , bridge(&_prefs, _mgr, &rtc, WITH_TCP_BRIDGE)
+      , bridge(&_prefs, _mgr, &rtc, TCP_BRIDGE_PORT)
 #endif
 {
   last_millis = 0;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -23,6 +23,16 @@
 #define WITH_BRIDGE
 #endif
 
+#ifdef WITH_USB_SERIAL_BRIDGE
+#include "helpers/bridges/USBSerialBridge.h"
+#define WITH_BRIDGE
+#endif
+
+#ifdef WITH_TCP_BRIDGE
+#include "helpers/bridges/TCPBridge.h"
+#define WITH_BRIDGE
+#endif
+
 #include <helpers/AdvertDataHelpers.h>
 #include <helpers/ArduinoHelpers.h>
 #include <helpers/ClientACL.h>
@@ -37,7 +47,12 @@
 
 #ifdef WITH_BRIDGE
 extern AbstractBridge* bridge;
+#define RS232_BRIDGE       0x01
+#define ESPNOW_BRIDGE      0x03
+#define USB_SERIAL_BRIDGE  0x04
+#define TCP_BRIDGE         0x05
 #endif
+
 
 struct RepeaterStats {
   uint16_t batt_milli_volts;
@@ -117,6 +132,10 @@ class MyMesh : public mesh::Mesh, public CommonCLICallbacks {
   RS232Bridge bridge;
 #elif defined(WITH_ESPNOW_BRIDGE)
   ESPNowBridge bridge;
+#elif defined(WITH_USB_SERIAL_BRIDGE)
+  USBSerialBridge bridge;
+#elif defined(WITH_TCP_BRIDGE)
+  TCPBridge bridge;
 #endif
 
   void putNeighbour(const mesh::Identity& id, uint32_t timestamp, float snr);
@@ -236,7 +255,7 @@ public:
     {
       bridge.begin();
     }
-    else 
+    else
     {
       bridge.end();
     }

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -35,6 +35,12 @@ static unsigned long userBtnDownAt = 0;
 #define USER_BTN_HOLD_OFF_MILLIS 1500
 #endif
 
+#ifdef ESP32
+  #ifdef WIFI_SSID
+    #include <helpers/esp32/SerialWifiInterface.h>
+  #endif
+#endif
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
@@ -93,6 +99,11 @@ void setup() {
     }
     store.save("_main", the_mesh.self_id);
   }
+
+#ifdef WIFI_SSID
+  board.setInhibitSleep(true);   // prevent sleep when WiFi is active
+  WiFi.begin(WIFI_SSID, WIFI_PWD);
+#endif
 
   Serial.print("Repeater ID: ");
   mesh::Utils::printHex(Serial, the_mesh.self_id.pub_key, PUB_KEY_SIZE); Serial.println();

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -899,6 +899,10 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
             "rs232"
 #elif WITH_ESPNOW_BRIDGE
             "espnow"
+#elif WITH_USB_SERIAL_BRIDGE
+            "usbserial"
+#elif WITH_TCP_BRIDGE
+            "tcp"
 #else
             "none"
 #endif
@@ -1138,7 +1142,7 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
   } else if (n >= 3 && strcmp(parts[1], "list") == 0) {
     uint8_t mask = 0;
     bool invert = false;
-    
+
     if (strcmp(parts[2], "allowed") == 0) {
       mask = REGION_DENY_FLOOD;
       invert = false;  // list regions that DON'T have DENY flag
@@ -1149,7 +1153,7 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
       strcpy(reply, "Err - use 'allowed' or 'denied'");
       return;
     }
-    
+
     int len = _region_map->exportNamesTo(reply, 160, mask, invert);
     if (len == 0) {
       strcpy(reply, "-none-");

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -6,7 +6,7 @@
 #include <helpers/ClientACL.h>
 #include <helpers/RegionMap.h>
 
-#if defined(WITH_RS232_BRIDGE) || defined(WITH_ESPNOW_BRIDGE)
+#if defined(WITH_RS232_BRIDGE) || defined(WITH_ESPNOW_BRIDGE) || defined(WITH_USB_SERIAL_BRIDGE) || defined(WITH_TCP_BRIDGE)
 #define WITH_BRIDGE
 #endif
 

--- a/src/helpers/bridges/TCPBridge.cpp
+++ b/src/helpers/bridges/TCPBridge.cpp
@@ -1,0 +1,129 @@
+#include "TCPBridge.h"
+
+#ifdef WITH_TCP_BRIDGE
+
+TCPBridge::TCPBridge(NodePrefs* prefs, mesh::PacketManager* mgr, mesh::RTCClock* rtc, uint16_t port)
+    : BridgeBase(prefs, mgr, rtc), _port(port), _server(port) {}
+
+void TCPBridge::begin() {
+  _server.begin();
+  _initialized = true;
+  BRIDGE_DEBUG_PRINTLN("TCP bridge listening on port %d\n", _port);
+}
+
+void TCPBridge::end() {
+  if (_client_connected) {
+    _client.stop();
+    _client_connected = false;
+  }
+  _server.end();
+  _initialized = false;
+  BRIDGE_DEBUG_PRINTLN("TCP bridge stopped\n");
+}
+
+void TCPBridge::loop() {
+  if (!_initialized) return;
+
+  // Accept new connection, displacing any existing one
+  WiFiClient incoming = _server.available();
+  if (incoming) {
+    if (_client_connected) {
+      _client.stop();
+    }
+    _client = incoming;
+    _client_connected = true;
+    _rx_buffer_pos = 0;
+    BRIDGE_DEBUG_PRINTLN("TCP client connected\n");
+  }
+
+  if (_client_connected) {
+    if (!_client.connected()) {
+      _client.stop();
+      _client_connected = false;
+      BRIDGE_DEBUG_PRINTLN("TCP client disconnected\n");
+      return;
+    }
+
+    while (_client.available()) {
+      uint8_t b = _client.read();
+
+      if (_rx_buffer_pos < 2) {
+        if ((_rx_buffer_pos == 0 && b == ((BRIDGE_PACKET_MAGIC >> 8) & 0xFF)) ||
+            (_rx_buffer_pos == 1 && b == (BRIDGE_PACKET_MAGIC & 0xFF))) {
+          _rx_buffer[_rx_buffer_pos++] = b;
+        } else {
+          _rx_buffer_pos = 0;
+          if (b == ((BRIDGE_PACKET_MAGIC >> 8) & 0xFF)) {
+            _rx_buffer[_rx_buffer_pos++] = b;
+          }
+        }
+      } else {
+        _rx_buffer[_rx_buffer_pos++] = b;
+
+        if (_rx_buffer_pos >= 4) {
+          uint16_t len = (_rx_buffer[2] << 8) | _rx_buffer[3];
+
+          if (len > (MAX_TRANS_UNIT + 1)) {
+            BRIDGE_DEBUG_PRINTLN("RX invalid length %d, resetting\n", len);
+            _rx_buffer_pos = 0;
+            continue;
+          }
+
+          if (_rx_buffer_pos == len + TCP_OVERHEAD) {
+            uint16_t received_checksum = (_rx_buffer[4 + len] << 8) | _rx_buffer[5 + len];
+
+            if (validateChecksum(_rx_buffer + 4, len, received_checksum)) {
+              BRIDGE_DEBUG_PRINTLN("RX, len=%d crc=0x%04x\n", len, received_checksum);
+              mesh::Packet* pkt = _mgr->allocNew();
+              if (pkt) {
+                if (pkt->readFrom(_rx_buffer + 4, len)) {
+                  onPacketReceived(pkt);
+                } else {
+                  BRIDGE_DEBUG_PRINTLN("RX failed to parse packet\n");
+                  _mgr->free(pkt);
+                }
+              } else {
+                BRIDGE_DEBUG_PRINTLN("RX failed to allocate packet\n");
+              }
+            } else {
+              BRIDGE_DEBUG_PRINTLN("RX checksum mismatch, rcv=0x%04x\n", received_checksum);
+            }
+            _rx_buffer_pos = 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+void TCPBridge::sendPacket(mesh::Packet* packet) {
+  if (!_initialized || !packet || !_client_connected) return;
+
+  if (!_seen_packets.hasSeen(packet)) {
+    uint8_t buffer[MAX_TCP_PACKET_SIZE];
+    uint16_t len = packet->writeTo(buffer + 4);
+
+    if (len > (MAX_TRANS_UNIT + 1)) {
+      BRIDGE_DEBUG_PRINTLN("TX packet too large (payload=%d, max=%d)\n", len, MAX_TRANS_UNIT + 1);
+      return;
+    }
+
+    buffer[0] = (BRIDGE_PACKET_MAGIC >> 8) & 0xFF;
+    buffer[1] = BRIDGE_PACKET_MAGIC & 0xFF;
+    buffer[2] = (len >> 8) & 0xFF;
+    buffer[3] = len & 0xFF;
+
+    uint16_t checksum = fletcher16(buffer + 4, len);
+    buffer[4 + len] = (checksum >> 8) & 0xFF;
+    buffer[5 + len] = checksum & 0xFF;
+
+    _client.write(buffer, len + TCP_OVERHEAD);
+    BRIDGE_DEBUG_PRINTLN("TX, len=%d crc=0x%04x\n", len, checksum);
+  }
+}
+
+void TCPBridge::onPacketReceived(mesh::Packet* packet) {
+  handleReceivedPacket(packet);
+}
+
+#endif

--- a/src/helpers/bridges/TCPBridge.h
+++ b/src/helpers/bridges/TCPBridge.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "helpers/bridges/BridgeBase.h"
+
+#ifdef WITH_TCP_BRIDGE
+
+#include <WiFiServer.h>
+#include <WiFiClient.h>
+
+/**
+ * Bridge using the RS232Bridge framing protocol over a WiFi TCP socket.
+ *
+ * The server listens on the port set by WITH_TCP_BRIDGE. One client is
+ * accepted at a time; a new connection displaces the previous one.
+ * WiFi must be connected before calling begin().
+ *
+ * Frame format (identical to RS232Bridge / USBSerialBridge):
+ *   [2 bytes] Magic header: 0xC03E
+ *   [2 bytes] Payload length
+ *   [N bytes] Raw mesh packet bytes
+ *   [2 bytes] Fletcher-16 checksum (over payload only)
+ *
+ * Enable with: -DWITH_TCP_BRIDGE=<port>  (e.g. -DWITH_TCP_BRIDGE=4403)
+ */
+class TCPBridge : public BridgeBase {
+public:
+  TCPBridge(NodePrefs* prefs, mesh::PacketManager* mgr, mesh::RTCClock* rtc, uint16_t port);
+
+  void begin() override;
+  void end() override;
+  void loop() override;
+  void sendPacket(mesh::Packet* packet) override;
+  void onPacketReceived(mesh::Packet* packet) override;
+
+private:
+  static constexpr uint16_t TCP_OVERHEAD = BRIDGE_MAGIC_SIZE + BRIDGE_LENGTH_SIZE + BRIDGE_CHECKSUM_SIZE;
+  static constexpr uint16_t MAX_TCP_PACKET_SIZE = (MAX_TRANS_UNIT + 1) + TCP_OVERHEAD;
+
+  uint16_t _port;
+  WiFiServer _server;
+  WiFiClient _client;
+  bool _client_connected = false;
+  uint8_t _rx_buffer[MAX_TCP_PACKET_SIZE];
+  uint16_t _rx_buffer_pos = 0;
+};
+
+#endif

--- a/src/helpers/bridges/USBSerialBridge.cpp
+++ b/src/helpers/bridges/USBSerialBridge.cpp
@@ -1,0 +1,102 @@
+#include "USBSerialBridge.h"
+
+#ifdef WITH_USB_SERIAL_BRIDGE
+
+USBSerialBridge::USBSerialBridge(NodePrefs* prefs, Stream& serial, mesh::PacketManager* mgr, mesh::RTCClock* rtc)
+    : BridgeBase(prefs, mgr, rtc), _serial(&serial) {}
+
+void USBSerialBridge::begin() {
+  _initialized = true;
+  BRIDGE_DEBUG_PRINTLN("USB serial bridge started\n");
+}
+
+void USBSerialBridge::end() {
+  _initialized = false;
+  BRIDGE_DEBUG_PRINTLN("USB serial bridge stopped\n");
+}
+
+void USBSerialBridge::loop() {
+  if (!_initialized) return;
+
+  while (_serial->available()) {
+    uint8_t b = _serial->read();
+
+    if (_rx_buffer_pos < 2) {
+      if ((_rx_buffer_pos == 0 && b == ((BRIDGE_PACKET_MAGIC >> 8) & 0xFF)) ||
+          (_rx_buffer_pos == 1 && b == (BRIDGE_PACKET_MAGIC & 0xFF))) {
+        _rx_buffer[_rx_buffer_pos++] = b;
+      } else {
+        _rx_buffer_pos = 0;
+        if (b == ((BRIDGE_PACKET_MAGIC >> 8) & 0xFF)) {
+          _rx_buffer[_rx_buffer_pos++] = b;
+        }
+      }
+    } else {
+      _rx_buffer[_rx_buffer_pos++] = b;
+
+      if (_rx_buffer_pos >= 4) {
+        uint16_t len = (_rx_buffer[2] << 8) | _rx_buffer[3];
+
+        if (len > (MAX_TRANS_UNIT + 1)) {
+          BRIDGE_DEBUG_PRINTLN("RX invalid length %d, resetting\n", len);
+          _rx_buffer_pos = 0;
+          continue;
+        }
+
+        if (_rx_buffer_pos == len + SERIAL_OVERHEAD) {
+          uint16_t received_checksum = (_rx_buffer[4 + len] << 8) | _rx_buffer[5 + len];
+
+          if (validateChecksum(_rx_buffer + 4, len, received_checksum)) {
+            BRIDGE_DEBUG_PRINTLN("RX, len=%d crc=0x%04x\n", len, received_checksum);
+            mesh::Packet* pkt = _mgr->allocNew();
+            if (pkt) {
+              if (pkt->readFrom(_rx_buffer + 4, len)) {
+                onPacketReceived(pkt);
+              } else {
+                BRIDGE_DEBUG_PRINTLN("RX failed to parse packet\n");
+                _mgr->free(pkt);
+              }
+            } else {
+              BRIDGE_DEBUG_PRINTLN("RX failed to allocate packet\n");
+            }
+          } else {
+            BRIDGE_DEBUG_PRINTLN("RX checksum mismatch, rcv=0x%04x\n", received_checksum);
+          }
+          _rx_buffer_pos = 0;
+        }
+      }
+    }
+  }
+}
+
+void USBSerialBridge::sendPacket(mesh::Packet* packet) {
+  if (!_initialized || !packet) return;
+
+  if (!_seen_packets.hasSeen(packet)) {
+    uint8_t buffer[MAX_SERIAL_PACKET_SIZE];
+    uint16_t len = packet->writeTo(buffer + 4);
+
+    if (len > (MAX_TRANS_UNIT + 1)) {
+      BRIDGE_DEBUG_PRINTLN("TX packet too large (payload=%d, max=%d)\n", len, MAX_TRANS_UNIT + 1);
+      return;
+    }
+
+    buffer[0] = (BRIDGE_PACKET_MAGIC >> 8) & 0xFF;
+    buffer[1] = BRIDGE_PACKET_MAGIC & 0xFF;
+    buffer[2] = (len >> 8) & 0xFF;
+    buffer[3] = len & 0xFF;
+
+    uint16_t checksum = fletcher16(buffer + 4, len);
+    buffer[4 + len] = (checksum >> 8) & 0xFF;
+    buffer[5 + len] = checksum & 0xFF;
+
+    _serial->write(buffer, len + SERIAL_OVERHEAD);
+    BRIDGE_DEBUG_PRINTLN("TX, len=%d crc=0x%04x\n", len, checksum);
+  }
+}
+
+void USBSerialBridge::onPacketReceived(mesh::Packet* packet) {
+  handleReceivedPacket(packet);
+}
+
+#endif

--- a/src/helpers/bridges/USBSerialBridge.h
+++ b/src/helpers/bridges/USBSerialBridge.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "helpers/bridges/BridgeBase.h"
+
+#include <Stream.h>
+
+#ifdef WITH_USB_SERIAL_BRIDGE
+
+/**
+ * Bridge using the RS232Bridge framing protocol over a USB CDC serial stream.
+ *
+ * Unlike RS232Bridge, this class takes any Stream (e.g. Serial on ESP32-S3 native USB)
+ * and skips all HardwareSerial pin/baud configuration — the USB CDC port is already
+ * initialised by the framework before setup() runs.
+ *
+ * Frame format (identical to RS232Bridge):
+ *   [2 bytes] Magic header: 0xC03E
+ *   [2 bytes] Payload length
+ *   [N bytes] Raw mesh packet bytes
+ *   [2 bytes] Fletcher-16 checksum (over payload only)
+ *
+ * Enable with: -DWITH_USB_SERIAL_BRIDGE=Serial  (or USBSerial, etc.)
+ */
+class USBSerialBridge : public BridgeBase {
+public:
+  USBSerialBridge(NodePrefs* prefs, Stream& serial, mesh::PacketManager* mgr, mesh::RTCClock* rtc);
+
+  void begin() override;
+  void end() override;
+  void loop() override;
+  void sendPacket(mesh::Packet* packet) override;
+  void onPacketReceived(mesh::Packet* packet) override;
+
+private:
+  static constexpr uint16_t SERIAL_OVERHEAD = BRIDGE_MAGIC_SIZE + BRIDGE_LENGTH_SIZE + BRIDGE_CHECKSUM_SIZE;
+  static constexpr uint16_t MAX_SERIAL_PACKET_SIZE = (MAX_TRANS_UNIT + 1) + SERIAL_OVERHEAD;
+
+  Stream* _serial;
+  uint8_t _rx_buffer[MAX_SERIAL_PACKET_SIZE];
+  uint16_t _rx_buffer_pos = 0;
+};
+
+#endif

--- a/variants/lilygo_tbeam_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_SX1262/platformio.ini
@@ -51,8 +51,8 @@ build_flags =
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=128
 ;  -D BLE_DEBUG_LOGGING=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
 ;  -D RADIOLIB_DEBUG_BASIC=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -74,9 +74,58 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TBeam_SX1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+# If using WITH_USB_SERIAL_BRIDGE, load the standard repeater code
+# first so that the repeater can be configured over USB. Then load
+# this code. Once USBSerial bridge is running the node can not use
+# the repeater configuration at flasher.meshcode.io.
+[env:Tbeam_SX1262_repeater_bridge_usbserial]
+extends = LilyGo_TBeam_SX1262
+build_flags =
+  ${LilyGo_TBeam_SX1262.build_flags}
+  -D ADVERT_NAME='"Tbeam SX1262 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+  -D WITH_USB_SERIAL_BRIDGE=1
+  -D USB_SERIAL_STREAM=Serial
+  -D BRIDGE_DEBUG=1
+build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
+  +<helpers/bridges/USBSerialBridge.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${LilyGo_TBeam_SX1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Tbeam_SX1262_repeater_bridge_wifi]
+extends = LilyGo_TBeam_SX1262
+build_flags =
+  ${LilyGo_TBeam_SX1262.build_flags}
+  -D ADVERT_NAME='"Tbeam SX1262 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+  -D WITH_TCP_BRIDGE=1
+  -D TCP_BRIDGE_PORT=4403
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypasswd"'
+  -D BRIDGE_DEBUG=1
+build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
+  +<helpers/bridges/TCPBridge.cpp>
   +<../examples/simple_repeater>
 lib_deps =
   ${LilyGo_TBeam_SX1262.lib_deps}
@@ -114,9 +163,9 @@ build_flags =
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
   -D WITH_ESPNOW_BRIDGE=1
-;  -D BRIDGE_DEBUG=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  -D BRIDGE_DEBUG=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>
   +<../examples/simple_repeater>
@@ -133,8 +182,8 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D ROOM_PASSWORD='"hello"'
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
   +<../examples/simple_room_server>
 lib_deps =


### PR DESCRIPTION
This PR adds support for bridging packets over USB serial and TCP connections in the same manner as the RS232 bridging works. It uses the same encoding as the RS232 bridge code.

USB serial bridge code is enabled with defining `WITH_USB_SERIAL_BRIDGE` and setting the serial stream by defining `USB_SERIAL_STREAM` (usually to `Serial`). Defining the stream in theory should allow the bridging output to be directed to a second USB port if the platform has another USB connection; although I do not have a solid way to test this configuration with the hardware available to me. 

TCP bridge code is enable by defining `WITH_TCP_BRIDGE`. The port that the repeater will listen on is defined by `TCP_BRIDGE_PORT`and will default to `4403` if not specified. As a result when using the TCP bridge code the WIFI credential definitions need to be specified also in the build. 

I have added build environments for the `lilygo_tbeam_SX1262` named `Tbeam_SX1262_repeater_bridge_usbserial` and `Tbeam_SX1262_repeater_bridge_wifi` to demonstrate how the firmwares can be built. These environments should be able to be transported to other platforms that have compatible hardware. 

In addition, I have added the `usbserial` and `tcp` bridge types to the `get bridge.type` CLI command. I am not certain if this will have any effects on the remote management in the companion app. There is nothing I see that is obvious. I have also updated the CLI documentation to note the values that can be returned by `get bridge.type`.

Closes: #3028