### PR TITLE
Add companion_radio_serial env for XIAO nRF52840 🤖🤖

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -61,7 +61,13 @@ MultiSerialInterface interface_manager;
 #if defined(SERIAL_RX)
   #include <helpers/ArduinoSerialInterface.h>
   ArduinoSerialInterface hardware_serial_interface;
-  HardwareSerial companion_serial(1);
+  #if defined(NRF52_PLATFORM)
+    // nRF52 has no numbered-constructor HardwareSerial; Serial1 is the concrete UARTE0
+    // instance the core always defines. setPins() below moves it to the requested pads.
+    Uart& companion_serial = Serial1;
+  #else
+    HardwareSerial companion_serial(1);
+  #endif
 #endif
 
 // platform file system

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -119,3 +119,28 @@ build_src_filter = ${Xiao_nrf52.build_src_filter}
   +<../examples/kiss_modem/*.cpp>
 lib_deps =
   ${Xiao_nrf52.lib_deps}
+
+[env:Xiao_nrf52_companion_radio_serial]
+extends = Xiao_nrf52
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
+build_flags =
+  ${Xiao_nrf52.build_flags}
+  -I examples/companion_radio/ui-orig
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D QSPIFLASH=1
+  -D SERIAL_TX=D6
+  -D SERIAL_RX=D7
+  -D PIN_WIRE_SCL=16
+  -D PIN_WIRE_SDA=17
+build_unflags =
+  -D PIN_WIRE_SCL=D6
+  -D PIN_WIRE_SDA=D7
+build_src_filter = ${Xiao_nrf52.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-orig/*.cpp>
+lib_deps =
+  ${Xiao_nrf52.lib_deps}
+  densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
This change lets a Seeed XIAO nRF52840 radio talk to a host computer over a simple two-wire serial connection instead of USB or Bluetooth — which is what's needed to use it inside a Clockwork PicoCalc or any other project that requires a connection to the nRF via GPIO instead of USB.

Two problems stood in the way, both now fixed:

It wouldn't compile. The code borrowed a serial-port setup written for a different chip family. Swapping in the nRF52's own equivalent fixed it without touching anything else.
Two pins were being used twice. The same two pins were also claimed by the sensor bus, which grabbed them back a moment after the serial link was set up — so the connection went dead with no error message anywhere. The sensors now use different pins.

Moving the sensor bus rather than the serial link was the only option: with the radio board mounted, just three pins are left exposed, and the two connections need four between them — and the board's own sensor was never on those pins anyway.

This board has several firmware variants — Bluetooth companion, USB companion, repeater, room server, modem, and now this serial one — sharing a common block of settings. The pin change is written as an override inside the new variant's own section rather than into that shared block, so it applies to this firmware alone: flash any of the other five and their pins behave exactly as before. Nothing else needs re-testing.

Tested on real hardware wired to a Luckfox Lyra: the radio has stayed on the mesh since flashing and handles everything expected of it. The two neighbouring variants were rebuilt as a check and still work. My PicoCalc has been working great with the nRF using this firmware for 3 weeks now. Super stable.