### PR TITLE
fix: remove unused GPS pins and GPIO5 role conflict on M5Stack Unit C6L

### DIFF
--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -17,7 +17,6 @@ build_flags =
   -D PIN_BUZZER=11
   -D PIN_BOARD_SDA=16
   -D PIN_BOARD_SCL=17
-  -D SX126X_RXEN=5
   -D SX126X_DIO2_AS_RF_SWITCH=true
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
@@ -27,8 +26,6 @@ build_flags =
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
   -D DISABLE_WIFI_OTA=1
-  -D GPS_RX=4
-  -D GPS_TX=5
 build_src_filter = ${esp32c6_base.build_src_filter}
   +<../variants/m5stack_unit_c6l>
   +<UnitC6LBoard.cpp>


### PR DESCRIPTION
Summary
Removes 3 pin definitions from the M5Stack Unit C6L build config:

* `GPS_RX=4` / `GPS_TX=5`: Unit C6L has no GPS hardware, so these are dead definitions.
* `SX126X_RXEN=5`: shares GPIO5 with `GPS_TX=5` above. Note this was not itself dead —
  RadioLib's `setRfSwitchPins()`/`setRfSwitchState()` actively drives GPIO5 on every TX/RX
  transition, independent of `SX126X_DIO2_AS_RF_SWITCH=true` (which switches the antenna via
  the SX1262's internal DIO2, not an MCU GPIO). Removing this line leaves DIO2-based switching
  as the sole antenna switch mechanism on this board.

This is independent of the crash-loop fix in #3088 (TCXO/I2C/PI4IO/TX_LED). During bisection
of that issue, these 3 lines were tested both present and removed with no observed effect on
the crash loop either way, so they're split out here as a separate, unrelated cleanup rather
than bundled into that fix.

Testing

* `pio run -e M5Stack_Unit_C6L_companion_radio_usb` builds clean.
* TX/RX functionality verified on hardware after removing SX126X_RXEN: sent and
  received messages successfully round-trip against a second node. No functional
  regression observed. GPS_RX/GPS_TX removal has no functional impact (confirmed unused).
  
Related to #2229 (split out from #3088 during investigation).