### PR TITLE
Fix unused pin definitions on some NRF52 boards

### DIFF
--- a/variants/heltec_t1/variant.h
+++ b/variants/heltec_t1/variant.h
@@ -25,8 +25,8 @@
 #define ST7735_SDA              (0 + 24)
 #define ST7735_SCK              (32 + 0)
 #define ST7735_RESET            (0 + 20)
-#define ST7735_MISO             (-1)
-#define ST7735_BUSY             (-1)
+#define ST7735_MISO             (0) // 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
+#define ST7735_BUSY             (0) // 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
 #define ST7735_BL               (0 + 15)
 #define VTFT_CTRL               (0 + 13)
 
@@ -66,8 +66,7 @@
 // UART
 
 // No longer populated on PCB.
-#define PIN_SERIAL2_RX          (-1)
-#define PIN_SERIAL2_TX          (-1)
+// Removed the pin definitions to avoid potential issues with Uart.
 
 ////////////////////////////////////////////////////////////////////////////////
 // I2C

--- a/variants/lilygo_techo_lite/variant.h
+++ b/variants/lilygo_techo_lite/variant.h
@@ -58,7 +58,7 @@
 #define PIN_SPI_MISO            _PINNUM(0, 17) // (MISO)
 #define PIN_SPI_MOSI            _PINNUM(0, 15) // (MOSI)
 #define PIN_SPI_SCK             _PINNUM(0, 13) // (SCK)
-#define PIN_SPI_NSS             (-1)
+#define PIN_SPI_NSS             (0)
 
 ////////////////////////////////////////////////////////////////////////////////
 // QSPI FLASH
@@ -123,7 +123,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // SPI1
 
-#define PIN_SPI1_MISO           (-1)            // Not used for Display
+#define PIN_SPI1_MISO           (0)            // Not used for Display, 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
 #define PIN_SPI1_MOSI           _PINNUM(0, 20)
 #define PIN_SPI1_SCK            _PINNUM(0, 19)
 
@@ -135,7 +135,7 @@ extern const int SCK;
 ////////////////////////////////////////////////////////////////////////////////
 // Display
 
-// #define DISP_MISO               (-1)         // Not used for Display
+// #define DISP_MISO               (0)         // Not used for Display, 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
 #define DISP_MOSI               _PINNUM(0, 20)
 #define DISP_SCLK               _PINNUM(0, 19)
 #define DISP_CS                 _PINNUM(0, 22)
@@ -143,7 +143,7 @@ extern const int SCK;
 #define DISP_RST                _PINNUM(0, 28)
 #define DISP_BUSY               _PINNUM(0, 3)
 #define DISP_POWER              _PINNUM(1, 12)
-// #define DISP_BACKLIGHT          (-1)         // Display has no backlight
+// #define DISP_BACKLIGHT          (0)         // Display has no backlight, 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
 
 #define PIN_DISPLAY_CS          DISP_CS
 #define PIN_DISPLAY_DC          DISP_DC

--- a/variants/mesh_pocket/variant.h
+++ b/variants/mesh_pocket/variant.h
@@ -108,7 +108,7 @@
 #define PIN_DISPLAY_DC                 (31)
 #define PIN_DISPLAY_RST                (32 + 4)
 
-#define PIN_SPI1_MISO           (-1)
+#define PIN_SPI1_MISO           (0)  // 0 maps to 0xff on this device which is NRFX_SPIM_PIN_NOT_USED
 #define PIN_SPI1_MOSI           (20)
 #define PIN_SPI1_SCK            (22)
 


### PR DESCRIPTION
This PR fixes potential unwanted behaviour on some NRF52 boards due to setting certain unused pins to -1.

On NRF52 setting some pins to -1 has a high potential to cause unknown behaviour on random pins. This is because -1 wraps to 255 which is an OOB read on the ``g_ADigitalPinMap`` array. Some drivers then pass that OOB byte to nrfx, which masks it to a real GPIO via ``nrf_gpio_pin_port_decode`` and what happens to that pin next depends on the driver.

nrfx expects to receive 0xFF to signify unused pins, so the correct thing to do is to pass the arduino pin that corresponds to 0xff in g_ADigitalPinMap to be safe.

Note there are some boards with GPS pins set to -1, this is fine and expected as we guard on -1 in our GPS code.

Tested Heltec T1, but not the T-Echo Lite or MeshPocket.