### PR TITLE
Fix SH1106 OLED address detection on T-Beam Supreme sub-variants

### DIFF
--- a/src/helpers/ui/SH1106Display.cpp
+++ b/src/helpers/ui/SH1106Display.cpp
@@ -23,9 +23,25 @@ ColorVal UIColor::corp_blue = SH110X_WHITE;
 bool SH1106Display::begin()
 {
   // Wire must already be initialised by board.begin() before this is called.
-  // Boards with non-standard SH1106 addresses should define DISPLAY_ADDRESS
-  // in their variant/platformio configuration.
-  return i2c_probe(Wire, DISPLAY_ADDRESS) && display.begin(DISPLAY_ADDRESS, true);
+  // Some boards (e.g. T-Beam S3 Supreme) ship a magnetometer whose configurable
+  // I2C address collides with the OLED's, at either 0x3C or 0x3D depending on
+  // hardware revision. Probe both candidates and disambiguate via the
+  // magnetometer's chip-ID register: a read of reg 0x00 returns 0x80 on a
+  // QMC6310N. Same trick LilyGo's factory firmware uses. (from PR #2591)
+  uint8_t candidates[] = { DISPLAY_ADDRESS, (DISPLAY_ADDRESS == 0x3C) ? (uint8_t)0x3D : (uint8_t)0x3C };
+  uint8_t found = 0;
+  for (uint8_t addr : candidates) {
+    if (!i2c_probe(Wire, addr)) continue;
+    Wire.beginTransmission(addr);
+    Wire.write((uint8_t)0x00);
+    if (Wire.endTransmission() != 0) continue;
+    if (Wire.requestFrom((int)addr, (int)1) != 1) continue;
+    if (Wire.read() == 0x80) continue;  // magnetometer, not the OLED
+    found = addr;
+    break;
+  }
+  if (found == 0) return false;
+  return display.begin(found, true);
 }
 
 void SH1106Display::turnOn()


### PR DESCRIPTION
## Summary

Fixes #3147 (T-Beam Supreme blank display on v1.17.0).

The T-Beam S3 Supreme ships a QMC6310N magnetometer whose configurable I2C address collides with the OLED's — depending on the board sub-variant (VHF/UHF, per LilyGo's hardware docs), the display sits at either `0x3C` or `0x3D`, with the magnetometer on the other one. `SH1106Display::begin()` only ever tried the single `DISPLAY_ADDRESS` from the variant's build flags (currently hardcoded to `0x3D` for this board), so on units where that doesn't match the actual wiring, the display silently fails to init even though the panel and I2C bus are both fine.

This is a regression from before v1.17.0: v1.16.0 worked because of #2815, but that fix only tries `0x3D` then falls back to `0x3C` without checking *which* device is actually at each address — so on boards where the magnetometer ACKs first, it gets initialized as if it were the display.

## Fix

`begin()` now probes both `0x3C` and `0x3D` and disambiguates by reading the magnetometer's chip-ID register (a read of register `0x00` returns `0x80` on a QMC6310N) — same technique LilyGo's own factory test firmware uses — instead of just taking whichever address ACKs first.

This is the same core approach as #2591, ported onto current `dev` (that PR predates a color-type refactor and no longer applies/builds cleanly).

## Testing

Built and flashed `T_Beam_S3_Supreme_SX1262_companion_radio_ble` locally on a T-Beam Supreme unit that reproduces #3147:
- Stock v1.17.0: display blank (confirmed).
- Stock v1.16.0: display works (confirmed).
- This patch on top of current `dev`: display works.

## Related

- Closes #3147
- Alternative approaches: #2591 (same underlying idea, doesn't apply cleanly to current `dev`), #2276 (hardcodes `0x3D`, already effectively what `dev` does today and insufficient on its own)
