### PR TITLE
Fix Heltec T1 display blink/flicker

### DIFF
--- a/src/helpers/ui/ST7735Display.cpp
+++ b/src/helpers/ui/ST7735Display.cpp
@@ -490,7 +490,7 @@ void ST7735Display::_resetAndInit() {
 
     // run init commands
     displayInit(Rcmd1);
-#if defined(HELTEC_TRACKER_V2) || defined(HELTEC_T096)
+#if defined(HELTEC_TRACKER_V2) || defined(HELTEC_T096) || defined(HELTEC_T1)
     displayInit(Rcmd2green160x80);
     //uint8_t madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV |ST7735_MADCTL_BGR;//Adjust color to BGR
     //display.sendCommand(ST77XX_MADCTL, &madctl, 1);
@@ -580,20 +580,16 @@ uint16_t ST7735Display::getTextWidth(const char* str) {
 }
 
 void ST7735Display::endFrame() {
-  // blit the canvas buffer to LCD
+  // full-frame blit (row windows show as flicker)
   set_CS(LOW);
   _spi->beginTransaction(_spiSettings);
-  uint16_t x, y;
   uint16_t* pixels = (uint16_t *) ((TFT_eSprite *) sprite)->getPointer();
-  for (y = 0; y < 80; y++, pixels += 160) {
-    setAddrWindow(0, y, 160, 1);
+  setAddrWindow(0, 0, 160, 80);
 #ifdef ESP_PLATFORM
-    _spi->transferBytes((uint8_t *)pixels, NULL, 2 * 160);
+  _spi->transferBytes((uint8_t *)pixels, NULL, 2 * 160 * 80);
 #else
-    _spi->transfer(pixels, NULL, 2 * 160);
+  _spi->transfer(pixels, NULL, 2 * 160 * 80);
 #endif
-  }
-
   _spi->endTransaction();
   set_CS(HIGH);
 }


### PR DESCRIPTION
This PR addresses #3065 

Observed display blink/flicker on production version of Heltec T1. I saw a blink about every 5s on home and about every 1s on message previews.

## Change

- add `HELTEC_T1` to the `Rcmd2green160x80` gate
- blit the full 160x80 frame in one window and one SPI transfer

Pixel data and byte count are unchanged.

## Test

Tested on a production Heltec T1. No blink/flicker observable to my eye.

I don't have a T096 or Tracker V1/V2 to test on.

Firmware v1.16.0:

https://github.com/user-attachments/assets/70cd9492-c971-41a3-987d-75f6f4d90d36

After change (flicker on the top blue bar is not observable via human eye):

https://github.com/user-attachments/assets/839c5465-8f21-470c-9343-438045641b33


AI use: This change was created using AI but tested by me.