### PR TITLE
Add heltec rc52

### DIFF
--- a/boards/heltec-rc52.json
+++ b/boards/heltec-rc52.json
@@ -1,0 +1,61 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      ["0x239A", "0x8071"],
+      ["0x239A", "0x0071"],
+      ["0x239A", "0x8072"]
+    ],
+    "usb_product": "HT-n5262",
+    "mcu": "nrf52840",
+    "variant": "heltec_rc52",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Heltec RC52",
+  "upload": {
+    "maximum_ram_size": 237568,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://heltec.org/",
+  "vendor": "Heltec"
+}

--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -203,25 +203,25 @@ static void writeOptionalPin(int pin, int level) {
 }
 
 void NV3001BDisplay::writeCommand(uint8_t cmd) {
-  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, LOW);
   digitalWrite(PIN_TFT_CS, LOW);
-  spi.transfer(cmd);
+  spi->transfer(cmd);
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi.endTransaction();
+  spi->endTransaction();
 }
 
 void NV3001BDisplay::writeBytes(const uint8_t* data, size_t len) {
   if (!data || len == 0) return;
 
-  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
   for (size_t i = 0; i < len; i++) {
-    spi.transfer(data[i]);
+    spi->transfer(data[i]);
   }
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi.endTransaction();
+  spi->endTransaction();
 }
 
 void NV3001BDisplay::writeCommandData(uint8_t cmd, const uint8_t* data, size_t len) {
@@ -253,15 +253,15 @@ void NV3001BDisplay::writeColor(uint16_t rgb, uint32_t count) {
   uint8_t hi = rgb >> 8;
   uint8_t lo = rgb & 0xff;
 
-  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
   while (count--) {
-    spi.transfer(hi);
-    spi.transfer(lo);
+    spi->transfer(hi);
+    spi->transfer(lo);
   }
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi.endTransaction();
+  spi->endTransaction();
 }
 
 void NV3001BDisplay::initPanel() {
@@ -416,6 +416,7 @@ void NV3001BDisplay::drawChar(int x, int y, char ch) {
 
 bool NV3001BDisplay::begin() {
   if (is_on) return true;
+  if (!spi) return false;
 
   if (periph_power) periph_power->claim();
 
@@ -427,7 +428,13 @@ bool NV3001BDisplay::begin() {
   digitalWrite(PIN_TFT_DC, HIGH);
   delay(20);
 
-  spi.begin(PIN_TFT_SCL, PIN_TFT_MISO, PIN_TFT_SDA, PIN_TFT_CS);
+#if defined(NRF52_PLATFORM)
+  spi->begin();
+#elif defined(ESP_PLATFORM) || defined(ESP32_PLATFORM)
+  spi->begin(PIN_TFT_SCL, PIN_TFT_MISO, PIN_TFT_SDA, PIN_TFT_CS);
+#else
+  spi->begin();
+#endif
   if (PIN_TFT_RST >= 0) {
     pinMode(PIN_TFT_RST, OUTPUT);
     digitalWrite(PIN_TFT_RST, HIGH);

--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -203,25 +203,25 @@ static void writeOptionalPin(int pin, int level) {
 }
 
 void NV3001BDisplay::writeCommand(uint8_t cmd) {
-  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, LOW);
   digitalWrite(PIN_TFT_CS, LOW);
-  spi->transfer(cmd);
+  spi.transfer(cmd);
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi->endTransaction();
+  spi.endTransaction();
 }
 
 void NV3001BDisplay::writeBytes(const uint8_t* data, size_t len) {
   if (!data || len == 0) return;
 
-  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
   for (size_t i = 0; i < len; i++) {
-    spi->transfer(data[i]);
+    spi.transfer(data[i]);
   }
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi->endTransaction();
+  spi.endTransaction();
 }
 
 void NV3001BDisplay::writeCommandData(uint8_t cmd, const uint8_t* data, size_t len) {
@@ -253,15 +253,15 @@ void NV3001BDisplay::writeColor(uint16_t rgb, uint32_t count) {
   uint8_t hi = rgb >> 8;
   uint8_t lo = rgb & 0xff;
 
-  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
   while (count--) {
-    spi->transfer(hi);
-    spi->transfer(lo);
+    spi.transfer(hi);
+    spi.transfer(lo);
   }
   digitalWrite(PIN_TFT_CS, HIGH);
-  spi->endTransaction();
+  spi.endTransaction();
 }
 
 void NV3001BDisplay::initPanel() {
@@ -416,7 +416,6 @@ void NV3001BDisplay::drawChar(int x, int y, char ch) {
 
 bool NV3001BDisplay::begin() {
   if (is_on) return true;
-  if (!spi) return false;
 
   if (periph_power) periph_power->claim();
 
@@ -429,11 +428,11 @@ bool NV3001BDisplay::begin() {
   delay(20);
 
 #if defined(NRF52_PLATFORM)
-  spi->begin();
+  spi.begin();
 #elif defined(ESP_PLATFORM) || defined(ESP32_PLATFORM)
-  spi->begin(PIN_TFT_SCL, PIN_TFT_MISO, PIN_TFT_SDA, PIN_TFT_CS);
+  spi.begin(PIN_TFT_SCL, PIN_TFT_MISO, PIN_TFT_SDA, PIN_TFT_CS);
 #else
-  spi->begin();
+  spi.begin();
 #endif
   if (PIN_TFT_RST >= 0) {
     pinMode(PIN_TFT_RST, OUTPUT);

--- a/src/helpers/ui/NV3001BDisplay.h
+++ b/src/helpers/ui/NV3001BDisplay.h
@@ -20,12 +20,14 @@
   #define NV3001B_PANEL_HEIGHT 220
 #endif
 
+class NV3001BDisplay : public DisplayDriver {
+#if defined(ESP_PLATFORM) || defined(ESP32_PLATFORM)
 #ifndef NV3001B_SPI_HOST
   #define NV3001B_SPI_HOST HSPI
 #endif
-
-class NV3001BDisplay : public DisplayDriver {
-  SPIClass spi;
+  SPIClass owned_spi;
+#endif
+  SPIClass* spi;
   RefCountedDigitalPin* periph_power;
   bool is_on = false;
   uint16_t color = 0xffff;
@@ -43,8 +45,18 @@ class NV3001BDisplay : public DisplayDriver {
   void drawChar(int x, int y, char ch);
 
 public:
+#if defined(ESP_PLATFORM) || defined(ESP32_PLATFORM)
   NV3001BDisplay(RefCountedDigitalPin* power = nullptr) :
-      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT), spi(NV3001B_SPI_HOST), periph_power(power) { }
+      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT),
+      owned_spi(NV3001B_SPI_HOST), spi(&owned_spi), periph_power(power) { }
+
+  NV3001BDisplay(SPIClass* displaySpi, RefCountedDigitalPin* power = nullptr) :
+      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT),
+      owned_spi(NV3001B_SPI_HOST), spi(displaySpi ? displaySpi : &owned_spi), periph_power(power) { }
+#else
+  NV3001BDisplay(SPIClass* displaySpi = &SPI, RefCountedDigitalPin* power = nullptr) :
+      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT), spi(displaySpi), periph_power(power) { }
+#endif
 
   bool begin();
   static const char* driverName() { return "NV3001B"; }

--- a/src/helpers/ui/NV3001BDisplay.h
+++ b/src/helpers/ui/NV3001BDisplay.h
@@ -27,7 +27,7 @@ class NV3001BDisplay : public DisplayDriver {
 #endif
   SPIClass owned_spi;
 #endif
-  SPIClass* spi;
+  SPIClass& spi;
   RefCountedDigitalPin* periph_power;
   bool is_on = false;
   uint16_t color = 0xffff;
@@ -48,14 +48,14 @@ public:
 #if defined(ESP_PLATFORM) || defined(ESP32_PLATFORM)
   NV3001BDisplay(RefCountedDigitalPin* power = nullptr) :
       DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT),
-      owned_spi(NV3001B_SPI_HOST), spi(&owned_spi), periph_power(power) { }
+      owned_spi(NV3001B_SPI_HOST), spi(owned_spi), periph_power(power) { }
 
   NV3001BDisplay(SPIClass* displaySpi, RefCountedDigitalPin* power = nullptr) :
       DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT),
-      owned_spi(NV3001B_SPI_HOST), spi(displaySpi ? displaySpi : &owned_spi), periph_power(power) { }
+      owned_spi(NV3001B_SPI_HOST), spi(displaySpi ? *displaySpi : owned_spi), periph_power(power) { }
 #else
   NV3001BDisplay(SPIClass* displaySpi = &SPI, RefCountedDigitalPin* power = nullptr) :
-      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT), spi(displaySpi), periph_power(power) { }
+      DisplayDriver(NV3001B_LOGICAL_WIDTH, NV3001B_LOGICAL_HEIGHT), spi(displaySpi ? *displaySpi : SPI), periph_power(power) { }
 #endif
 
   bool begin();

--- a/variants/heltec_rc52/HeltecRC52Board.cpp
+++ b/variants/heltec_rc52/HeltecRC52Board.cpp
@@ -49,6 +49,9 @@ void HeltecRC52Board::begin()
 #ifdef NRF52_POWER_MANAGEMENT
   checkBootVoltage(&power_config);
 #endif
+  pinMode(P_LORA_TX_LED, OUTPUT);
+  digitalWrite(P_LORA_TX_LED, LOW); // off by default, active high
+
   periph_power.begin();
   periph_power.claim();
 }
@@ -57,6 +60,14 @@ void HeltecRC52Board::shutdownPeripherals()
 {
   NRF52Board::shutdownPeripherals();
   variant_shutdown();
+}
+
+void HeltecRC52Board::onBeforeTransmit() {
+  digitalWrite(P_LORA_TX_LED, HIGH);
+}
+
+void HeltecRC52Board::onAfterTransmit() {
+  digitalWrite(P_LORA_TX_LED, LOW);
 }
 
 uint16_t HeltecRC52Board::getBattMilliVolts()

--- a/variants/heltec_rc52/HeltecRC52Board.cpp
+++ b/variants/heltec_rc52/HeltecRC52Board.cpp
@@ -1,0 +1,88 @@
+#include "HeltecRC52Board.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+extern void variant_shutdown();
+
+#ifdef NRF52_POWER_MANAGEMENT
+const PowerMgtConfig power_config = {
+    .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
+    .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
+    .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK};
+
+void HeltecRC52Board::initiateShutdown(uint8_t reason)
+{
+  shutdownPeripherals();
+
+  bool enable_lpcomp = (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
+                        reason == SHUTDOWN_REASON_BOOT_PROTECT);
+  pinMode(PIN_ADC_CTRL, OUTPUT);
+  digitalWrite(PIN_ADC_CTRL, enable_lpcomp ? ADC_CTRL_ENABLED : !ADC_CTRL_ENABLED);
+
+  if (enable_lpcomp) {
+    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+  }
+
+  enterSystemOff(reason);
+}
+#endif
+
+void HeltecRC52Board::begin()
+{
+  NRF52BoardDCDC::begin();
+
+  pinMode(PIN_VBAT_READ, INPUT);
+  pinMode(PIN_ADC_CTRL, OUTPUT);
+  digitalWrite(PIN_ADC_CTRL, !ADC_CTRL_ENABLED);
+
+#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
+#endif
+  Wire.begin();
+
+  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+  digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
+  pinMode(RADIOCORE_FEM_EN, OUTPUT);
+  digitalWrite(RADIOCORE_FEM_EN, HIGH);
+
+  pinMode(SENSOR_RST_PIN, OUTPUT);
+  digitalWrite(SENSOR_RST_PIN, HIGH);
+  pinMode(SENSOR_INT, INPUT);
+
+  periph_power.begin();
+
+#ifdef NRF52_POWER_MANAGEMENT
+  checkBootVoltage(&power_config);
+#endif
+}
+
+void HeltecRC52Board::shutdownPeripherals()
+{
+  NRF52Board::shutdownPeripherals();
+  variant_shutdown();
+}
+
+uint16_t HeltecRC52Board::getBattMilliVolts()
+{
+  analogReadResolution(12);
+  analogReference(AR_INTERNAL_3_0);
+  pinMode(PIN_VBAT_READ, INPUT);
+  pinMode(PIN_ADC_CTRL, OUTPUT);
+  digitalWrite(PIN_ADC_CTRL, ADC_CTRL_ENABLED);
+
+  delay(10);
+  uint32_t raw = 0;
+  for (int i = 0; i < 8; i++) {
+    raw += analogRead(PIN_VBAT_READ);
+  }
+  raw /= 8;
+  digitalWrite(PIN_ADC_CTRL, !ADC_CTRL_ENABLED);
+
+  return (uint16_t)((float)raw * MV_LSB * ADC_MULTIPLIER);
+}
+
+const char* HeltecRC52Board::getManufacturerName() const
+{
+  return "Heltec RC52";
+}

--- a/variants/heltec_rc52/HeltecRC52Board.cpp
+++ b/variants/heltec_rc52/HeltecRC52Board.cpp
@@ -41,20 +41,16 @@ void HeltecRC52Board::begin()
 #endif
   Wire.begin();
 
-  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
-  digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
-  pinMode(RADIOCORE_FEM_EN, OUTPUT);
-  digitalWrite(RADIOCORE_FEM_EN, HIGH);
-
   pinMode(SENSOR_RST_PIN, OUTPUT);
   digitalWrite(SENSOR_RST_PIN, HIGH);
   pinMode(SENSOR_INT, INPUT);
 
-  periph_power.begin();
 
 #ifdef NRF52_POWER_MANAGEMENT
   checkBootVoltage(&power_config);
 #endif
+  periph_power.begin();
+  periph_power.claim();
 }
 
 void HeltecRC52Board::shutdownPeripherals()

--- a/variants/heltec_rc52/HeltecRC52Board.h
+++ b/variants/heltec_rc52/HeltecRC52Board.h
@@ -17,6 +17,8 @@ public:
   HeltecRC52Board() : NRF52Board("RC52_OTA"), periph_power(SENSOR_POWER_CTRL_PIN, SENSOR_POWER_ON) {}
 
   void begin() override;
+  void onBeforeTransmit() override;
+  void onAfterTransmit() override;
   void shutdownPeripherals() override;
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override;

--- a/variants/heltec_rc52/HeltecRC52Board.h
+++ b/variants/heltec_rc52/HeltecRC52Board.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+#include <helpers/NRF52Board.h>
+#include <helpers/RefCountedDigitalPin.h>
+
+class HeltecRC52Board : public NRF52BoardDCDC {
+protected:
+#ifdef NRF52_POWER_MANAGEMENT
+  void initiateShutdown(uint8_t reason) override;
+#endif
+
+public:
+  RefCountedDigitalPin periph_power;
+
+  HeltecRC52Board() : NRF52Board("RC52_OTA"), periph_power(SENSOR_POWER_CTRL_PIN, SENSOR_POWER_ON) {}
+
+  void begin() override;
+  void shutdownPeripherals() override;
+  uint16_t getBattMilliVolts() override;
+  const char* getManufacturerName() const override;
+};

--- a/variants/heltec_rc52/HeltecRC52RotaryInput.cpp
+++ b/variants/heltec_rc52/HeltecRC52RotaryInput.cpp
@@ -1,0 +1,128 @@
+#include "HeltecRC52RotaryInput.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+namespace {
+constexpr uint8_t TCA6408_ADDR = 0x20;
+constexpr uint8_t TCA6408_INPUT_REG = 0x00;
+constexpr uint8_t TCA6408_POLARITY_REG = 0x02;
+constexpr uint8_t TCA6408_CONFIG_REG = 0x03;
+constexpr uint8_t TCA6408_ROTARY_A_MASK = 0x01;
+constexpr uint8_t TCA6408_ROTARY_B_MASK = 0x02;
+constexpr uint8_t TCA6408_ROTARY_MASK = TCA6408_ROTARY_A_MASK | TCA6408_ROTARY_B_MASK;
+constexpr uint32_t TCA6408_DEBOUNCE_MS = 5;
+}
+
+bool HeltecRC52RotaryInput::begin()
+{
+  initialized = true;
+  ready = false;
+  input_state = TCA6408_ROTARY_MASK;
+  active_low_phase = false;
+
+  if (periph_power && !power_claimed) {
+    periph_power->claim();
+    power_claimed = true;
+    delay(12);
+  }
+
+  if (!writeRegister(TCA6408_POLARITY_REG, 0x00) || !writeRegister(TCA6408_CONFIG_REG, 0xFF)) {
+    return false;
+  }
+
+  uint8_t state = 0;
+  if (!readInput(state)) {
+    return false;
+  }
+
+  input_state = state & TCA6408_ROTARY_MASK;
+  ready = true;
+  return true;
+}
+
+RotaryInputEvent HeltecRC52RotaryInput::poll()
+{
+  if (!initialized) {
+    begin();
+    return RotaryInputEvent::None;
+  }
+
+  if (!ready) {
+    return RotaryInputEvent::None;
+  }
+
+  uint8_t new_state = 0;
+  if (!readInput(new_state)) {
+    return RotaryInputEvent::None;
+  }
+
+  new_state &= TCA6408_ROTARY_MASK;
+  RotaryInputEvent event = handleTransition(new_state);
+  input_state = new_state;
+  return event;
+}
+
+bool HeltecRC52RotaryInput::writeRegister(uint8_t reg, uint8_t value)
+{
+  Wire.beginTransmission(TCA6408_ADDR);
+  Wire.write(reg);
+  Wire.write(value);
+  return Wire.endTransmission() == 0;
+}
+
+bool HeltecRC52RotaryInput::readInput(uint8_t& value)
+{
+  Wire.beginTransmission(TCA6408_ADDR);
+  Wire.write(TCA6408_INPUT_REG);
+  if (Wire.endTransmission(false) != 0) {
+    return false;
+  }
+  if (Wire.requestFrom(TCA6408_ADDR, static_cast<uint8_t>(1)) != 1) {
+    return false;
+  }
+
+  value = Wire.read();
+  return true;
+}
+
+RotaryInputEvent HeltecRC52RotaryInput::handleTransition(uint8_t newState)
+{
+  uint8_t changed = (input_state ^ newState) & TCA6408_ROTARY_MASK;
+  RotaryInputEvent event = RotaryInputEvent::None;
+  bool a_low = (newState & TCA6408_ROTARY_A_MASK) == 0;
+  bool b_low = (newState & TCA6408_ROTARY_B_MASK) == 0;
+
+  if (!a_low && !b_low) {
+    active_low_phase = false;
+  }
+
+  if (!active_low_phase && (changed & TCA6408_ROTARY_A_MASK) && a_low && !b_low) {
+    event = RotaryInputEvent::Prev;
+    active_low_phase = true;
+  } else if (!active_low_phase && (changed & TCA6408_ROTARY_B_MASK) && b_low && !a_low) {
+    event = RotaryInputEvent::Next;
+    active_low_phase = true;
+  }
+
+  if (event == RotaryInputEvent::None && !active_low_phase && (changed & TCA6408_ROTARY_A_MASK)) {
+    bool a_rising = (newState & TCA6408_ROTARY_A_MASK) != 0;
+    if (a_rising && b_low) {
+      event = RotaryInputEvent::Prev;
+    }
+  }
+
+  if (event == RotaryInputEvent::None && !active_low_phase && (changed & TCA6408_ROTARY_B_MASK)) {
+    bool b_rising = (newState & TCA6408_ROTARY_B_MASK) != 0;
+    if (b_rising && a_low) {
+      event = RotaryInputEvent::Next;
+    }
+  }
+
+  if (event == RotaryInputEvent::None || (millis() - last_event_ms) < TCA6408_DEBOUNCE_MS) {
+    return RotaryInputEvent::None;
+  }
+
+  last_event_ms = millis();
+  return event;
+}

--- a/variants/heltec_rc52/HeltecRC52RotaryInput.h
+++ b/variants/heltec_rc52/HeltecRC52RotaryInput.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <helpers/RefCountedDigitalPin.h>
+#include <helpers/ui/RotaryInput.h>
+
+class HeltecRC52RotaryInput : public RotaryInput {
+public:
+  explicit HeltecRC52RotaryInput(RefCountedDigitalPin* periphPower = nullptr) : periph_power(periphPower) { }
+
+  bool begin() override;
+  RotaryInputEvent poll() override;
+  bool isReady() const override { return ready; }
+
+private:
+  bool writeRegister(uint8_t reg, uint8_t value);
+  bool readInput(uint8_t& value);
+  RotaryInputEvent handleTransition(uint8_t newState);
+
+  uint8_t input_state = 0x03;
+  uint32_t last_event_ms = 0;
+  bool ready = false;
+  bool initialized = false;
+  bool power_claimed = false;
+  bool active_low_phase = false;
+  RefCountedDigitalPin* periph_power = nullptr;
+};

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -23,6 +23,8 @@ build_flags = ${nrf52_base.build_flags}
   -D LORA_TX_POWER=22
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/sensors>

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -20,6 +20,7 @@ build_flags = ${nrf52_base.build_flags}
   -D P_LORA_SCLK=25
   -D P_LORA_MISO=14
   -D P_LORA_MOSI=22
+  -D P_LORA_TX_LED=15
   -D LORA_TX_POWER=22
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -1,0 +1,187 @@
+[heltec_rc52]
+extends = nrf52_base
+board = heltec-rc52
+board_build.ldscript = boards/nrf52840_s140_v6.ld
+build_flags = ${nrf52_base.build_flags}
+  ${sensor_base.build_flags}
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
+  -I variants/heltec_rc52
+  -I src/helpers/ui
+  -D HELTEC_RC52
+  -D NRF52_POWER_MANAGEMENT
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D P_LORA_DIO_1=11
+  -D P_LORA_NSS=13
+  -D P_LORA_RESET=32
+  -D P_LORA_BUSY=24
+  -D P_LORA_SCLK=25
+  -D P_LORA_MISO=14
+  -D P_LORA_MOSI=22
+  -D LORA_TX_POWER=22
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<helpers/*.cpp>
+  +<helpers/sensors>
+  +<../variants/heltec_rc52>
+lib_deps =
+  ${nrf52_base.lib_deps}
+  ${sensor_base.lib_deps}
+debug_tool = jlink
+upload_protocol = nrfutil
+
+[env:heltec_rc52_without_display_repeater]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D ADVERT_NAME='"Heltec RC52 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+
+[env:heltec_rc52_without_display_room_server]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D ADVERT_NAME='"Heltec RC52 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+
+[env:heltec_rc52_without_display_companion_radio_ble]
+extends = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=NullDisplayDriver
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_rc52_without_display_companion_radio_usb]
+extends = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=NullDisplayDriver
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<helpers/nrf52/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+;
+; Heltec RC52 with NV3001B display
+;
+[heltec_rc52_with_display]
+extends = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6.ld
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D HELTEC_RC52_WITH_DISPLAY
+  -D DISPLAY_CLASS=NV3001BDisplay
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<helpers/ui/NV3001BDisplay.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+lib_deps =
+  ${heltec_rc52.lib_deps}
+
+[env:heltec_rc52_repeater]
+extends = heltec_rc52_with_display
+build_src_filter = ${heltec_rc52_with_display.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${heltec_rc52_with_display.build_flags}
+  -D ADVERT_NAME='"Heltec RC52 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+
+[env:heltec_rc52_room_server]
+extends = heltec_rc52_with_display
+build_src_filter = ${heltec_rc52_with_display.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${heltec_rc52_with_display.build_flags}
+  -D ADVERT_NAME='"Heltec RC52 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+
+[env:heltec_rc52_companion_radio_ble]
+extends = heltec_rc52_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52_with_display.build_flags}
+  -I examples/companion_radio/ui-new
+  -D PIN_BUZZER=5
+  -D UI_HAS_ROTARY_INPUT
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D ENV_INCLUDE_GPS=1
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${heltec_rc52_with_display.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52_with_display.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:heltec_rc52_companion_radio_usb]
+extends = heltec_rc52_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52_with_display.build_flags}
+  -I examples/companion_radio/ui-new
+  -D PIN_BUZZER=5
+  -D UI_HAS_ROTARY_INPUT
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D ENV_INCLUDE_GPS=1
+build_src_filter = ${heltec_rc52_with_display.build_src_filter}
+  +<helpers/nrf52/*.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52_with_display.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:heltec_rc52_kiss_modem]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/heltec_rc52/target.cpp
+++ b/variants/heltec_rc52/target.cpp
@@ -1,0 +1,52 @@
+#include "target.h"
+
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+#if defined(UI_HAS_ROTARY_INPUT)
+#include "HeltecRC52RotaryInput.h"
+#endif
+
+#ifdef ENV_INCLUDE_GPS
+#include <helpers/sensors/MicroNMEALocationProvider.h>
+#endif
+
+HeltecRC52Board board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock, PIN_GPS_RESET, PIN_GPS_EN);
+EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+EnvironmentSensorManager sensors;
+#endif
+
+#ifdef DISPLAY_CLASS
+#ifdef HELTEC_RC52_WITH_DISPLAY
+DISPLAY_CLASS display(&SPI1);
+#else
+DISPLAY_CLASS display;
+#endif
+MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#if defined(UI_HAS_ROTARY_INPUT)
+static HeltecRC52RotaryInput rotaryInputImpl(&board.periph_power);
+RotaryInput& rotary_input = rotaryInputImpl;
+#endif
+#endif
+
+bool radio_init()
+{
+  rtc_clock.begin(Wire);
+  return radio.std_init(&SPI);
+}
+
+mesh::LocalIdentity radio_new_identity()
+{
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/heltec_rc52/target.h
+++ b/variants/heltec_rc52/target.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <HeltecRC52Board.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#include <helpers/sensors/LocationProvider.h>
+
+#ifdef DISPLAY_CLASS
+#include <helpers/ui/MomentaryButton.h>
+#if defined(UI_HAS_ROTARY_INPUT)
+#include <helpers/ui/RotaryInput.h>
+#endif
+#ifdef HELTEC_RC52_WITH_DISPLAY
+#include <helpers/ui/NV3001BDisplay.h>
+#else
+#include <helpers/ui/NullDisplayDriver.h>
+#endif
+#endif
+
+extern HeltecRC52Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+extern DISPLAY_CLASS display;
+extern MomentaryButton user_btn;
+#if defined(UI_HAS_ROTARY_INPUT)
+extern RotaryInput& rotary_input;
+#endif
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();

--- a/variants/heltec_rc52/variant.cpp
+++ b/variants/heltec_rc52/variant.cpp
@@ -1,0 +1,92 @@
+#include "variant.h"
+#include "Arduino.h"
+#include "nrf.h"
+#include <Wire.h>
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    0xff, 0xff, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    16,   17,   18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    32,   33,   34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+
+static void resetOptionalPin(int pin)
+{
+  if (pin >= 0) nrf_gpio_cfg_default(pin);
+}
+
+void initVariant()
+{
+  pinMode(PIN_BUTTON1, INPUT_PULLUP);
+
+  pinMode(RADIOCORE_FEM_EN, OUTPUT);
+  digitalWrite(RADIOCORE_FEM_EN, HIGH);
+
+  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+  digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
+
+  pinMode(PIN_ADC_CTRL, OUTPUT);
+  digitalWrite(PIN_ADC_CTRL, !ADC_CTRL_ENABLED);
+
+#ifdef PIN_BUZZER
+  pinMode(PIN_BUZZER, OUTPUT);
+  digitalWrite(PIN_BUZZER, LOW);
+#endif
+
+  pinMode(PIN_TFT_EN, OUTPUT);
+  digitalWrite(PIN_TFT_EN, !PIN_TFT_EN_ACTIVE);
+  pinMode(PIN_TFT_BL, OUTPUT);
+  digitalWrite(PIN_TFT_BL, !PIN_TFT_BL_ACTIVE);
+  pinMode(PIN_TFT_CS, OUTPUT);
+  digitalWrite(PIN_TFT_CS, HIGH);
+}
+
+void variant_shutdown()
+{
+  Wire.end();
+
+  digitalWrite(RADIOCORE_FEM_EN, LOW);
+  digitalWrite(RADIOCORE_VFEM_CTRL, LOW);
+  digitalWrite(PIN_ADC_CTRL, !ADC_CTRL_ENABLED);
+#ifdef PIN_BUZZER
+  digitalWrite(PIN_BUZZER, LOW);
+#endif
+  digitalWrite(PIN_TFT_BL, !PIN_TFT_BL_ACTIVE);
+  digitalWrite(PIN_TFT_EN, !PIN_TFT_EN_ACTIVE);
+
+  nrf_gpio_cfg_default(PIN_BUTTON1);
+  nrf_gpio_cfg_default(PIN_ADC_CTRL);
+#ifdef PIN_BUZZER
+  nrf_gpio_cfg_default(PIN_BUZZER);
+#endif
+
+  nrf_gpio_cfg_default(PIN_TFT_BL);
+  nrf_gpio_cfg_default(PIN_TFT_EN);
+  nrf_gpio_cfg_default(PIN_TFT_CS);
+  nrf_gpio_cfg_default(PIN_TFT_DC);
+  nrf_gpio_cfg_default(PIN_TFT_MOSI);
+  nrf_gpio_cfg_default(PIN_TFT_RST);
+
+  nrf_gpio_cfg_default(PIN_SPI_MISO);
+  nrf_gpio_cfg_default(PIN_SPI_MOSI);
+  nrf_gpio_cfg_default(PIN_SPI_SCK);
+
+  resetOptionalPin(PIN_SPI1_MISO);
+  nrf_gpio_cfg_default(PIN_SPI1_MOSI);
+  nrf_gpio_cfg_default(PIN_SPI1_SCK);
+
+  nrf_gpio_cfg_default(PIN_GPS_EN);
+  nrf_gpio_cfg_default(PIN_GPS_RESET);
+  nrf_gpio_cfg_default(PIN_GPS_PPS);
+  nrf_gpio_cfg_default(PIN_GPS_RX);
+  nrf_gpio_cfg_default(PIN_GPS_TX);
+
+  nrf_gpio_cfg_default(SENSOR_POWER_CTRL_PIN);
+  nrf_gpio_cfg_default(SENSOR_RST_PIN);
+  nrf_gpio_cfg_default(SENSOR_INT);
+  nrf_gpio_cfg_default(PIN_BOARD_SDA);
+  nrf_gpio_cfg_default(PIN_BOARD_SCL);
+
+  nrf_gpio_cfg_default(RADIOCORE_FEM_EN);
+  nrf_gpio_cfg_default(RADIOCORE_VFEM_CTRL);
+}

--- a/variants/heltec_rc52/variant.cpp
+++ b/variants/heltec_rc52/variant.cpp
@@ -48,9 +48,7 @@ void variant_shutdown()
   digitalWrite(RADIOCORE_FEM_EN, LOW);
   digitalWrite(RADIOCORE_VFEM_CTRL, LOW);
   digitalWrite(PIN_ADC_CTRL, !ADC_CTRL_ENABLED);
-#ifdef PIN_BUZZER
-  digitalWrite(PIN_BUZZER, LOW);
-#endif
+
   digitalWrite(PIN_TFT_BL, !PIN_TFT_BL_ACTIVE);
   digitalWrite(PIN_TFT_EN, !PIN_TFT_EN_ACTIVE);
 
@@ -64,7 +62,6 @@ void variant_shutdown()
   nrf_gpio_cfg_default(PIN_TFT_EN);
   nrf_gpio_cfg_default(PIN_TFT_CS);
   nrf_gpio_cfg_default(PIN_TFT_DC);
-  nrf_gpio_cfg_default(PIN_TFT_MOSI);
   nrf_gpio_cfg_default(PIN_TFT_RST);
 
   nrf_gpio_cfg_default(PIN_SPI_MISO);

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -53,8 +53,8 @@ extern "C" {
 #define SENSOR_RST_PIN (32 + 15)
 
 
-#define PIN_GPS_TX (0 + 8) // GPS TX toward MCU RX
-#define PIN_GPS_RX (0 + 7) // MCU TX toward GPS RX
+#define PIN_GPS_TX (0 + 8)
+#define PIN_GPS_RX (0 + 7)
 #define PIN_GPS_EN (32 + 9)
 #define PIN_GPS_PPS (32 + 1)
 #define PIN_GPS_RESET (32 + 6)

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -42,13 +42,11 @@ extern "C" {
 #define PWRMGT_LPCOMP_REFSEL 1
 
 #define WIRE_INTERFACES_COUNT 1
-// Default board-package I2C pins.
-#define PIN_WIRE_SDA (0 + 6)
-#define PIN_WIRE_SCL (0 + 29)
 
-// External connector I2C used by MeshCore sensors/rotary input.
 #define PIN_BOARD_SDA (32 + 11) // P1.11
 #define PIN_BOARD_SCL (0 + 2)   // P0.02
+#define PIN_WIRE_SDA PIN_BOARD_SDA
+#define PIN_WIRE_SCL PIN_BOARD_SCL
 #define SENSOR_POWER_CTRL_PIN (0 + 12)
 #define SENSOR_POWER_ON HIGH
 #define SENSOR_INT (0 + 20)

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -1,0 +1,101 @@
+#ifndef _VARIANT_HELTEC_RC52_
+#define _VARIANT_HELTEC_RC52_
+
+#define VARIANT_MCK (64000000ul)
+#define USE_LFXO
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HARD_VERSION_ADDR    (0xED000 + 7 * 4096 - 16 - 1)
+#define HT_LICENSE_ADDR      (0xED000 + 7 * 4096 - 16)
+#define HT_LICENSE_ADDR_BASE (0xED000 + 6 * 4096)
+
+#define PINS_COUNT         (48)
+#define NUM_DIGITAL_PINS   (48)
+#define NUM_ANALOG_INPUTS  (1)
+#define NUM_ANALOG_OUTPUTS (0)
+
+#define PIN_LED1     (-1)
+#define PIN_NEOPIXEL (-1)
+#define NEOPIXEL_NUM 0
+#define LED_BUILTIN  PIN_LED1
+#define LED_BLUE     PIN_LED1
+#define LED_STATE_ON 1
+
+#define PIN_BUTTON1      (32 + 10) // P1.10, external pull-up, active low
+#define PIN_BUTTON_USER  PIN_BUTTON1
+#define PIN_USER_BTN     PIN_BUTTON1
+
+#define ADC_RESOLUTION 14
+#define PIN_VBAT_READ (0 + 31)
+#define PIN_ADC_CTRL (0 + 4)
+#define ADC_CTRL_ENABLED HIGH
+#define ADC_MULTIPLIER 4.9F
+#define MV_LSB (3000.0F / 4096.0F)
+
+#define PWRMGT_VOLTAGE_BOOTLOCK 3300
+#define PWRMGT_LPCOMP_AIN 7
+#define PWRMGT_LPCOMP_REFSEL 1
+
+#define WIRE_INTERFACES_COUNT 1
+// Default board-package I2C pins.
+#define PIN_WIRE_SDA (0 + 6)
+#define PIN_WIRE_SCL (0 + 29)
+
+// External connector I2C used by MeshCore sensors/rotary input.
+#define PIN_BOARD_SDA (32 + 11) // P1.11
+#define PIN_BOARD_SCL (0 + 2)   // P0.02
+#define SENSOR_POWER_CTRL_PIN (0 + 12)
+#define SENSOR_POWER_ON HIGH
+#define SENSOR_INT (0 + 20)
+#define SENSOR_RST_PIN (32 + 15)
+
+
+#define PIN_GPS_TX (0 + 8) // GPS TX toward MCU RX
+#define PIN_GPS_RX (0 + 7) // MCU TX toward GPS RX
+#define PIN_GPS_EN (32 + 9)
+#define PIN_GPS_PPS (32 + 1)
+#define PIN_GPS_RESET (32 + 6)
+#define PIN_GPS_EN_ACTIVE HIGH
+#define PIN_GPS_RESET_ACTIVE LOW
+#define GPS_BAUD_RATE 9600
+#define GPS_THREAD_INTERVAL 50
+#define PERIPHERAL_WARMUP_MS 100
+
+#define PIN_SERIAL1_RX PIN_GPS_RX
+#define PIN_SERIAL1_TX PIN_GPS_TX
+
+#define PIN_TFT_CS        (32 + 4)
+#define PIN_TFT_RST       (0 + 10)
+#define PIN_TFT_DC        (0 + 28)
+#define PIN_TFT_SCL       (0 + 30)
+#define PIN_TFT_SDA       (32 + 2)
+#define PIN_TFT_EN        (32 + 13)
+#define PIN_TFT_EN_ACTIVE LOW
+#define PIN_TFT_BL        (0 + 9)
+#define PIN_TFT_BL_ACTIVE HIGH
+#define SPI_FREQUENCY 8000000
+
+#define RADIOCORE_FEM_EN    (0 + 26)
+#define RADIOCORE_VFEM_CTRL (0 + 16)
+
+#define SPI_INTERFACES_COUNT 2
+#define SPI_32MHZ_INTERFACE 1
+
+#define PIN_SPI_MISO (0 + 14)
+#define PIN_SPI_MOSI (0 + 22)
+#define PIN_SPI_SCK  (0 + 25)
+
+#define PIN_SPI1_MISO (-1)
+#define PIN_SPI1_MOSI PIN_TFT_SDA
+#define PIN_SPI1_SCK  PIN_TFT_SCL
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds Heltec RC52 support as a new nRF52840 board target for MeshCore.
It introduces the heltec_rc52 board definition, variant files, and PlatformIO environments for the core RC52 firmware matrix: repeater, room server, companion radio over BLE/USB, and KISS modem, with display and without-display variants where applicable.
The RC52 display path uses the shared NV3001B driver with injected SPI1 support for the nRF52 display bus. The default NV3001B ESP32 hardware SPI behavior remains unchanged for existing boards.