### PR TITLE
Add charging indicator to companion_radio battery icon

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -145,7 +145,10 @@ class HomeScreen : public UIScreen {
     // keeping the fill bar itself clean and uninterrupted
     bool charging = board.isExternalPowered();
     if (charging) {
-      const uint8_t* symbol = (batteryPercentage < 100) ? charging_icon : plug_icon;
+      // There's no charge-complete signal on most boards, so "full" is a high
+      // voltage band rather than an exact 100% (a real pack rarely reads 4.2V).
+      const int BATT_FULL_PCT = 95;
+      const uint8_t* symbol = (batteryPercentage >= BATT_FULL_PCT) ? plug_icon : charging_icon;
       display.setColor(UIColor::title_txt);
       display.drawXbm(iconX - 9, iconY + 1, symbol, 8, 8);
     }

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -141,11 +141,21 @@ class HomeScreen : public UIScreen {
     int fillWidth = (batteryPercentage * (iconWidth - 4)) / 100;
     display.fillRect(iconX + 2, iconY + 2, fillWidth, iconHeight - 4);
 
-    // show muted icon if buzzer is muted
+    // while charging, show a bolt (or a plug once full) just left of the battery,
+    // keeping the fill bar itself clean and uninterrupted
+    bool charging = board.isExternalPowered();
+    if (charging) {
+      const uint8_t* symbol = (batteryPercentage < 100) ? charging_icon : plug_icon;
+      display.setColor(UIColor::title_txt);
+      display.drawXbm(iconX - 9, iconY + 1, symbol, 8, 8);
+    }
+
+    // show muted icon if buzzer is muted (shifted further left when the charging
+    // icon already occupies the slot immediately left of the battery)
 #ifdef PIN_BUZZER
     if (_task->isBuzzerQuiet()) {
       display.setColor(UIColor::warning_txt);
-      display.drawXbm(iconX - 9, iconY + 1, muted_icon, 8, 8);
+      display.drawXbm(iconX - (charging ? 18 : 9), iconY + 1, muted_icon, 8, 8);
     }
 #endif
   }

--- a/examples/companion_radio/ui-new/icons.h
+++ b/examples/companion_radio/ui-new/icons.h
@@ -120,3 +120,13 @@ static const uint8_t advert_icon[] = {
 static const uint8_t muted_icon[] = {
   0x20, 0x6a, 0xea, 0xe4, 0xe4, 0xea, 0x6a, 0x20
 };
+
+// small lightning bolt, 8x8px, shown next to the battery icon while charging
+static const uint8_t charging_icon[] = {
+  0x18, 0x30, 0x60, 0xFC, 0x18, 0x30, 0x60, 0xC0
+};
+
+// small power plug, 8x8px, shown next to the battery icon once fully charged
+static const uint8_t plug_icon[] = {
+  0x24, 0x24, 0x7E, 0x7E, 0x7E, 0x3C, 0x18, 0x18
+};


### PR DESCRIPTION

<img width="3024" height="4032" alt="IMG_7184" src="https://github.com/user-attachments/assets/2176b679-ac8f-411d-b1d9-e454b6c9e43d" />
<img width="3024" height="4032" alt="IMG_7185" src="https://github.com/user-attachments/assets/fa8d29bc-4af4-4e7d-b593-a4c01414270b" />
## What

Adds a charging indicator to the `ui-new` companion_radio home screen. While the device is externally powered, a small lightning-bolt icon is drawn just to the left of the battery indicator; once the battery reads full it switches to a plug icon.

The icon sits **beside** the battery rather than over it, so the fill bar stays clean and uninterrupted at every charge level. When a buzzer is present, the mute icon shifts one slot further left so the two never overlap.

## How

- Charging state comes from `board.isExternalPowered()`, so this works on any board that reports external power (e.g. the nRF52 VBUS-detect path).
- Two new 8x8 XBM icons (`charging_icon`, `plug_icon`) in `icons.h`.
- No display-driver changes; uses the existing `UIColor` theme (`title_txt`).

## Testing

Built and flashed on a Heltec T114 (`Heltec_t114_companion_radio_ble`). Bolt appears on USB power, plug appears at 100%, and the battery bar is unaffected when running on battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)