### PR TITLE
Disable CAD on Companion Firmware until it's configurable

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -262,7 +262,7 @@ int MyMesh::getInterferenceThreshold() const {
   return 0; // disabled for now, until currentRSSI() problem is resolved
 }
 bool MyMesh::getCADEnabled() const {
-  return true; // hardware CAD before TX (no CLI toggle on companion; enabled by default)
+  return false; // hardware CAD before TX (disabled by default, until configurable)
 }
 
 int MyMesh::calcRxDelay(float score, uint32_t air_time) const {


### PR DESCRIPTION
This PR disables the recently added CAD check in companion firmware that's done just before a transmit, until we have the ability to configure it for more widespread testing.

@oltaco has fixed a bug where IRQ flags were not configured correctly, which already drastically improves collision avoidance.

There's been a lot of internal discussion, as well as in some GitHub issues here and there that some of the CAD parameters need to be configured or tuned based on the RF environment.

So, to avoid any side effects of CAD being forced enabled on all companions, with no way to turn it off, we will leave it disabled for the v1.17.0 release, with the intention of adding a way to turn it on in a future firmware release.

The repeater firmware still requires users to enable CAD via `set cad on`, and already defaults to off.