### PR TITLE
Set T-Echo Card TCXO voltage to 3.0

### DIFF
--- a/variants/lilygo_techo_card/variant.h
+++ b/variants/lilygo_techo_card/variant.h
@@ -107,7 +107,7 @@
 #define  P_LORA_NSS                (11)  // P0.11
 #define  SX126X_RXEN               (33)  // P1.01
 #define  SX126X_TXEN               (27)  // P0.27
-#define  SX126X_DIO3_TCXO_VOLTAGE  (1.8f)
+#define  SX126X_DIO3_TCXO_VOLTAGE  (3.0f)
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As per https://github.com/meshcore-dev/MeshCore/pull/3140 and https://github.com/Xinyuan-LilyGO/T-Echo-Lite/issues/14