### PR TITLE
nRF52840 "start ota" Failure Recovery

### DIFF
--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -396,7 +396,8 @@ bool NRF52Board::startOTAUpdate(const char *id, char reply[]) {
   Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
   Bluefruit.configPrphConn(92, BLE_GAP_EVENT_LENGTH_MIN, 16, 16);
 
-  Bluefruit.begin(1, 0);
+  if (!Bluefruit.begin(1, 0)) return false;
+
   // Set max power. Accepted values are: -40, -30, -20, -16, -12, -8, -4, 0, 4
   Bluefruit.setTxPower(4);
   // Set the BLE device name


### PR DESCRIPTION
If Bluefruit.begin fails, BLE OTA mode won't actually start and the board might require a reboot to reattempt. 

PR code tested on Xiao nRF52840 under normal conditions; OTA still working as expected.


Fixes:
- Bluefruit.begin returns false in NRF52Board.startOTAUpdate if OTA mode fails to start. User is notified of the fault through existing error message in CommonCLI and can reattempt "start ota" command.