### PR TITLE
ThinkNode M6: button shutdown/wake for repeater and room server

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -30,9 +30,13 @@ static char ethernet_command[160];
 // For power saving
 unsigned long POWERSAVING_FIRSTSLEEP_SECS = 120; // The first sleep (if enabled) from boot
 
-#if defined(PIN_USER_BTN) && defined(_SEEED_SENSECAP_SOLAR_H_)
+#if defined(PIN_USER_BTN) && (defined(_SEEED_SENSECAP_SOLAR_H_) || defined(THINKNODE_M6))
 static unsigned long userBtnDownAt = 0;
+#if defined(THINKNODE_M6)
+#define USER_BTN_HOLD_OFF_MILLIS 5000   // matches Elecrow's stock firmware UX
+#else
 #define USER_BTN_HOLD_OFF_MILLIS 1500
+#endif
 #endif
 
 void setup() {
@@ -170,13 +174,22 @@ void loop() {
   }
 #endif
 
-#if defined(PIN_USER_BTN) && defined(_SEEED_SENSECAP_SOLAR_H_) && !defined(DISPLAY_CLASS)
-  // Hold the user button to power off the SenseCAP Solar repeater.
+#if defined(PIN_USER_BTN) && (defined(_SEEED_SENSECAP_SOLAR_H_) || defined(THINKNODE_M6)) && !defined(DISPLAY_CLASS)
+  // Hold the user button to power off the repeater.
   int btnState = digitalRead(PIN_USER_BTN);
   if (btnState == LOW) {
     if (userBtnDownAt == 0) {
       userBtnDownAt = millis();
     } else if ((unsigned long)(millis() - userBtnDownAt) >= USER_BTN_HOLD_OFF_MILLIS) {
+#if defined(THINKNODE_M6) && defined(PIN_LED_RED)
+      // blink the power LED a few times to confirm the hold was registered
+      for (int i = 0; i < 3; i++) {
+        digitalWrite(PIN_LED_RED, HIGH);
+        delay(150);
+        digitalWrite(PIN_LED_RED, LOW);
+        delay(150);
+      }
+#endif
       Serial.println("Powering off...");
       board.powerOff();  // does not return
     }

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -26,6 +26,11 @@ static char command[MAX_POST_TEXT_LEN+1];
 static char ethernet_command[MAX_POST_TEXT_LEN+1];
 #endif
 
+#if defined(PIN_USER_BTN) && defined(THINKNODE_M6)
+static unsigned long userBtnDownAt = 0;
+#define USER_BTN_HOLD_OFF_MILLIS 5000   // matches Elecrow's stock firmware UX
+#endif
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
@@ -145,6 +150,30 @@ void loop() {
     }
     ethernet_send_reply(reply);
     ethernet_command[0] = 0;
+  }
+#endif
+
+#if defined(PIN_USER_BTN) && defined(THINKNODE_M6) && !defined(DISPLAY_CLASS)
+  // Hold the user button to power off the room server.
+  int btnState = digitalRead(PIN_USER_BTN);
+  if (btnState == LOW) {
+    if (userBtnDownAt == 0) {
+      userBtnDownAt = millis();
+    } else if ((unsigned long)(millis() - userBtnDownAt) >= USER_BTN_HOLD_OFF_MILLIS) {
+#ifdef PIN_LED_RED
+      // blink the power LED a few times to confirm the hold was registered
+      for (int i = 0; i < 3; i++) {
+        digitalWrite(PIN_LED_RED, HIGH);
+        delay(150);
+        digitalWrite(PIN_LED_RED, LOW);
+        delay(150);
+      }
+#endif
+      Serial.println("Powering off...");
+      board.powerOff();  // does not return
+    }
+  } else {
+    userBtnDownAt = 0;
   }
 #endif
 

--- a/variants/thinknode_m6/ThinkNodeM6Board.cpp
+++ b/variants/thinknode_m6/ThinkNodeM6Board.cpp
@@ -15,6 +15,20 @@ void ThinkNodeM6Board::begin() {
   digitalWrite(P_LORA_TX_LED, LOW);
 #endif
 
+#ifdef PIN_USER_BTN
+  pinMode(PIN_USER_BTN, INPUT_PULLUP);
+#endif
+
+#ifdef PIN_LED_RED
+  // blink the power LED a few times to confirm power-on/wake
+  for (int i = 0; i < 3; i++) {
+    digitalWrite(PIN_LED_RED, HIGH);
+    delay(150);
+    digitalWrite(PIN_LED_RED, LOW);
+    delay(150);
+  }
+#endif
+
   delay(10); // give sx1262 some time to power up
 }
 

--- a/variants/thinknode_m6/ThinkNodeM6Board.h
+++ b/variants/thinknode_m6/ThinkNodeM6Board.h
@@ -43,6 +43,12 @@ public:
     digitalWrite(P_LORA_TX_LED, LOW);
     #endif
 
+    #ifdef PIN_USER_BTN
+    while (digitalRead(PIN_USER_BTN) == LOW);  // wait for release, avoid instant re-trigger
+    // keep pull-up enabled in system-off so the wake line doesn't float low
+    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(g_ADigitalPinMap[PIN_USER_BTN]), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
+    #endif
+
     // power off board
     NRF52Board::powerOff();
   }


### PR DESCRIPTION
## Problem

Fixes #2313. The ThinkNode M6's battery isn't physically accessible, so there was no way to power the device off to conserve battery when idle.

## Fix

Hold the Function Button for ~5s to power off (matches the timing of Elecrow's stock firmware for this board). A single press wakes it back up — the chip is fully halted in `SYSTEMOFF` while off, so there's no way to measure a hold duration on wake, only on the way down. The power LED (red) blinks 3 times on both shutdown and wake/boot as visual confirmation the action registered.

`ThinkNodeM6Board::powerOff()` now arms the button pin as a GPIO wake source (pull-up + `SENSE_LOW`) before entering `SYSTEMOFF` via `NRF52Board::powerOff()`.

## Scope

Limited to `simple_repeater` and `simple_room_server`. `companion_radio` is intentionally left out — #2837 is already moving that build's button handling into `UITask` (running headless via `NullDisplayDriver`), and duplicating a second independent button-read loop there would conflict with that approach rather than complement it.

## Testing

Built and flashed on a physical ThinkNode M6 repeater:
- Hold ~5s → LED blinks 3x, device powers off, mesh goes unreachable
- Single press → LED blinks 3x, device reboots, mesh reachable again
- Repeated the cycle multiple times, consistent behavior each time
- `ThinkNode_M6_room_server` and `SenseCap_Solar_repeater` (shared guard, unaffected) build clean; room_server not flash-tested on hardware