### PR TITLE
Enable INA226 support for ProMicro nRF52840

### DIFF
--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -23,6 +23,7 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_BMP280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
+  -D ENV_INCLUDE_INA226=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/sensors>
   +<../variants/promicro>
@@ -34,6 +35,7 @@ lib_deps= ${nrf52_base.lib_deps}
   adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit BMP280 Library@^2.6.8
   stevemarple/MicroNMEA @ ^2.0.6
+  robtillaart/INA226@^0.6.6
 
 [env:ProMicro_repeater]
 extends = Promicro


### PR DESCRIPTION
This pull request enables the existing INA226 functionality for the ProMicro nRF52840 target.

### Changes

-ENV_INCLUDE_INA226
- robtillaart/INA226

### Testing

I built the firmware and tested it on a ProMicro nRF52840. The INA226 works correctly without any additional code changes.

This simply enables an already supported feature for the ProMicro configuration.
Thank you