### PR TITLE
Fix Heltec T096 Tx issue

### DIFF
--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -79,8 +79,7 @@ private:
       def("bw", _parent->bw);
       def("sf", _parent->sf);
       def("cr", _parent->cr);
-      static const char radio_cad_key[] = {'c', 'a', 'd', '\0'}; // workaround for T096, don't touch without testing T096 repeater still transmit
-      def(radio_cad_key, _parent->cad_enabled);
+      def("cad", _parent->cad_enabled);
       def("int_thr", _parent->interference_threshold);
       def("rxgain", _parent->rx_boosted_gain);
       def("fem_rxgain", _parent->rx_boosted_gain);

--- a/variants/heltec_t096/LoRaFEMControl.cpp
+++ b/variants/heltec_t096/LoRaFEMControl.cpp
@@ -21,7 +21,6 @@ void LoRaFEMControl::setSleepModeEnable(void)
 
 void LoRaFEMControl::setTxModeEnable(void)
 {
-    pinMode(P_LORA_KCT8103L_PA_CTX, OUTPUT);    // force pinMode before transmit as temporary workaround for https://github.com/meshcore-dev/MeshCore/issues/3151
     digitalWrite(P_LORA_KCT8103L_PA_CSD, HIGH);
     digitalWrite(P_LORA_KCT8103L_PA_CTX, HIGH);
 }

--- a/variants/heltec_t096/variant.h
+++ b/variants/heltec_t096/variant.h
@@ -104,7 +104,7 @@
 #define PIN_SPI_SCK             (32 + 8)
 #define PIN_SPI_NSS             LORA_CS
 
-#define PIN_SPI1_MISO           (-1)
+#define PIN_SPI1_MISO           (0)
 #define PIN_SPI1_MOSI           (0+17)
 #define PIN_SPI1_SCK            (0+20)
 


### PR DESCRIPTION
This PR fixes the Heltec T096 transmit issue which was found to be caused by out of bounds read of the pin map.

Reverted the previous workarounds, changed ``PIN_SPI1_MISO`` pin to 0, which in this variant maps to 0xFF and ends up as ``NRFX_SPIM_PIN_NOT_USED``.

Closes https://github.com/meshcore-dev/MeshCore/issues/3151