### PR TITLE
Add BME680 and BMP085 sensors to the firmware builds for ProMicro

### DIFF
--- a/variants/promicro/fix_bsec_lib.py
+++ b/variants/promicro/fix_bsec_lib.py
@@ -1,0 +1,15 @@
+Import('env')
+import os
+
+# Bosch has a goof in their PlatformIO packaging making linking fail.
+# The BSEC library's extra_script.py selects cortex-m4/libalgobsec.a (soft-float ABI).
+# nRF52840 compiles with -mfloat-abi=hard, requiring the fpv4-sp-d16-hard blob.
+# Workaround to prepend the hard-float path so the linker finds it before the 
+# soft-float one.
+bsec_hard = os.path.join(
+    env.subst('$PROJECT_DIR'),
+    '.pio', 'libdeps', env.subst('$PIOENV'),
+    'BSEC Software Library', 'src',
+    'cortex-m4', 'fpv4-sp-d16-hard'
+)
+env.Prepend(LIBPATH=[bsec_hard])

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -1,6 +1,8 @@
 [Promicro]
 extends = nrf52_base
 board = promicro_nrf52840
+extra_scripts = ${nrf52_base.extra_scripts}
+  post:variants/promicro/fix_bsec_lib.py
 build_flags = ${nrf52_base.build_flags}
   -I variants/promicro
   -D PROMICRO
@@ -20,6 +22,9 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_GPS=1
   -D ENV_INCLUDE_AHTX0=1
   -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_BMP085=1
+  -UENV_INCLUDE_BME680
+  -D ENV_INCLUDE_BME680_BSEC=1
   -D ENV_INCLUDE_BMP280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
@@ -33,7 +38,9 @@ lib_deps= ${nrf52_base.lib_deps}
   adafruit/Adafruit AHTX0 @ ^2.0.5
   adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit BMP280 Library@^2.6.8
+  adafruit/Adafruit BMP085 Library @ ^1.2.4
   stevemarple/MicroNMEA @ ^2.0.6
+  boschsensortec/BSEC Software Library @ ^1.8.1492
 
 [env:ProMicro_repeater]
 extends = Promicro


### PR DESCRIPTION
Added support for BMP085 and BME680 environment sensors for the ProMicro (Faketec) builds of MeshCore.