### PR TITLE
Fix Heltec V4-R8 waking from hibernate on LoRa traffic 🤖🤖

### DIFF
--- a/variants/heltec_v4_r8/HeltecV4R8Board.cpp
+++ b/variants/heltec_v4_r8/HeltecV4R8Board.cpp
@@ -62,7 +62,17 @@ void HeltecV4R8Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
 }
 
 void HeltecV4R8Board::powerOff() {
-  enterDeepSleep(0);
+  // enterDeepSleep() is wake-on-LoRa: it keeps the FEM in RX and arms DIO1
+  // as an EXT1 wakeup source, so with the radio still running any received
+  // packet boots the device again. Hibernate needs the FEM off (latched
+  // through deep sleep; init() releases the holds on the next boot) and the
+  // base behaviour: radio put to sleep, no wakeup sources armed.
+  loRaFEMControl.setSleepModeEnable();
+  digitalWrite(P_LORA_PA_POWER, LOW);
+  rtc_gpio_hold_en((gpio_num_t)P_LORA_KCT8103L_PA_CSD);
+  rtc_gpio_hold_en((gpio_num_t)P_LORA_PA_POWER);
+
+  ESP32Board::enterDeepSleep(0);
 }
 
 uint16_t HeltecV4R8Board::getBattMilliVolts() {


### PR DESCRIPTION
Fixes #3165

Since c644720e ("uitask: screen and radio poweroff moved to board") nothing puts the radio to sleep when a companion hibernates — that responsibility moved into the boards' `powerOff()`. `HeltecV4R8Board::powerOff()` however reuses the wake-on-LoRa `enterDeepSleep()`, which keeps the FEM in RX and arms EXT1 wakeup on `P_LORA_DIO_1`, so any received packet reboots the device within seconds of entering hibernate. Full analysis in #3165.

This PR makes `powerOff()` shut the FEM down (CSD low, PA rail off, both latched through deep sleep — `LoRaFEMControl::init()` already releases the holds on the next boot) and use the base `ESP32Board::enterDeepSleep(0)`, which puts the radio to sleep and clears all wakeup sources. The wake-on-LoRa `enterDeepSleep()` remains unchanged for its intended use.

Tested on a V4-R8 (OLED SKU): the device now stays in hibernate with active mesh traffic nearby; wake via the RST button works, normal operation after wake confirmed (BLE + RX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)