### PR TITLE
LR1110: fix startReceive() passing an IRQ bit as the RX timeout 🤖🤖

### DIFF
--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -36,8 +36,15 @@ class CustomLR1110 : public LR1110 {
     bool getRxBoostedGainMode() const { return _rx_boosted; }
 
     int16_t startReceive() override {
-      // include the PREAMBLE_DETECTED irq bit in reported flags
-      return LR1110::startReceive(RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+      // include the PREAMBLE_DETECTED irq bit in reported flags.
+      //
+      // NOTE: the first argument is the RX *timeout*, not an IRQ mask. Passing
+      // RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED (1<<4 = 16) here armed the receiver
+      // with a 16-tick timeout -- at the LR11x0's 30.52us tick that is a ~488us
+      // receive window, so the radio dropped out of RX before any packet could
+      // arrive and the node never received anything. It must stay RX_TIMEOUT_INF
+      // (continuous RX), which is what LR11x0::startReceive() itself passes.
+      return LR1110::startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
     }
 
     bool isReceiving() {

--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -37,13 +37,6 @@ class CustomLR1110 : public LR1110 {
 
     int16_t startReceive() override {
       // include the PREAMBLE_DETECTED irq bit in reported flags.
-      //
-      // NOTE: the first argument is the RX *timeout*, not an IRQ mask. Passing
-      // RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED (1<<4 = 16) here armed the receiver
-      // with a 16-tick timeout -- at the LR11x0's 30.52us tick that is a ~488us
-      // receive window, so the radio dropped out of RX before any packet could
-      // arrive and the node never received anything. It must stay RX_TIMEOUT_INF
-      // (continuous RX), which is what LR11x0::startReceive() itself passes.
       return LR1110::startReceive(RADIOLIB_LR11X0_RX_TIMEOUT_INF, RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED), RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
     }
 


### PR DESCRIPTION
Fixes #3075

`CustomLR1110::startReceive()` passes `RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED` as RadioLib's first argument, which is the RX **timeout**, not an IRQ mask. The constant is `1 << 4` = `16`, so the receiver is armed with a 16-tick timeout — ~488 µs at the LR11x0's 30.52 µs tick. The radio drops out of RX before a packet can arrive, so LR1110 boards on `dev` transmit normally but never receive anything.

This passes `RADIOLIB_LR11X0_RX_TIMEOUT_INF` instead, which is what `LR11x0::startReceive()` itself uses. The `PREAMBLE_DETECTED` flag that ea5d7c8b set out to add is untouched — it lives in the second argument, where it already was — so the intent of that commit is preserved.

The sibling wrappers added in the same series (`CustomLLCC68`, `CustomSTM32WLx`, `CustomSX1262`, `CustomSX1268`) all pass `*_RX_TIMEOUT_INF` correctly; LR1110 was the only one passing an IRQ bit.

### Testing

Two SenseCAP T1000-E units at 910.525 MHz / BW 62.5 / SF 8 / CR 5.

Before: both transmit (`tx_air_secs` rising) but `rx_air_secs`, `recv_errors`, `last_rssi` all stay at 0 — the receiver never opens long enough to log even a failed preamble.

Applying the fix to only one unit isolates the cause. The fixed repeater began receiving immediately while the unfixed companion stayed deaf:

```
repeater  RX delta: {'recv': 1, 'flood_rx': 1}   last_rssi -29, last_snr 17.0, noise_floor -104
companion RX delta: {'recv': 0, 'flood_rx': 0}
```

With both fixed, traffic flows in each direction (`-29`/`-31` dBm, SNR ~15), verified with adverts and public-channel messages.

### Build coverage

Builds clean on `dev` for `t1000e_repeater`, `ThinkNode_M7_repeater`, `ThinkNode_M3_repeater`, `wio_wm1110_repeater`.

`Minewsemi_me25ls01_repeater` does not build, but that is pre-existing on `dev` and unrelated to this change — `examples/simple_repeater/UITask.cpp` fails on `user_btn` / `BUTTON_EVENT_*` not being declared for that variant. It fails identically on a clean `dev` checkout without this commit.

### Caveat

Behaviour confirmed on T1000-E hardware only. The other `CustomLR1110` variants (`wio_wm1110`, `minewsemi_me25ls01`, `thinknode_m3/m7/m9`) are affected by inspection — same override, same constant — not by testing.
