### PR TITLE
Allow for build-time macro to disable the bluetooth LED

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -129,6 +129,12 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   char charpin[20];
   snprintf(charpin, sizeof(charpin), "%lu", (unsigned long)pin_code);
   
+  #ifdef DISABLE_BLE_LED  \\ use variant platformio.ini build_flags macro: -D DISABLE_BLE_LED
+    Bluefruit.autoConnLed(false);  \\ false removes the automatic control of the LED by the Bluefruit library
+  #else
+    Bluefruit.autoConnLed(true);  \\ true leaves the default automatic control of the LED by the Bluefruit library
+  #endif
+  
   // If we want to control BLE LED ourselves, uncomment this:
   // Bluefruit.autoConnLed(false);
   Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);


### PR DESCRIPTION
Several variants use one or another method to disable the bluetooth LED that is grabbed by the Adafruit Bluefruit library by default. This allows for a single build flag macro to control the behavior (default behavior if not defined, not auto-controlled by Bluefruit if defined). This would open up for future cases where this could be controlled via a CLI command or by an application.

Does not change behavior if the flag is not defined.