### PR TITLE
Fix room message timestamps

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1100,7 +1100,27 @@ void MyMesh::handleCmdFrame(size_t len) {
         result = sendCommandData(*recipient, msg_timestamp, attempt, text, est_timeout);
         expected_ack = 0; // no Ack expected
       } else {
+        const uint32_t app_timestamp = msg_timestamp;
+        const bool is_room_message = recipient->type == ADV_TYPE_ROOM;
+        uint8_t message_fingerprint[MAX_HASH_SIZE];
+        if (is_room_message) {
+          mesh::Utils::sha256(message_fingerprint, sizeof(message_fingerprint),
+                              recipient->id.pub_key, PUB_KEY_SIZE,
+                              (const uint8_t*)text, strlen(text));
+          if (!room_message_timestamps.find(message_fingerprint, app_timestamp,
+                                            &msg_timestamp)) {
+            // Older room servers compare posts with login and keep-alive
+            // timestamps, which already come from this monotonic clock.
+            msg_timestamp = getRTCClock()->getCurrentTimeUnique();
+          }
+        }
         result = sendMessage(*recipient, msg_timestamp, attempt, text, expected_ack, est_timeout);
+        if (result != MSG_SEND_FAILED && is_room_message) {
+          // Preserve the translated timestamp across application retries so
+          // the room can ACK the retry without storing a duplicate post.
+          room_message_timestamps.remember(message_fingerprint, app_timestamp,
+                                           msg_timestamp);
+        }
       }
       // TODO: add expected ACK to table
       if (result == MSG_SEND_FAILED) {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -30,6 +30,7 @@
 #include <helpers/ArduinoHelpers.h>
 #include <helpers/BaseSerialInterface.h>
 #include <helpers/IdentityStore.h>
+#include <helpers/MessageTimestampCache.h>
 #include <helpers/SimpleMeshTables.h>
 #include <helpers/StaticPoolPacketManager.h>
 #include <target.h>
@@ -61,6 +62,10 @@
 
 #ifndef OFFLINE_QUEUE_SIZE
 #define OFFLINE_QUEUE_SIZE 16
+#endif
+
+#ifndef ROOM_MESSAGE_TIMESTAMP_CACHE_SIZE
+#define ROOM_MESSAGE_TIMESTAMP_CACHE_SIZE 16
 #endif
 
 #ifndef BLE_NAME_PREFIX
@@ -253,6 +258,7 @@ private:
   #define EXPECTED_ACK_TABLE_SIZE 8
   AckTableEntry expected_ack_table[EXPECTED_ACK_TABLE_SIZE]; // circular table
   int next_ack_idx;
+  mesh::MessageTimestampCache<ROOM_MESSAGE_TIMESTAMP_CACHE_SIZE> room_message_timestamps;
 
   #define ADVERT_PATH_TABLE_SIZE   16
   AdvertPath advert_paths[ADVERT_PATH_TABLE_SIZE]; // circular table

--- a/src/helpers/MessageTimestampCache.h
+++ b/src/helpers/MessageTimestampCache.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace mesh {
+
+// Maps an application message identity to the timestamp used on air. This
+// lets retransmissions keep the same timestamp even when the sender needs to
+// translate timestamps between clock sources.
+template <size_t ENTRY_COUNT>
+class MessageTimestampCache {
+public:
+  MessageTimestampCache() { clear(); }
+
+  bool find(const uint8_t fingerprint[MAX_HASH_SIZE], uint32_t source_timestamp,
+            uint32_t* mapped_timestamp = NULL) const {
+    if (fingerprint == NULL) return false;
+
+    for (size_t i = 0; i < ENTRY_COUNT; i++) {
+      const Entry& entry = entries_[i];
+      if (entry.valid && entry.source_timestamp == source_timestamp
+          && memcmp(entry.fingerprint, fingerprint, MAX_HASH_SIZE) == 0) {
+        if (mapped_timestamp != NULL) {
+          *mapped_timestamp = entry.mapped_timestamp;
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool remember(const uint8_t fingerprint[MAX_HASH_SIZE], uint32_t source_timestamp,
+                uint32_t mapped_timestamp) {
+    if (fingerprint == NULL) return false;
+
+    for (size_t i = 0; i < ENTRY_COUNT; i++) {
+      Entry& entry = entries_[i];
+      if (entry.valid && entry.source_timestamp == source_timestamp
+          && memcmp(entry.fingerprint, fingerprint, MAX_HASH_SIZE) == 0) {
+        entry.mapped_timestamp = mapped_timestamp;
+        return true;
+      }
+    }
+
+    Entry& entry = entries_[next_entry_];
+    memcpy(entry.fingerprint, fingerprint, MAX_HASH_SIZE);
+    entry.source_timestamp = source_timestamp;
+    entry.mapped_timestamp = mapped_timestamp;
+    entry.valid = true;
+    next_entry_ = (next_entry_ + 1) % ENTRY_COUNT;
+    return true;
+  }
+
+  void clear() {
+    memset(entries_, 0, sizeof(entries_));
+    next_entry_ = 0;
+  }
+
+private:
+  static_assert(ENTRY_COUNT > 0, "MessageTimestampCache needs at least one entry");
+
+  struct Entry {
+    uint8_t fingerprint[MAX_HASH_SIZE];
+    uint32_t source_timestamp;
+    uint32_t mapped_timestamp;
+    bool valid;
+  };
+
+  Entry entries_[ENTRY_COUNT];
+  size_t next_entry_;
+};
+
+} // namespace mesh

--- a/test/test_message_timestamp_cache/test_message_timestamp_cache.cpp
+++ b/test/test_message_timestamp_cache/test_message_timestamp_cache.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+
+#include <helpers/MessageTimestampCache.h>
+
+static void makeFingerprint(uint8_t fingerprint[MAX_HASH_SIZE], uint8_t value) {
+  memset(fingerprint, value, MAX_HASH_SIZE);
+}
+
+TEST(MessageTimestampCache, ReturnsMappedTimestampForRetry) {
+  mesh::MessageTimestampCache<4> cache;
+  uint8_t fingerprint[MAX_HASH_SIZE];
+  makeFingerprint(fingerprint, 0x11);
+
+  ASSERT_TRUE(cache.remember(fingerprint, 100U, 500U));
+
+  uint32_t mapped = 0;
+  EXPECT_TRUE(cache.find(fingerprint, 100U, &mapped));
+  EXPECT_EQ(500U, mapped);
+}
+
+TEST(MessageTimestampCache, DistinguishesLogicalMessages) {
+  mesh::MessageTimestampCache<4> cache;
+  uint8_t first[MAX_HASH_SIZE];
+  uint8_t second[MAX_HASH_SIZE];
+  makeFingerprint(first, 0x21);
+  makeFingerprint(second, 0x22);
+
+  ASSERT_TRUE(cache.remember(first, 100U, 500U));
+
+  EXPECT_FALSE(cache.find(first, 101U));
+  EXPECT_FALSE(cache.find(second, 100U));
+}
+
+TEST(MessageTimestampCache, UpdatesAnExistingMapping) {
+  mesh::MessageTimestampCache<2> cache;
+  uint8_t fingerprint[MAX_HASH_SIZE];
+  makeFingerprint(fingerprint, 0x33);
+
+  ASSERT_TRUE(cache.remember(fingerprint, 7U, 70U));
+  ASSERT_TRUE(cache.remember(fingerprint, 7U, 71U));
+
+  uint32_t mapped = 0;
+  EXPECT_TRUE(cache.find(fingerprint, 7U, &mapped));
+  EXPECT_EQ(71U, mapped);
+}
+
+TEST(MessageTimestampCache, ReplacesOldestEntryWhenFull) {
+  mesh::MessageTimestampCache<2> cache;
+  uint8_t first[MAX_HASH_SIZE];
+  uint8_t second[MAX_HASH_SIZE];
+  uint8_t third[MAX_HASH_SIZE];
+  makeFingerprint(first, 0x41);
+  makeFingerprint(second, 0x42);
+  makeFingerprint(third, 0x43);
+
+  ASSERT_TRUE(cache.remember(first, 1U, 101U));
+  ASSERT_TRUE(cache.remember(second, 2U, 102U));
+  ASSERT_TRUE(cache.remember(third, 3U, 103U));
+
+  EXPECT_FALSE(cache.find(first, 1U));
+  EXPECT_TRUE(cache.find(second, 2U));
+  EXPECT_TRUE(cache.find(third, 3U));
+}
+
+TEST(MessageTimestampCache, RejectsNullFingerprint) {
+  mesh::MessageTimestampCache<2> cache;
+
+  EXPECT_FALSE(cache.remember(NULL, 1U, 2U));
+  EXPECT_FALSE(cache.find(NULL, 1U));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- translate direct room-message timestamps onto the companion's monotonic RTC clock
- preserve that translated timestamp across application retries
- add a bounded timestamp-mapping cache with native regression tests

The current implementation uses one per-client `last_timestamp` replay watermark for login requests, keep-alives, CLI traffic, and room posts. Current upstream `dev` still uses this shared watermark, as do deployed room servers built from earlier versions of the same implementation.

This PR changes only companion firmware so those deployed room servers do not need to be updated.

## Root cause

The companion already generates login and keep-alive timestamps from its own RTC. For ordinary text messages, however, it forwards the timestamp supplied by the phone app. Those timestamps can come from different clock states even though the packets are sent by the same companion.

With a shared room-server replay watermark, this can produce the following sequence:

1. The companion logs in using a timestamp from its RTC, advancing `client->last_timestamp` on the room server.
2. The app submits a room message carrying an older phone-supplied timestamp.
3. The room server compares that timestamp with the login timestamp and rejects the message as stale.
4. No ACK is sent, so the app remains at `Sending (attempt 2/3)` and subsequent attempts fail the same comparison.

The fix gives a new room message a timestamp from the companion's monotonic RTC, matching the clock source already used for login and keep-alive traffic.

## Why retries keep the same timestamp

The logical message timestamp and the MeshCore packet hash serve different purposes:

- The room server uses the timestamp to decide whether a post is new or a retry. It must remain stable across attempts.
- Mesh duplicate detection hashes the encrypted payload. Each app retry changes the `attempt` byte inside that payload, so attempts 1, 2, and 3 have different packet hashes even when their logical timestamp is unchanged.

This gives the intended behavior:

- If the original message is lost, the retry is newer than the room's watermark, so the room stores it and ACKs it.
- If the room received the original but its ACK was lost, the equal timestamp identifies the retry; the room sends another ACK without storing a duplicate post.
- Assigning a fresh timestamp to every retry would instead make the room store the same text more than once.

Lower-level retransmission of the exact same encrypted packet is separate from the app-level attempt mechanism addressed here.

## Impact and scope

Companions can send messages to room servers using the shared replay watermark without requiring a room-server firmware update. Peer messages, channel messages, and room-server firmware are unchanged.

## Validation

- `pio test -e native` — 30 tests passed
- `pio run -e Heltec_v3_companion_radio_ble` — passed
- `pio run -e RAK_WisMesh_Tag_companion_radio_ble` — passed
