### PR TITLE
Workaround for Heltec T096 transmit issue

### DIFF
--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -79,7 +79,8 @@ private:
       def("bw", _parent->bw);
       def("sf", _parent->sf);
       def("cr", _parent->cr);
-      def("cad", _parent->cad_enabled);
+      static const char radio_cad_key[] = {'c', 'a', 'd', '\0'}; // workaround for T096, don't touch without testing T096 repeater still transmit
+      def(radio_cad_key, _parent->cad_enabled);
       def("int_thr", _parent->interference_threshold);
       def("rxgain", _parent->rx_boosted_gain);
       def("fem_rxgain", _parent->rx_boosted_gain);

--- a/variants/heltec_t096/LoRaFEMControl.cpp
+++ b/variants/heltec_t096/LoRaFEMControl.cpp
@@ -21,6 +21,7 @@ void LoRaFEMControl::setSleepModeEnable(void)
 
 void LoRaFEMControl::setTxModeEnable(void)
 {
+    pinMode(P_LORA_KCT8103L_PA_CTX, OUTPUT);    // force pinMode before transmit as temporary workaround for https://github.com/meshcore-dev/MeshCore/issues/3151
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
 }


### PR DESCRIPTION
This PR is a temporary workaround for the Heltec T096 transmit issue (https://github.com/meshcore-dev/MeshCore/issues/3151)

The root issue seems to be that compiler optimisations are causing an ordering issue resulting in the ``P_LORA_KCT8103L_PA_CTX`` pin direction getting reset to input after ``LoRaFEMControl::init()``.

The string array is enough to fix the ordering so that it doesn't happen (for now), but as a precaution we will also force the pinMode to output before every transmit in case a code change causes ordering to change again.

Investigation is ongoing as to what exactly is resetting the pin direction on ``P_LORA_KCT8103L_PA_CTX``.