### PR TITLE
Add QSPIFlash support for Seeed MeshTracker X1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -94,7 +94,7 @@ build_flags = ${arduino_base.build_flags}
   -D USE_CC310_HW_CRYPTO=1
 lib_deps =
   ${arduino_base.lib_deps}
-  https://github.com/oltaco/CustomLFS#0.2.2
+  https://github.com/oltaco/CustomLFS#0.2.3
 ; ----------------- RP2040 ---------------------
 
 [rp2040_base]

--- a/variants/meshtracker_x1/platformio.ini
+++ b/variants/meshtracker_x1/platformio.ini
@@ -75,6 +75,7 @@ board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
 board_upload.maximum_size = 708608
 build_flags = ${MeshTracker_X1.build_flags}
   -I examples/companion_radio/ui-orig
+  -D QSPIFLASH=1
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
 ;  -D MESH_PACKET_LOGGING=1
@@ -103,6 +104,7 @@ board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
 board_upload.maximum_size = 708608
 build_flags = ${MeshTracker_X1.build_flags}
   -I examples/companion_radio/ui-orig
+  -D QSPIFLASH=1
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456

--- a/variants/meshtracker_x1/variant.cpp
+++ b/variants/meshtracker_x1/variant.cpp
@@ -70,6 +70,9 @@ void initVariant()
   pinMode(PIN_3V3_EN, OUTPUT);
   digitalWrite(PIN_3V3_EN, HIGH);
 
+  pinMode(PIN_FLASH_EN, OUTPUT);
+  digitalWrite(PIN_FLASH_EN, HIGH);
+
   pinMode(PIN_BAT_ADC_EN, OUTPUT);
   digitalWrite(PIN_BAT_ADC_EN, HIGH);
 

--- a/variants/meshtracker_x1/variant.h
+++ b/variants/meshtracker_x1/variant.h
@@ -122,3 +122,17 @@
 // Buzzer
 
 #define BUZZER_PIN              (25)            // P0.25, pwm output
+
+////////////////////////////////////////////////////////////////////////////////
+// QSPI Flash
+
+#define PIN_FLASH_EN           (15)             // P0.15 (Flash power enable)
+
+#define PIN_QSPI_SCK           (19)             // P0.19
+#define PIN_QSPI_CS            (20)             // P0.20
+#define PIN_QSPI_IO0           (21)             // P0.21
+#define PIN_QSPI_IO1           (22)             // P0.22
+#define PIN_QSPI_IO2           (23)             // P0.23
+#define PIN_QSPI_IO3           (32)             // P1.00
+
+#define EXTERNAL_FLASH_DEVICES  GD25Q64C


### PR DESCRIPTION
Added QPSIFlash support for Seeed MeshTracker X1 and bumped CustomLFS version for the required new flash chip support.