### PR TITLE
fix: ESPNowBridge recv callback signature breaks build on RISC-V ESP32 (C3/C6)

### DIFF
--- a/src/helpers/bridges/ESPNowBridge.cpp
+++ b/src/helpers/bridges/ESPNowBridge.cpp
@@ -9,7 +9,7 @@
 ESPNowBridge *ESPNowBridge::_instance = nullptr;
 
 // Static callback wrappers
-void ESPNowBridge::recv_cb(const uint8_t *mac, const uint8_t *data, int32_t len) {
+void ESPNowBridge::recv_cb(const uint8_t *mac, const uint8_t *data, int len) {
   if (_instance) {
     _instance->onDataRecv(mac, data, len);
   }
@@ -100,7 +100,7 @@ void ESPNowBridge::xorCrypt(uint8_t *data, size_t len) {
   }
 }
 
-void ESPNowBridge::onDataRecv(const uint8_t *mac, const uint8_t *data, int32_t len) {
+void ESPNowBridge::onDataRecv(const uint8_t *mac, const uint8_t *data, int len) {
   // Ignore packets that are too small to contain header + checksum
   if (len < (BRIDGE_MAGIC_SIZE + BRIDGE_CHECKSUM_SIZE)) {
     BRIDGE_DEBUG_PRINTLN("RX packet too small, len=%d\n", len);

--- a/src/helpers/bridges/ESPNowBridge.h
+++ b/src/helpers/bridges/ESPNowBridge.h
@@ -42,7 +42,7 @@
 class ESPNowBridge : public BridgeBase {
 private:
   static ESPNowBridge *_instance;
-  static void recv_cb(const uint8_t *mac, const uint8_t *data, int32_t len);
+  static void recv_cb(const uint8_t *mac, const uint8_t *data, int len);
   static void send_cb(const uint8_t *mac, esp_now_send_status_t status);
 
   /**
@@ -90,7 +90,7 @@ private:
    * @param data Received data
    * @param len Length of received data
    */
-  void onDataRecv(const uint8_t *mac, const uint8_t *data, int32_t len);
+  void onDataRecv(const uint8_t *mac, const uint8_t *data, int len);
 
   /**
    * ESP-NOW send callback


### PR DESCRIPTION
## Summary

esp_now_recv_cb_t expects a plain int for the data length parameter. On Xtensa targets int32_t happens to be typedef'd as int, so it built fine, but on RISC-V targets (e.g. ESP32-C3) int32_t is long int, a distinct type from int even though both are 32 bit, so the function pointer conversion is rejected outright.

This was never caught before because CI never built the *_repeater_bridge_espnow environments for RISC-V boards. Confirmed the build failure against current dev on Tenstar_C3_sx1262_repeater_bridge_espnow before this fix, and confirmed the fix resolves it.

## Changes

- ESPNowBridge::recv_cb and ESPNowBridge::onDataRecv now take int instead of int32_t for the length parameter, matching the esp_now_recv_cb_t signature exactly.

## How to reproduce

```
git clone https://github.com/meshcore-dev/MeshCore.git
cd MeshCore
git checkout dev
pip install platformio
pio run -e Tenstar_C3_sx1262_repeater_bridge_espnow
```

Expected result before this fix:

```
esptool.py v4.5.1
Creating esp32c3 image...
Merged 1 ELF section
Successfully created esp32c3 image.
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib7f6/SPI/SPI.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib50f/Wire/Wire.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/Hal.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/Module.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/hal/Arduino/ArduinoHal.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/hal/ESP-IDF/EspHal.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/hal/RPiPico/PicoHal.cpp.o
src/helpers/bridges/ESPNowBridge.cpp: In member function 'virtual void ESPNowBridge::begin()':
src/helpers/bridges/ESPNowBridge.cpp:48:35: error: invalid conversion from 'void (*)(const uint8_t*, const uint8_t*, int32_t)' {aka 'void (*)(const unsigned char*, const unsigned char*, long int)'} to 'esp_now_recv_cb_t' {aka 'void (*)(const unsigned char*, const unsigned char*, int)'} [-fpermissive]
   esp_now_register_recv_cb(recv_cb);
                                   ^
In file included from src/helpers/bridges/ESPNowBridge.h:4,
                 from src/helpers/bridges/ESPNowBridge.cpp:1:
/home/sebastian/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32c3/include/esp_wifi/include/esp_now.h:136:54: note:   initializing argument 1 of 'esp_err_t esp_now_register_recv_cb(esp_now_recv_cb_t)'
 esp_err_t esp_now_register_recv_cb(esp_now_recv_cb_t cb);
                                    ~~~~~~~~~~~~~~~~~~^~
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/hal/Stm32duino/Stm32wlHal.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/modules/CC1101/CC1101.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/modules/LLCC68/LLCC68.cpp.o
Compiling .pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/lib03a/RadioLib/modules/LR11x0/LR1110.cpp.o
*** [.pio/build/Tenstar_C3_sx1262_repeater_bridge_espnow/src/helpers/bridges/ESPNowBridge.cpp.o] Error 1
```

## Test plan

- [x] Tenstar_C3_sx1262_repeater_bridge_espnow (ESP32-C3, RISC-V) builds successfully
- [x] Tenstar_C3_sx1268_repeater_bridge_espnow (ESP32-C3, RISC-V) builds successfully
- [x] Heltec_ct62_repeater_bridge_espnow (ESP32-C6, RISC-V) builds successfully
- [x] heltec_rc32_repeater_bridge_espnow (ESP32-S3, Xtensa) builds successfully, confirming no regression on existing targets
- [x] heltec_rc32_without_display_repeater_bridge_espnow (ESP32-S3, Xtensa) builds successfully
