### PR TITLE
fix(m5stack_unit_c6l): add USB CDC flags to repeater and room_server envs

### DIFF
--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -43,6 +43,8 @@ build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 build_flags =
   ${M5Stack_Unit_C6L.build_flags}
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
   -D ADVERT_NAME='"Unit C6L Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
@@ -60,6 +62,8 @@ build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   +<../examples/simple_room_server>
 build_flags =
   ${M5Stack_Unit_C6L.build_flags}
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
   -D ADVERT_NAME='"Unit C6L Room"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0


### PR DESCRIPTION
Same root cause as #3099 (kiss_modem): without `ARDUINO_USB_CDC_ON_BOOT=1` / `ARDUINO_USB_MODE=1`, Serial routes to UART0, which has no physical connector on this board — so the USB admin console was unreachable on the repeater and room_server envs.

Tested on real hardware: USB admin console now responds on both envs, confirmed frequency/region configuration via serial.