### PR TITLE
Fix X1 charge status LED always showing charged

### DIFF
--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -344,11 +344,7 @@ void UITask::userLedHandler() {
   static bool ext_powered = false, ext_charging = false;
   if (cur_time > next_pwr_check) {
     ext_powered = _board->isExternalPowered();
-    bool chrg = digitalRead(EXT_CHRG_DETECT) == LOW;
-  #ifdef EXT_CHRG_DONE
-    if (digitalRead(EXT_CHRG_DONE) == LOW) chrg = false;   // charge-done wins
-  #endif
-    ext_charging = ext_powered && chrg;
+    ext_charging = ext_powered && digitalRead(EXT_CHRG_DETECT) == LOW;
     next_pwr_check = cur_time + 1000;
   }
   if (ext_powered && _msgcount == 0) {

--- a/variants/meshtracker_x1/variant.cpp
+++ b/variants/meshtracker_x1/variant.cpp
@@ -63,7 +63,6 @@ void initVariant()
 {
   pinMode(BATTERY_PIN, INPUT);
   pinMode(EXT_CHRG_DETECT, INPUT_PULLUP);
-  pinMode(EXT_CHRG_DONE, INPUT_PULLUP);
   pinMode(EXT_PWR_DETECT, INPUT);
   pinMode(PIN_BUTTON1, INPUT_PULLDOWN);
 

--- a/variants/meshtracker_x1/variant.h
+++ b/variants/meshtracker_x1/variant.h
@@ -25,7 +25,8 @@
 #define ADC_MULTIPLIER          (2.0F)
 
 #define EXT_CHRG_DETECT         (35)            // P1.3, LOW while charging
-#define EXT_CHRG_DONE           (36)            // P1.4, LOW when charge complete
+// P1.4 is the charger's second status line, but it reads LOW regardless of
+// charge state on this board, so it is not used (Meshtastic leaves it out too)
 #define EXT_PWR_DETECT          (5)             // P0.5
 
 #define ADC_RESOLUTION          (14)


### PR DESCRIPTION
## Summary

Follow up to #3122, correcting the charge complete handling on the MeshTracker X1.

The charge status logic gives priority to the charger's second status line (P1.4) as a "done" signal, but on this board that pin reads low regardless of charge state, so the complete branch always wins and the LED sits on the charged colour from the moment it is plugged in.

Charge state now comes from P1.3 alone, which behaves correctly. P1.4 is left unused with a comment explaining why, the same choice Meshtastic makes in their X1 variant where the equivalent define is commented out.

## Testing

Verified on hardware across a full charge cycle: with this change the LED shows the charging animation while charging and switches to the charged colour when the charger terminates. Pin readings taken during charging confirm the cause, P1.3 reads low as expected while charging and P1.4 also reads low, which is what sends the merged code down the wrong branch. All four X1 environments build clean.
