### PR TITLE
Add Challenger RP2040 LoRa variant

### DIFF
--- a/variants/challenger_rp2040_lora/ChallengerRP2040LoraBoard.cpp
+++ b/variants/challenger_rp2040_lora/ChallengerRP2040LoraBoard.cpp
@@ -1,0 +1,13 @@
+#include "ChallengerRP2040LoraBoard.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+void ChallengerRP2040LoraBoard::begin() {
+  startup_reason = BD_STARTUP_NORMAL;
+
+  pinMode(PIN_LED, OUTPUT);
+
+  Wire.begin();
+  delay(10); // give sx1276 some time to power up
+}

--- a/variants/challenger_rp2040_lora/ChallengerRP2040LoraBoard.h
+++ b/variants/challenger_rp2040_lora/ChallengerRP2040LoraBoard.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+
+#define PIN_LED 24
+
+class ChallengerRP2040LoraBoard : public mesh::MainBoard {
+protected:
+  uint8_t startup_reason;
+
+public:
+  void begin();
+  uint8_t getStartupReason() const override { return startup_reason; }
+  void onBeforeTransmit() override {
+    digitalWrite(PIN_LED, HIGH); // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(PIN_LED, LOW); // turn TX LED off
+  }
+  const char *getManufacturerName() const override { return "Challenger RP2040 Lora"; }
+  void reboot() override { rp2040.reboot(); }
+
+  // Unsupported functions
+  bool startOTAUpdate(const char *id, char reply[]) override { return false; };
+  uint16_t getBattMilliVolts() override { return 0; };
+};

--- a/variants/challenger_rp2040_lora/platformio.ini
+++ b/variants/challenger_rp2040_lora/platformio.ini
@@ -1,0 +1,78 @@
+[challenger_rp2040_lora]
+extends = rp2040_base
+board = pico
+board_build.core = earlephilhower
+board_build.filesystem_size = 0.5m
+build_flags = ${rp2040_base.build_flags}
+  -I variants/challenger_rp2040_lora
+  -D P_LORA_DIO_0=14
+  -D P_LORA_DIO_1=15
+  -D P_LORA_NSS=9
+  -D P_LORA_RESET=13
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=12
+  -D P_LORA_MOSI=11
+  -D LORA_TX_POWER=20
+  -D RADIO_CLASS=CustomSX1276
+  -D WRAPPER_CLASS=CustomSX1276Wrapper
+build_src_filter = ${rp2040_base.build_src_filter}
+  +<challenger_rp2040_loraBoard.cpp>
+  +<../variants/challenger_rp2040_lora>
+lib_deps = ${rp2040_base.lib_deps}
+
+[env:challenger_rp2040_lora_repeater]
+extends = challenger_rp2040_lora
+build_flags = ${challenger_rp2040_lora.build_flags}
+  -D ADVERT_NAME='"challenger_rp2040_lora Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${challenger_rp2040_lora.build_src_filter}
+  +<../examples/simple_repeater>
+
+[env:challenger_rp2040_lora_room_server]
+extends = challenger_rp2040_lora
+build_flags = ${challenger_rp2040_lora.build_flags}
+  -D ADVERT_NAME='"Test Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${challenger_rp2040_lora.build_src_filter}
+  +<../examples/simple_room_server>
+
+[env:challenger_rp2040_lora_companion_radio_usb]
+extends = challenger_rp2040_lora
+build_flags = ${challenger_rp2040_lora.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D ENABLE_USB_INTERFACE
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${challenger_rp2040_lora.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps = ${challenger_rp2040_lora.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
+
+[env:challenger_rp2040_lora_terminal_chat]
+extends = challenger_rp2040_lora
+build_flags = ${challenger_rp2040_lora.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${challenger_rp2040_lora.build_src_filter}
+  +<../examples/simple_secure_chat/main.cpp>
+lib_deps = ${challenger_rp2040_lora.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:challenger_rp2040_lora_kiss_modem]
+extends = challenger_rp2040_lora
+build_src_filter = ${challenger_rp2040_lora.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/challenger_rp2040_lora/target.cpp
+++ b/variants/challenger_rp2040_lora/target.cpp
@@ -1,0 +1,25 @@
+#include "target.h"
+
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+ChallengerRP2040LoraBoard board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_0, P_LORA_RESET, P_LORA_DIO_1, SPI1);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&SPI1);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng); // create new random identity
+}

--- a/variants/challenger_rp2040_lora/target.h
+++ b/variants/challenger_rp2040_lora/target.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <ChallengerRP2040LoraBoard.h>
+#include <RadioLib.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include <helpers/radiolib/CustomSX1276Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+
+extern ChallengerRP2040LoraBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
This PR adds the [Challenger RP2040 LoRa](https://ilabs.se/product/challenger-rp2040-lora/) as a new variant.

The pinout of the board is pictured in the schematics appended to the end of this PR.

I have tested the `challenger_rp2040_lora_companion_radio_usb` firmware on two physical devices, and confirmed they can send messages to eachother.

The board does not have any way to measure battery voltage built in, despite having battery charging circuitry.

<img width="2199" height="1542" alt="image" src="https://github.com/user-attachments/assets/1d40be64-edb4-40c6-8373-bbdccd0b10e6" />
<img width="2199" height="1542" alt="image" src="https://github.com/user-attachments/assets/62657c37-879f-4fe3-b225-62fcffef9420" />
