### PR TITLE
Add board hooks for periodic work and variant telemetry

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -249,6 +249,11 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
     }
     sensors.querySensors(perm_mask, telemetry);
 
+    // Board-specific telemetry (boards can override queryBoardTelemetry in their Board class)
+    if (perm_mask & TELEM_PERM_ENVIRONMENT) {
+      board.queryBoardTelemetry(telemetry);
+    }
+
 	// This default temperature will be overridden by external sensors (if any)
     float temperature = board.getMCUTemperature();
     if(!isnan(temperature)) { // Supported boards with built-in temperature sensor. ESP32-C3 may return NAN

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -249,6 +249,11 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
     }
     sensors.querySensors(perm_mask, telemetry);
 
+    // board specific telemetry -- target specific
+    if (perm_mask & TELEM_PERM_ENVIRONMENT) {
+      board.queryBoardTelemetry(telemetry);
+    }
+
 	// This default temperature will be overridden by external sensors (if any)
     float temperature = board.getMCUTemperature();
     if(!isnan(temperature)) { // Supported boards with built-in temperature sensor. ESP32-C3 may return NAN

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -157,6 +157,8 @@ void loop() {
     command[0] = 0;  // reset command buffer
   }
 
+  board.tick();        // Feed watchdog and perform board-specific tasks
+
 #ifdef ETHERNET_ENABLED
   ethernet_loop_maintain();
   if (ethernet_read_line(ethernet_command, sizeof(ethernet_command))) {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -157,6 +157,8 @@ void loop() {
     command[0] = 0;  // reset command buffer
   }
 
+  board.tick();   // let the board feed its watchdog, run periodic housekeeping
+
 #ifdef ETHERNET_ENABLED
   ethernet_loop_maintain();
   if (ethernet_read_line(ethernet_command, sizeof(ethernet_command))) {

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -145,6 +145,8 @@ void loop() {
     command[0] = 0;  // reset command buffer
   }
 
+  board.tick();        // Feed watchdog and perform board-specific tasks
+
   the_mesh.loop();
   sensors.loop();
 #ifdef DISPLAY_CLASS

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -145,6 +145,8 @@ void loop() {
     command[0] = 0;  // reset command buffer
   }
 
+  board.tick();   // let the board feed its watchdog, run periodic housekeeping
+
   the_mesh.loop();
   sensors.loop();
 #ifdef DISPLAY_CLASS

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -37,6 +37,8 @@
 #define BRIDGE_DEBUG_PRINTLN(...) {}
 #endif
 
+class CayenneLPP;
+
 namespace mesh {
 
 #define  BD_STARTUP_NORMAL     0  // getStartupReason() codes
@@ -75,6 +77,12 @@ public:
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }
   virtual uint8_t getShutdownReason() const { return 0; }
   virtual const char* getShutdownReasonString(uint8_t reason) { return "Not available"; }
+
+  // Custom board commands and telemetry (boards can override these)
+  virtual void tick() {}
+  virtual bool getCustomGetter(const char* getCommand, char* reply, uint32_t maxlen) { return false; }
+  virtual const char* setCustomSetter(const char* setCommand) { return nullptr; }
+  virtual bool queryBoardTelemetry(CayenneLPP& telemetry) { return false; }
 };
 
 /**

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -37,6 +37,8 @@
 #define BRIDGE_DEBUG_PRINTLN(...) {}
 #endif
 
+class CayenneLPP;
+
 namespace mesh {
 
 #define  BD_STARTUP_NORMAL     0  // getStartupReason() codes
@@ -74,6 +76,13 @@ public:
   virtual const char* getShutdownReasonString(uint8_t reason) { return "Not available"; }
 
   virtual bool handleCommand(const char* command, uint32_t sender_timestamp, char* reply) { return false; }
+
+  // Called from the example main loops. Lets a board feed its watchdog and
+  // run periodic housekeeping. Default no-op.
+  virtual void tick() { /* no op */ }
+
+  // Lets a board contribute its own telemetry channels. Default no-op.
+  virtual bool queryBoardTelemetry(CayenneLPP& telemetry) { return false; }
 };
 
 /**

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -740,6 +740,13 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     savePrefs();
     strcpy(reply, "OK");
 #endif
+  } else if (memcmp(config, "board.", 6) == 0) {
+    const char* result = _board->setCustomSetter(&config[6]);
+    if (result != nullptr) {
+      strcpy(reply, result);
+    } else {
+      strcpy(reply, "Error: unknown board command");
+    }
   } else if (memcmp(config, "adc.multiplier ", 15) == 0) {
     _prefs->adc_multiplier = atof(&config[15]);
     if (_board->setAdcMultiplier(_prefs->adc_multiplier)) {
@@ -914,6 +921,14 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   #else
       strcpy(reply, "Error: unsupported");
   #endif
+  } else if (memcmp(config, "board.", 6) == 0) {
+    char res[100];
+    memset(res, 0, sizeof(res));
+    if (_board->getCustomGetter(&config[6], res, sizeof(res))) {
+      strcpy(reply, res);
+    } else {
+      strcpy(reply, "Error: unknown board command");
+    }
   } else if (memcmp(config, "adc.multiplier", 14) == 0) {
     float adc_mult = _board->getAdcMultiplier();
     if (adc_mult == 0.0f) {


### PR DESCRIPTION
Needed for #3130 (Inhero MR2 hardware support).

This adds two no-op virtual methods to `mesh::MainBoard` so a board variant
can do these things without core changes:

- `tick()` — called from the simple_repeater and simple_sensor main loops.
  Lets a board feed its watchdog and run periodic housekeeping. Default: no-op.
- `queryBoardTelemetry(CayenneLPP&)` — simple_repeater asks the board for
  additional telemetry channels (gated by `TELEM_PERM_ENVIRONMENT`).
  Default: no-op.

An earlier revision of this PR also carried a `get board.*` / `set board.*`
CLI forwarding hook. That is covered on `dev` by `MainBoard::handleCommand()`
(47b0b7b3) since then, so it is gone from this PR; the variant uses the
existing hook.

Both defaults are no-ops, so every existing variant builds and behaves
unchanged. Verified locally: `RAK_4631_repeater` and `Heltec_v3_repeater`
(both from the PR build-check matrix) build green on this branch.

The Inhero MR2 variant that uses these hooks follows in #3132.
