### PR TITLE
ThinkNode M6: Remove QSPIFLASH=1 build flag to fix companion roles

### DIFF
--- a/variants/thinknode_m6/platformio.ini
+++ b/variants/thinknode_m6/platformio.ini
@@ -85,7 +85,6 @@ build_flags =
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
-  -D QSPIFLASH=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M6.build_src_filter}
@@ -107,7 +106,6 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
-  -D QSPIFLASH=1
   -D OFFLINE_QUEUE_SIZE=256
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300
   -D ENABLE_USB_INTERFACE


### PR DESCRIPTION
M6 doesn't have flash chip available, so companion roles fail to start.