### PR TITLE
Fix unnecessary IRQ clearing

### DIFF
--- a/src/helpers/radiolib/CustomSX1262.h
+++ b/src/helpers/radiolib/CustomSX1262.h
@@ -117,6 +117,12 @@ class CustomSX1262 : public SX1262 {
         _headerSeen = false;
         return false;
       }
+      if (!header && _headerSeen) {
+        // something cleared the header flag, reset our state.
+        _activityAt = 0; _headerSeen = false;
+        return false;
+      }
+
       if (header) {
         if (!_headerSeen) { _headerSeen = true; _activityAt = now; };
         if (now - _activityAt > _maxPayloadMillis) {


### PR DESCRIPTION
This PR fixes IRQ being cleared unnecessarily.

Previously IRQ flags were cleared unconditionally after the calculated timeout, however if we already received the packet then the IRQ has been cleared and there is no need to clear it again.