### PR TITLE
Allow companion BLE/USB CMD_SET_DEVICE_TIME to set clock backwards

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1240,13 +1240,8 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_SET_DEVICE_TIME && len >= 5) {
     uint32_t secs;
     memcpy(&secs, &cmd_frame[1], 4);
-    uint32_t curr = getRTCClock()->getCurrentTime();
-    if (secs >= curr) {
-      getRTCClock()->setCurrentTime(secs);
-      writeOKFrame();
-    } else {
-      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
-    }
+    getRTCClock()->setCurrentTime(secs);  // trusted local app, so allow backwards too (fixes drifted clock)
+    writeOKFrame();
   } else if (cmd_frame[0] == CMD_SEND_SELF_ADVERT) {
     mesh::Packet* pkt;
     if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {


### PR DESCRIPTION
CMD_SET_DEVICE_TIME only ever arrives from the locally-paired companion app/CLI, not from untrusted mesh peers, so the owner should be able to correct a drifted device clock in either direction. Previously a fast- running clock (e.g. software fallback clock on nRF52 boards with no GPS fix or RTC chip, after long uptime) could never be corrected once it drifted ahead, since the firmware rejected any earlier timestamp.

Fixes #3173