### PR TITLE
Clarify hashtag privacy and group sender identity

### DIFF
--- a/docs/companion_protocol.md
+++ b/docs/companion_protocol.md
@@ -440,6 +440,8 @@ Byte 0: 0x14
     - Uses a secret key derived from the channel name
     - It is the first 16 bytes of `sha256("#test")`
     - For example hashtag channel `#test` has the key: `9cd8fcf22a47333b591d96a2b848b73f`
+    - Traffic is encrypted on air, but anyone who knows or guesses the channel
+      name can derive the key. Hashtag channels should not be treated as private.
     - Used as a topic based public group chat, separate from the default public channel
 3. **Private Channels**
     - Uses a randomly generated 16-byte secret key

--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -236,6 +236,9 @@ txt_type
 
 The plaintext contained in the ciphertext matches the format described in [plain text message](#plain-text-message). Specifically, it consists of a four byte timestamp, a flags byte, and the message. The flags byte will generally be `0x00` because it is a "plain text message". The message will be of the form `<sender name>: <message body>` (eg., `user123: I'm on my way`).
 
+The sender name is unverified message text. Group messages contain no sender
+signature, so any channel-key holder can choose any sender name.
+
 # Group datagram
 
 | Field        | Size (bytes)    | Description                                  |


### PR DESCRIPTION
## Summary

- clarify that hashtag-channel encryption does not provide privacy when the name is guessable
- clarify that group sender names are unsigned and selectable by any channel-key holder

## Verification

- `git diff --check`

Closes #3044