### PR TITLE
GPS: configure L76K for GPS, BeiDou and GLONASS

### DIFF
--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -51,6 +51,17 @@ class MicroNMEALocationProvider : public LocationProvider {
     unsigned long _last_time_sync = 0;
     static const unsigned long TIME_SYNC_INTERVAL = 1800000; // Re-sync every 30 minutes
 
+#ifdef GPS_L76K
+    void configureL76K() {
+        // Reapply the constellation mode at each provider start instead of
+        // assuming it survives a receiver power cycle.
+        // Mode 7 enables GPS + BeiDou + GLONASS.
+        delay(250);
+        MicroNMEA::sendSentence(*_gps_serial, "$PCAS04,7");
+        delay(250);
+    }
+#endif
+
 public :
     MicroNMEALocationProvider(Stream& ser, mesh::RTCClock* clock = NULL, int pin_reset = GPS_RESET, int pin_en = GPS_EN,RefCountedDigitalPin* peripher_power=NULL) :
     nmea(_nmeaBuffer, sizeof(_nmeaBuffer)), _clock(clock), _gps_serial(&ser), _peripher_power(peripher_power), _pin_reset(pin_reset), _pin_en(pin_en) {
@@ -91,6 +102,11 @@ public :
             delay(10);
             digitalWrite(_pin_reset, !GPS_RESET_ACTIVE);
         }
+#ifdef GPS_L76K
+        // EnvironmentSensorManager calls reset() immediately after begin().
+        // Configure only after that reset so the setting is not discarded.
+        configureL76K();
+#endif
     }
 
     void stop() override {


### PR DESCRIPTION
## What

Configure serial L76K receivers for GPS + BeiDou + GLONASS during their location
provider start sequence, after the receiver reset step.

The implementation is guarded by the existing `GPS_L76K` board marker. It waits
250 ms after reset, sends the documented `PCAS04,7` command through
`MicroNMEA::sendSentence()` (which generates the checksum and terminators), then
waits another 250 ms before normal processing continues.

## Why

The ThinkNode M6 already identifies its receiver with `GPS_L76K`, but MeshCore
does not currently configure its constellation mode. The L76K defaults to GPS +
BeiDou; PCAS04 mode 7 also enables GLONASS and can provide additional satellite
margin.

This is not claimed as a proven fix for an intermittent `0 sats` state. It is a
small, documented initialization improvement that can be tested independently.

## Scope

- affects only builds defining `GPS_L76K` (currently ThinkNode M6, Heltec Tower
  V2, Nano G2 Ultra and ThinkNode M9);
- reuses the existing board marker instead of adding an unused opt-in macro;
- does not change UART baud rate, GPS power/reset handling or NMEA parsing;
- sends the configuration after `reset()`, because `EnvironmentSensorManager`
  calls `begin()` followed immediately by `reset()`;
- does not send PCAS03, so GSA/GSV diagnostics remain available;
- does not send PCAS11, which is absent from the L76K V1.1 specification;
- adds 500 ms to each L76K start sequence.

The impact of enabling the additional constellation on receiver power consumption
has not yet been measured.

## Source

Quectel *L76K GNSS Protocol Specification* V1.1, PCAS04 section. Mode 7 is
GPS + BeiDou + GLONASS. QZSS is enabled independently by the receiver.

Related to #2862 and #2863.