### PR TITLE
Station G3 logging repeater variant actually logs

### DIFF
--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -110,7 +110,7 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
-;  -D MESH_PACKET_LOGGING=1
+  -D MESH_PACKET_LOGGING=1
   -D SX126X_RX_BOOSTED_GAIN=1
 ;  https://wiki.uniteng.com/en/meshtastic/station-g2#impact-of-lora-node-dense-areashigh-noise-environments-on-rf-performance
 ;  -D MESH_DEBUG=1

--- a/variants/station_g3_esp32/platformio.ini
+++ b/variants/station_g3_esp32/platformio.ini
@@ -71,7 +71,7 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
-;  -D MESH_PACKET_LOGGING=1
+  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Station_G3_ESP32.build_src_filter}
   +<../examples/simple_repeater>


### PR DESCRIPTION
Fixes the platformio.ini defition for the Station_G3_ESP32_logging_repeater so the MESH_PACKET_LOGGING parameter is not commented out.