### PR TITLE
Fix M5Stack Unit C6L kiss_modem env missing USB CDC flags

### DIFF
--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -109,5 +109,9 @@ lib_deps =
 
 [env:M5Stack_Unit_C6L_kiss_modem]
 extends = M5Stack_Unit_C6L
+build_flags = ${M5Stack_Unit_C6L.build_flags}
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+  -D ENABLE_USB_INTERFACE
 build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   +<../examples/kiss_modem/>


### PR DESCRIPTION
## Problem

`M5Stack_Unit_C6L_kiss_modem` env did not include the USB CDC build flags present in `M5Stack_Unit_C6L_companion_radio_usb`:

- `ARDUINO_USB_CDC_ON_BOOT=1`
- `ARDUINO_USB_MODE=1`
- `ENABLE_USB_INTERFACE`

On ESP32-C6, native USB serial requires these flags at boot. Without them, output routes to UART0, which has no physical connector on this board, making the KISS modem unresponsive over USB.

## Fix

Added the same three flags used in the companion_radio_usb env for this board.

## Testing

Hardware-verified on M5Stack Unit C6L. Built with `pio run -t upload -e M5Stack_Unit_C6L_kiss_modem`, confirmed device enumerates as `/dev/ttyACM0`, confirmed KISS modem operational via openhop_repeater.