### PR TITLE
Fix missing PREAMBLE_DETECTED IRQ flag for all radio wrappers

### DIFF
--- a/src/helpers/radiolib/CustomLLCC68.h
+++ b/src/helpers/radiolib/CustomLLCC68.h
@@ -2,9 +2,6 @@
 
 #include <RadioLib.h>
 
-#define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
-#define SX126X_IRQ_PREAMBLE_DETECTED           0x04
-
 class CustomLLCC68 : public LLCC68 {
   public:
     CustomLLCC68(Module *mod) : LLCC68(mod) { }
@@ -78,9 +75,14 @@ class CustomLLCC68 : public LLCC68 {
     return true;  // success
   }
 
+    int16_t startReceive() override {
+      // include the PREAMBLE_DETECTED irq bit in reported flags
+      return LLCC68::startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    }
+
     bool isReceiving() {
       uint16_t irq = getIrqFlags();
-      bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
+      bool detected = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID) || (irq & RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
 

--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -35,6 +35,11 @@ class CustomLR1110 : public LR1110 {
 
     bool getRxBoostedGainMode() const { return _rx_boosted; }
 
+    int16_t startReceive() override {
+      // include the PREAMBLE_DETECTED irq bit in reported flags
+      return LR1110::startReceive(RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    }
+
     bool isReceiving() {
       uint32_t irq = getIrqStatus();
       bool preamble = irq & RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED;      // bit 4

--- a/src/helpers/radiolib/CustomSTM32WLx.h
+++ b/src/helpers/radiolib/CustomSTM32WLx.h
@@ -2,16 +2,18 @@
 
 #include <RadioLib.h>
 
-#define SX126X_IRQ_HEADER_VALID                     0b0000010000  //  4     4     valid LoRa header received
-#define SX126X_IRQ_PREAMBLE_DETECTED           0x04
-
 class CustomSTM32WLx : public STM32WLx {
   public:
     CustomSTM32WLx(STM32WLx_Module *mod) : STM32WLx(mod) { }
 
+    int16_t startReceive() override {
+      // include the PREAMBLE_DETECTED irq bit in reported flags
+      return STM32WLx::startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    }
+
     bool isReceiving() {
       uint16_t irq = getIrqFlags();
-      bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
+      bool detected = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID) || (irq & RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
 };

--- a/src/helpers/radiolib/CustomSX1262.h
+++ b/src/helpers/radiolib/CustomSX1262.h
@@ -100,6 +100,11 @@ class CustomSX1262 : public SX1262 {
       return true;  // success
     }
 
+    int16_t startReceive() override {
+      // include the PREAMBLE_DETECTED irq bit in reported flags
+      return SX1262::startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    }
+
     bool isReceiving() {
       uint32_t irq = getIrqFlags();
       bool preamble = irq & RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED; // bit 2

--- a/src/helpers/radiolib/CustomSX1268.h
+++ b/src/helpers/radiolib/CustomSX1268.h
@@ -2,9 +2,6 @@
 
 #include <RadioLib.h>
 
-#define SX126X_IRQ_HEADER_VALID                0b0000010000  //  4     4     valid LoRa header received
-#define SX126X_IRQ_PREAMBLE_DETECTED           0x04
-
 class CustomSX1268 : public SX1268 {
   public:
     CustomSX1268(Module *mod) : SX1268(mod) { }
@@ -78,9 +75,14 @@ class CustomSX1268 : public SX1268 {
       return true;  // success
     }
 
+    int16_t startReceive() override {
+      // include the PREAMBLE_DETECTED irq bit in reported flags
+      return SX1268::startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+    }
+
     bool isReceiving() {
       uint16_t irq = getIrqFlags();
-      bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
+      bool detected = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID) || (irq & RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
 


### PR DESCRIPTION
This PR adds the ``*_PREAMBLE_DETECTED`` IRQ flag to the receive mode IRQ flags for all relevant radio wrappers.