### PR TITLE
Attempt self-recovery on radio_init() failure

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -135,7 +135,16 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
+  }
 
   fast_rng.begin(radio_driver.getRngSeed());
 

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -78,8 +78,15 @@ void onGetStats(uint32_t* rx, uint32_t* tx, uint32_t* errors) {
 void setup() {
   board.begin();
 
-  if (!radio_init()) {
-    halt();
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
   }
 
   radio_driver.begin();

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -60,9 +60,15 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) {
-    MESH_DEBUG_PRINTLN("Radio init failed!");
-    halt();
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
   }
 
   fast_rng.begin(radio_driver.getRngSeed());

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -45,7 +45,16 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
+  }
 
   fast_rng.begin(radio_driver.getRngSeed());
 

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -564,7 +564,16 @@ void setup() {
   external_watchdog.begin();
 #endif
 
-  if (!radio_init()) { halt(); }
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
+  }
 
   fast_rng.begin(radio_driver.getRngSeed());
 

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -70,7 +70,16 @@ void setup() {
   }
 #endif
 
-  if (!radio_init()) { halt(); }
+  int radioinit_attempts = 0;
+  while (!radio_init()) {
+    ++radioinit_attempts;
+    MESH_DEBUG_PRINTLN("Radio init failed! (attempt %d)", radioinit_attempts);
+    if (radioinit_attempts >= 3) {
+      MESH_DEBUG_PRINTLN("Radio init failed 3x - rebooting");
+      board.reboot();
+    }
+    delay(500);
+  }
 
   fast_rng.begin(radio_driver.getRngSeed());
 


### PR DESCRIPTION
If radio_init() fails on the first attempt, currently the board will halt immediately with no feedback. This commit changes the behaviour to make 3 attempts to call the init. On a 4th failure, the board reboots to attempt to clear the fault and try again.

Debug logs are also written if MESH_DEBUG happens to be active.