### PR TITLE
Add other Adafruit environment sensors to Pro Micro (Faketec) hardware variant builds

### DIFF
--- a/variants/promicro/fix_bsec_lib.py
+++ b/variants/promicro/fix_bsec_lib.py
@@ -1,0 +1,15 @@
+Import('env')
+import os
+
+# Bosch has a goof in their PlatformIO packaging making linking fail.
+# The BSEC library's extra_script.py selects cortex-m4/libalgobsec.a (soft-float ABI).
+# nRF52840 compiles with -mfloat-abi=hard, requiring the fpv4-sp-d16-hard blob.
+# Workaround to prepend the hard-float path so the linker finds it before the 
+# soft-float one.
+bsec_hard = os.path.join(
+    env.subst('$PROJECT_DIR'),
+    '.pio', 'libdeps', env.subst('$PIOENV'),
+    'BSEC Software Library', 'src',
+    'cortex-m4', 'fpv4-sp-d16-hard'
+)
+env.Prepend(LIBPATH=[bsec_hard])

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -1,6 +1,8 @@
 [Promicro]
 extends = nrf52_base
 board = promicro_nrf52840
+extra_scripts = ${nrf52_base.extra_scripts}
+  post:variants/promicro/fix_bsec_lib.py
 build_flags = ${nrf52_base.build_flags}
   -I variants/promicro
   -D PROMICRO
@@ -21,6 +23,9 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_AHTX0=1
   -D ENV_INCLUDE_BME280=1
   -D ENV_INCLUDE_BMP280=1
+  -UENV_INCLUDE_BME680
+  -D ENV_INCLUDE_BME680_BSEC=1
+  -D ENV_INCLUDE_BMP085
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
 build_src_filter = ${nrf52_base.build_src_filter}
@@ -34,6 +39,8 @@ lib_deps= ${nrf52_base.lib_deps}
   adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit BMP280 Library@^2.6.8
   stevemarple/MicroNMEA @ ^2.0.6
+  boschsensortec/BSEC Software Library @ ^1.8.1492
+  adafruit/Adafruit BMP085 Library @ ^1.2.4
 
 [env:ProMicro_repeater]
 extends = Promicro


### PR DESCRIPTION
NRF Pro Micro is a pretty popular board for building repeaters and companions, and since it already includes BME280 and BMP280 sensors why not add other ones, that are included in, for example, RAK4631 builds?

Uses #2634 code for BME680 part by @NickDunklee because his library integration works better than the standard Adafruit library, at least on the similar hardware.