### PR TITLE
Fix RX Boosted Gain setting after AGC reset is triggered

### DIFF
--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -19,7 +19,6 @@ public:
     ((CustomLR1110 *)_radio)->setMaxPayloadMillis(pm.payloadMillis);
   }
 
-  void doResetAGC() override { lr11x0ResetAGC((LR11x0 *)_radio, ((CustomLR1110 *)_radio)->getFreqMHz()); }
   bool isReceivingPacket() override {
     return ((CustomLR1110 *)_radio)->isReceiving();
   }
@@ -50,4 +49,6 @@ public:
   bool getRxBoostedGainMode() const override {
     return ((CustomLR1110 *)_radio)->getRxBoostedGainMode();
   }
+
+  void doResetAGC() override { lr11x0ResetAGC((LR11x0 *)_radio, ((CustomLR1110 *)_radio)->getFreqMHz(), getRxBoostedGainMode()); }
 };

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -35,5 +35,5 @@ public:
   }
   uint8_t getSpreadingFactor() const override { return ((CustomSTM32WLx *)_radio)->spreadingFactor; }
 
-  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio); }
+  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio, getRxBoostedGainMode()); }
 };

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -41,12 +41,12 @@ public:
     ((CustomSX1262 *)_radio)->sleep(false);
   }
 
-  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio); }
-
   bool setRxBoostedGainMode(bool en) override {
     return ((CustomSX1262 *)_radio)->setRxBoostedGainMode(en) == RADIOLIB_ERR_NONE;
   }
   bool getRxBoostedGainMode() const override {
     return ((CustomSX1262 *)_radio)->getRxBoostedGainMode();
   }
+
+  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio, getRxBoostedGainMode()); }
 };

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -38,12 +38,12 @@ public:
   }
   uint8_t getSpreadingFactor() const override { return ((CustomSX1268 *)_radio)->spreadingFactor; }
 
-  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio); }
-
   bool setRxBoostedGainMode(bool en) override {
     return ((CustomSX1268 *)_radio)->setRxBoostedGainMode(en) == RADIOLIB_ERR_NONE;
   }
   bool getRxBoostedGainMode() const override {
     return ((CustomSX1268 *)_radio)->getRxBoostedGainMode();
   }
+
+  void doResetAGC() override { sx126xResetAGC((SX126x *)_radio, getRxBoostedGainMode()); }
 };

--- a/src/helpers/radiolib/LR11x0Reset.h
+++ b/src/helpers/radiolib/LR11x0Reset.h
@@ -5,7 +5,7 @@
 // Full receiver reset for LR11x0-family chips (LR1110, LR1120, LR1121).
 // Warm sleep powers down analog, calibrate(0x3F) refreshes all calibration blocks,
 // then re-applies RX settings that calibration may reset.
-inline void lr11x0ResetAGC(LR11x0* radio, float freqMHz) {
+inline void lr11x0ResetAGC(LR11x0* radio, float freqMHz, bool rx_boost_gain) {
   radio->sleep(true, 0);
   radio->standby(RADIOLIB_LR11X0_STANDBY_RC, true);
 
@@ -16,6 +16,6 @@ inline void lr11x0ResetAGC(LR11x0* radio, float freqMHz) {
   radio->calibrateImageRejection(freqMHz - 4.0f, freqMHz + 4.0f);
 
 #ifdef RX_BOOSTED_GAIN
-  radio->setRxBoostedGainMode(RX_BOOSTED_GAIN);
+  radio->setRxBoostedGainMode(rx_boost_gain);
 #endif
 }

--- a/src/helpers/radiolib/SX126xReset.h
+++ b/src/helpers/radiolib/SX126xReset.h
@@ -5,7 +5,7 @@
 // Full receiver reset for all SX126x-family chips (SX1262, SX1268, LLCC68, STM32WLx).
 // Warm sleep powers down analog, Calibrate(0x7F) refreshes ADC/PLL/image calibration,
 // then re-applies RX settings that calibration may reset.
-inline void sx126xResetAGC(SX126x* radio) {
+inline void sx126xResetAGC(SX126x* radio, bool rx_boost_gain) {
   radio->sleep(true);
   radio->standby(RADIOLIB_SX126X_STANDBY_RC, true);
 
@@ -26,7 +26,7 @@ inline void sx126xResetAGC(SX126x* radio) {
   radio->setDio2AsRfSwitch(SX126X_DIO2_AS_RF_SWITCH);
 #endif
 #ifdef SX126X_RX_BOOSTED_GAIN
-  radio->setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
+  radio->setRxBoostedGainMode(rx_boost_gain);
 #endif
 #ifdef SX126X_REGISTER_PATCH
   uint8_t r_data = 0;


### PR DESCRIPTION
The AGC reset actually seems to just reset the entire SX1262. When the "AGC reset" function is called, the firmware needs to re-initialize settings on the radio. One of these settings is the RX Boosted Gain. 

HerculesMulligan pointed out in the discord that when the AGC reset is triggered, it appears to reset the RX boosted gain value to the compiled in default rather than the setting set by the user. https://discord.com/channels/1495203904898728149/1495410606985969765/1536169618794877018

This seemed like a simple fix after a quick look at the code. I haven't tested this PR at the time of creation, but will work on doing so afterwards. I'll comment on the PR once I've tested it out.