### PR TITLE
Add Lierda AM36 Pico (L-LRMAM36-FANN4-PK02) variant — ESP32-S3 + Semtech LR2021

### DIFF
--- a/variants/lierda_am36_pico/LierdaAM36Board.h
+++ b/variants/lierda_am36_pico/LierdaAM36Board.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+
+// Lierda AM36 Pico dev board (L-LRMAM36-FANN4-PK02).
+// The L-LRMAM36-FANN4 module pairs an ESP32-S3 with a Semtech LR2021.
+// Nothing exotic at the board level: USB-C power, no battery divider on the
+// dev board. The only LED is a hardwired 3V3 power indicator (no status LED).
+class LierdaAM36Board : public ESP32Board {
+public:
+  LierdaAM36Board() { }
+
+  void begin() {
+    ESP32Board::begin();
+#ifdef PIN_USER_BTN
+    pinMode(PIN_USER_BTN, INPUT_PULLUP);   // KEY, pressed = LOW
+#endif
+  }
+
+  const char* getManufacturerName() const override {
+    return "Lierda AM36 Pico";
+  }
+};

--- a/variants/lierda_am36_pico/README.md
+++ b/variants/lierda_am36_pico/README.md
@@ -1,0 +1,90 @@
+# MeshCore on the Lierda AM36 Pico (L-LRMAM36-FANN4-PK02)
+
+Community variant for the Lierda AM36 Pico evaluation board. The on-board
+L-LRMAM36-FANN4 module is an **ESP32-S3** (8MB flash / 8MB PSRAM) paired with a
+**Semtech LR2021** Generation-4 LoRa transceiver.
+
+> Status: **hardware-validated** (Jul 2026) against a live US915 MeshCore mesh:
+> radio init, noise floor sampling (~-119 dBm), BLE pairing with the iOS
+> companion app, flood + direct TX with interrupt-driven send-complete, and
+> two-way channel messaging through a third-party repeater
+> (SNR up 11.5 dB / down 13.0 dB, replies received at SNR 3.25 dB).
+> Requires the `CustomLR2021` radio classes from MeshCore PR #2944.
+
+## Hardware facts used by this variant
+
+| Signal | ESP32-S3 GPIO | Source | Verified |
+|---|---|---|---|
+| LR2021 SPI SCK | 40 | `esp32_lora_driver` Kconfig (`LIERDA_BOARD_LRMAM36_FANN4`) | yes (on air) |
+| LR2021 SPI MOSI | 41 | same | yes |
+| LR2021 SPI MISO | 42 | same | yes |
+| LR2021 NSS | 39 | same | yes |
+| LR2021 NRST | 38 | same | yes |
+| LR2021 BUSY | 17 | same | yes |
+| LR2021 IRQ | 21 - **wired to LR2021 DIO7** | Kconfig `LR20XX_DIO7_GPIO` | yes (TX-done + RX interrupts) |
+| KEY button | 4 (schematic net `GPIO4/KEY1`) | schematic | **not yet** - left disabled |
+
+The IRQ DIO matters: the Seeed Wio-LR2021 (which PR #2944 targets) uses DIO8,
+so this variant sets `-D LR2021_IRQ_DIO=7`. No external TCXO or RF-switch
+GPIOs exist on the MCU side - the module handles RF internally. The board's
+only LED is a hardwired 3V3 power indicator, so no `PIN_STATUS_LED` is defined.
+
+## Build
+
+1. Install VS Code + the PlatformIO extension.
+2. Get the source with the LR2021 driver:
+   ```bash
+   git clone https://github.com/meshcore-dev/MeshCore
+   cd MeshCore
+   git fetch origin pull/2944/head:lr2021
+   git checkout lr2021
+   ```
+   (Once PR #2944 is merged, plain `dev` works.)
+3. Copy this `lierda_am36_pico/` folder into `variants/`.
+   (PlatformIO auto-discovers `variants/*/platformio.ini`.)
+4. Radio parameters: builds inherit MeshCore's defaults; set your region's
+   frequency/BW/SF/CR from the companion app after first boot (settings are
+   persisted on the device), or override `LORA_*` flags in a
+   `platformio.local.ini` for your own builds. The module covers 863-930 MHz.
+5. Build:
+   ```bash
+   pio run -e Lierda_AM36_Pico_companion_radio_ble
+   ```
+   Other envs: `..._companion_radio_usb`, `..._repeater`.
+   Note: the iOS companion app connects over BLE only, so iPhone users want
+   the `_ble` build.
+
+## Flash
+
+1. Connect the Type-C port labelled **USB** (NOT the one labelled UART - that
+   goes to the CP2105 bridge). The USB port is the ESP32-S3's native
+   USB-JTAG/CDC and is what esptool talks to.
+2. ```bash
+   pio run -e Lierda_AM36_Pico_companion_radio_ble -t upload
+   ```
+3. If the port doesn't enumerate or upload fails to sync: hold **BOOT**, tap
+   **RST**, release **BOOT** (forces download mode), then retry the upload.
+4. Tap **RST** after flashing completes.
+
+## Verify
+
+- Serial console is on the same USB port
+  (`pio device monitor -e Lierda_AM36_Pico_companion_radio_ble`). Note the
+  ESP32-S3 re-enumerates USB on reset, so the monitor may need a restart after
+  tapping RST. A failed radio bring-up prints
+  `ERROR: LR2021 init failed: <code>` and halts (no BLE advertising).
+- **Attach the LoRa antenna before any TX.**
+- Pair from the MeshCore app over Bluetooth (default PIN `123456`, set via
+  `BLE_PIN_CODE`), set your region's radio parameters in the app, and send a
+  channel message or advert.
+
+## Known quirks / notes
+
+- SPI to the LR2021 sits on GPIO39-42, which are the S3's JTAG pins. That's
+  fine (flashing/debug uses USB-JTAG), just don't try external JTAG.
+- PSRAM is present but left disabled - MeshCore doesn't need it, and octal
+  PSRAM misconfiguration is a classic S3 boot-loop source.
+- The KEY button (schematic net `GPIO4/KEY1`) is left disabled until traced
+  on hardware; uncomment `PIN_USER_BTN` in `platformio.ini` once confirmed.
+- PR #2944's wrapper drops the radio to standby before every `startReceive()`
+  (LR2021 wedges if re-armed mid-RX) - don't "optimize" that away.

--- a/variants/lierda_am36_pico/README.md
+++ b/variants/lierda_am36_pico/README.md
@@ -4,11 +4,15 @@ Community variant for the Lierda AM36 Pico evaluation board. The on-board
 L-LRMAM36-FANN4 module is an **ESP32-S3** (8MB flash / 8MB PSRAM) paired with a
 **Semtech LR2021** Generation-4 LoRa transceiver.
 
-> Status: **hardware-validated** (Jul 2026) against a live US915 MeshCore mesh:
-> radio init, noise floor sampling (~-119 dBm), BLE pairing with the iOS
-> companion app, flood + direct TX with interrupt-driven send-complete, and
-> two-way channel messaging through a third-party repeater
-> (SNR up 11.5 dB / down 13.0 dB, replies received at SNR 3.25 dB).
+> Status: **hardware-validated** (Jul 2026) on a live mesh: radio init, noise
+> floor sampling (~-119 dBm), BLE pairing with the iOS companion app, flood +
+> direct TX with interrupt-driven send-complete, and two-way messaging with a
+> Heltec Tracker v2 (SX1262) peer - i.e. confirmed LR2021 <-> SX1262 interop -
+> at 927.875 MHz / BW 62.5 / SF9 / CR7, both nodes using muzi works 17 cm whip
+> antennas (replies at SNR 3.25 dB). Also received channel messages from six
+> third-party senders at 3-9 hops with full path reconstruction, and measured a
+> third-party repeater (not operated by the author) at
+> up 11.5 dB / down 13.0 dB.
 > Requires the `CustomLR2021` radio classes from MeshCore PR #2944.
 
 ## Hardware facts used by this variant

--- a/variants/lierda_am36_pico/platformio.ini
+++ b/variants/lierda_am36_pico/platformio.ini
@@ -1,0 +1,100 @@
+; Lierda AM36 Pico (L-LRMAM36-FANN4-PK02)
+; Module: L-LRMAM36-FANN4 = ESP32-S3 (8MB flash / 8MB PSRAM) + Semtech LR2021
+;
+; Pin map taken from lierda-iot/esp32_lora_driver Kconfig defaults for
+; LIERDA_BOARD_LRMAM36_FANN4 and verified against the board schematic
+; (L-LRMAM36-FANN4-PK02_SCH_V01.pdf):
+;   LR2021 SPI:  SCK=40  MOSI=41  MISO=42  NSS=39
+;   LR2021 ctrl: NRST=38 BUSY=17  IRQ=GPIO21 (wired to LR2021 DIO7!)
+;   KEY button:  GPIO4 per schematic net label (not yet verified on hardware)
+;   LED1:        hardwired 3V3 power indicator (not GPIO-controllable)
+;
+; Requires the CustomLR2021 radio classes from MeshCore PR #2944.
+; Flash via the board's "USB" Type-C port (ESP32-S3 native USB), not "UART".
+
+[Lierda_AM36_Pico]
+extends = esp32_base
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.flash_size = 8MB
+board_upload.flash_size = 8MB
+build_flags = ${esp32_base.build_flags}
+  -I variants/lierda_am36_pico
+  -D LIERDA_AM36_PICO
+  ; --- native-USB serial console on the "USB" Type-C port ---
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  ; --- LR2021 wiring (ESP32-S3 GPIO numbers) ---
+  -D P_LORA_SCLK=40
+  -D P_LORA_MOSI=41
+  -D P_LORA_MISO=42
+  -D P_LORA_NSS=39
+  -D P_LORA_RESET=38
+  -D P_LORA_BUSY=17
+  -D P_LORA_DIO_1=21
+  ; host IRQ line is routed from the LR2021's DIO7 (PR default is DIO8 for
+  ; the Seeed Wio-LR2021 - this override is essential on the Lierda module)
+  -D LR2021_IRQ_DIO=7
+  ; --- radio driver selection ---
+  -D RADIO_CLASS=CustomLR2021
+  -D WRAPPER_CLASS=CustomLR2021Wrapper
+  -D LORA_TX_POWER=22
+  ; --- board UI ---
+  ; KEY button is believed to be GPIO4 (schematic net GPIO4/KEY1) but has not
+  ; been traced/verified on hardware yet; uncomment once confirmed:
+  ; -D PIN_USER_BTN=4
+  ; The board's only LED (LED1) is a hardwired 3V3 power indicator - there is
+  ; no GPIO-controllable status LED, so PIN_STATUS_LED is not defined.
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lierda_am36_pico>
+  +<helpers/ui/MomentaryButton.cpp>
+lib_deps =
+  ${esp32_base.lib_deps}
+
+; ---------------- Companion (phone app over the USB port) ----------------
+[env:Lierda_AM36_Pico_companion_radio_usb]
+extends = Lierda_AM36_Pico
+build_flags =
+  ${Lierda_AM36_Pico.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Lierda_AM36_Pico.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${Lierda_AM36_Pico.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; ---------------- Companion over BLE ----------------
+[env:Lierda_AM36_Pico_companion_radio_ble]
+extends = Lierda_AM36_Pico
+build_flags =
+  ${Lierda_AM36_Pico.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${Lierda_AM36_Pico.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${Lierda_AM36_Pico.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; ---------------- Repeater ----------------
+[env:Lierda_AM36_Pico_repeater]
+extends = Lierda_AM36_Pico
+build_src_filter = ${Lierda_AM36_Pico.build_src_filter}
+  +<../examples/simple_repeater/*.cpp>
+build_flags =
+  ${Lierda_AM36_Pico.build_flags}
+  -D ADVERT_NAME='"AM36 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+lib_deps =
+  ${Lierda_AM36_Pico.lib_deps}
+  ${esp32_ota.lib_deps}

--- a/variants/lierda_am36_pico/target.cpp
+++ b/variants/lierda_am36_pico/target.cpp
@@ -1,0 +1,34 @@
+#include <Arduino.h>
+#include "target.h"
+
+#include <helpers/ArduinoHelpers.h>
+
+LierdaAM36Board board;
+
+// LR2021 on dedicated SPI pins (module-internal wiring; see platformio.ini)
+static SPIClass spi;
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;   // no-op stub - dev board has no on-board sensors
+
+#ifdef PIN_USER_BTN
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);  // KEY, active low
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+  // CustomLR2021::std_init() routes the IRQ to DIO7 (LR2021_IRQ_DIO),
+  // brings up SPI on P_LORA_SCLK/MISO/MOSI, and applies LORA_* defaults.
+  return radio.std_init(&spi);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/lierda_am36_pico/target.h
+++ b/variants/lierda_am36_pico/target.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/ESP32Board.h>
+// CustomLR2021 / CustomLR2021Wrapper come from MeshCore PR #2944
+#include <helpers/radiolib/CustomLR2021Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include <helpers/ui/MomentaryButton.h>
+#include "LierdaAM36Board.h"
+
+extern LierdaAM36Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+#ifdef PIN_USER_BTN
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
> **Depends on #2944** (adds the `CustomLR2021` / `CustomLR2021Wrapper` radio
> classes). CI will fail on `dev` until that PR merges — opening as a draft and
> will mark ready for review once it lands. The variant builds cleanly against
> the #2944 branch today.

Adds a variant for the **Lierda AM36 Pico** evaluation board
(`L-LRMAM36-FANN4-PK02`). The board carries Lierda's L-LRMAM36-FANN4 module:
an **ESP32-S3** (8 MB flash / 8 MB PSRAM) paired with a **Semtech LR2021**
Gen-4 LoRa transceiver. As far as I can tell this is the first ESP32-S3 +
LR2021 target in MeshCore.

Headline test result: **confirmed LR2021 ↔ SX1262 interoperability** on a live
mesh — messages received from six distinct third-party senders at up to
**9 hops**, with full path reconstruction. Details below.

## Environments added

- `Lierda_AM36_Pico_companion_radio_usb`
- `Lierda_AM36_Pico_companion_radio_ble`
- `Lierda_AM36_Pico_repeater`

Names follow the existing suffix convention, so `build.sh` target discovery
picks them up with no changes needed to the release workflows.

## Pin map and provenance

| Signal | ESP32-S3 GPIO |
|---|---|
| LR2021 SPI SCK | 40 |
| LR2021 SPI MOSI | 41 |
| LR2021 SPI MISO | 42 |
| LR2021 NSS | 39 |
| LR2021 NRST | 38 |
| LR2021 BUSY | 17 |
| LR2021 IRQ | 21 — routed from LR2021 **DIO7** |

Values are taken from Lierda's own ESP-IDF driver,
[`lierda-iot/esp32_lora_driver`](https://github.com/lierda-iot/esp32_lora_driver),
specifically the `default N if LIERDA_BOARD_LRMAM36_FANN4` entries in its
`Kconfig` (`LR2021_SPI_CLK`, `LR2021_SPI_MOSI`, `LR2021_SPI_MISO`,
`LR2021_NSS_GPIO`, `LR2021_NRST_GPIO`, `LR2021_BUSY_GPIO`, `LR20XX_DIO7_GPIO`),
cross-checked against the board schematic shipped in
[`lierda-iot/esp32_lora_samples`](https://github.com/lierda-iot/esp32_lora_samples)
under `docs/L-LRMAM36-FANN4-PK02_SCH_V01.pdf`.

**Important difference from the Seeed Wio-LR2021 kit in #2944:** the host IRQ on
this module comes from the LR2021's **DIO7**, not DIO8. The variant therefore
sets `-D LR2021_IRQ_DIO=7`. Without this override the radio initialises and
transmits, but send-completion and receive interrupts never fire.

## Board specifics

- **No status LED.** The board's only LED is a hardwired 3V3 power indicator
  (`V3P3 → 620R → LED1 → GND` on the schematic), so `PIN_STATUS_LED` is
  deliberately not defined.
- **KEY button left disabled.** The schematic net label suggests GPIO4, but I
  haven't traced it on hardware, so `PIN_USER_BTN` is commented out with a note
  rather than shipped unverified. Happy to enable it in a follow-up.
- **PSRAM not enabled** — MeshCore doesn't need it, and it avoids octal-PSRAM
  boot-loop pitfalls on the S3.
- **SPI lands on GPIO39–42**, which are the S3's JTAG pins. Harmless here since
  flashing and debug both go over native USB-JTAG.
- **Two USB-C ports.** The one silkscreened `USB` is the ESP32-S3's native USB
  and is what esptool talks to; `UART` goes to an on-board CP2105 bridge and is
  not used for flashing. Noted in the variant README since it's an easy trap.
- Radio parameters are left at MeshCore's inherited defaults — no region
  hardcoding — since the companion app sets and persists them at runtime.

## Hardware testing

Tested on a physical board, not just built.

**Test setup**
- DUT: Lierda AM36 Pico, `Lierda_AM36_Pico_companion_radio_ble` build
- Peer: **Heltec Tracker v2** running MeshCore (`heltec_tracker_v2`,
  `CustomSX1262`) — so this exercises **LR2021 ↔ SX1262 interop**
- Antennas: [muzi ᴡᴏʀᴋꜱ 17 cm whip](https://muzi.works/products/whip-antenna-17cm)
  (SMA male, manufacturer-measured SWR 1.3) on **both** nodes
- Radio params: 927.875 MHz / BW 62.5 kHz / SF9 / CR7, `LORA_TX_POWER=22`
- Client: MeshCore **iOS** app over BLE
- Base: v1.16.0-era `dev` + #2944, RadioLib 7.7.1, espressif32 @ 6.11.0

**Transmit**
- Radio init clean; noise floor sampling steady at ~−119/−120 dBm with dips to
  −108…−115 dBm on channel activity (i.e. real ADC reads, not a stuck register)
- Flood (`type=4, route=F`) and direct (`type=9, route=D`) TX both confirmed,
  logged via the success path of `isSendComplete()` — i.e. interrupt-driven
  completion, with no `outbound packed send timed out` warnings. This is what
  validates the DIO7 IRQ routing.
- `LORA_TX_POWER=22` exercised on air with no instability observed

**Receive**
- **Two-way messaging with the SX1262 peer**: channel message sent from the
  AM36 Pico was received by the Heltec Tracker v2, and the reply was received
  back on the AM36 Pico at **SNR 3.25 dB**. Some traffic between the two nodes
  routed through repeaters that I operate.
- **Channel messages received from six distinct third-party senders** over a
  ~1 hour window — operators and hardware I have no involvement with.
- **Multi-hop reception confirmed across a wide range of path lengths**: packets
  decoded at 3, 4, 5, 6, 7 and **9 hops**, plus one direct (0-hop) reception.
- **Path reconstruction verified**: the app resolved complete repeater chains
  for received messages (a 4-hop path across four intermediate repeaters and a
  5-hop path across five, at 2 bytes per hop), confirming the radio works
  correctly with MeshCore's path/routing handling and not just point-to-point
  links.
- Discovered and measured a repeater I do **not** operate at
  **↑11.5 dB / ↓13.0 dB** — that same repeater subsequently appeared as the
  final hop in a received message's path. Own transmissions were also seen
  returned as repeats ("Heard 2 Repeats").

**Companion / host interface**
- BLE pairing and companion protocol confirmed with the iOS app
  (`App meshcore-flutter connected`); device reports as `Lierda AM36 Pico`
- Radio parameter changes pushed from the app applied and persisted correctly
  (`CMD_SET_RADIO_PARAMS` accepted)

## Not covered

- KEY button GPIO (see above)
- Repeater and USB-companion environments compile but were not field-tested;
  only the BLE companion build was run on air
- FLRC and the LR2021's other Gen-4 modes — plain LoRa only, matching current
  MeshCore behaviour
- No range testing; all RF testing was short-range, though received traffic
  traversed multi-hop paths across the local mesh