### PR TITLE
Increase LilyGo T-Beam SX1276 channels from 8 to 40

### DIFF
--- a/variants/lilygo_tbeam_SX1276/platformio.ini
+++ b/variants/lilygo_tbeam_SX1276/platformio.ini
@@ -45,7 +45,7 @@ build_flags =
   ${LilyGo_TBeam_SX1276.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=160
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
 ;  -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=128


### PR DESCRIPTION
This PR increases the maximum group channels limit from `8` to `40` for the LilyGo T-Beam SX1276 companion radio firmware.

A user reported they could only add 8 channels.

They have tested the firmware I compiled with this patch and confirmed it works.