### PR TITLE
ThinkNode M6: expose external-power and charger state

### DIFF
--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -74,6 +74,8 @@ public:
 
   // Power management interface (boards with power management override these)
   virtual bool isExternalPowered() { return false; }
+  // True while a board can identify an active battery-charging source.
+  virtual bool isChargerActive() { return false; }
   virtual uint16_t getBootVoltage() { return 0; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -76,6 +76,14 @@ public:
   virtual bool isExternalPowered() { return false; }
   // True while a board can identify an active battery-charging source.
   virtual bool isChargerActive() { return false; }
+
+  // Optional, source-specific power detection. Boards that can distinguish a USB
+  // supply from a solar charger override these; defaults keep every other board
+  // unaffected (the generic CLI prints "n/a" when a capability is absent).
+  virtual bool hasUsbPowerDetect() const { return false; }
+  virtual bool isUsbPowered() { return false; }
+  virtual bool hasSolarChargerDetect() const { return false; }
+  virtual bool isSolarChargerActive() { return false; }
   virtual uint16_t getBootVoltage() { return 0; }
   virtual uint32_t getResetReason() const { return 0; }
   virtual const char* getResetReasonString(uint32_t reason) { return "Not available"; }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -274,8 +274,16 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     } else if (memcmp(command, "board", 5) == 0) {
       sprintf(reply, "%s", _board->getManufacturerName());
     } else if (strcmp(command, "power") == 0) {
-      snprintf(reply, 160, "batt:%u mV ext:%s charger:%s",
+      const char* usb_state = _board->hasUsbPowerDetect()
+                                  ? (_board->isUsbPowered() ? "yes" : "no")
+                                  : "n/a";
+      const char* solar_state = _board->hasSolarChargerDetect()
+                                    ? (_board->isSolarChargerActive() ? "yes" : "no")
+                                    : "n/a";
+      snprintf(reply, 160, "batt:%u mV usb:%s solar_chg:%s ext:%s charger:%s",
               (unsigned)_board->getBattMilliVolts(),
+              usb_state,
+              solar_state,
               _board->isExternalPowered() ? "yes" : "no",
               _board->isChargerActive() ? "yes" : "no");
     } else if (memcmp(command, "sensor get ", 11) == 0) {

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -273,6 +273,11 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       sprintf(reply, "%s (Build: %s)", _callbacks->getFirmwareVer(), _callbacks->getBuildDate());
     } else if (memcmp(command, "board", 5) == 0) {
       sprintf(reply, "%s", _board->getManufacturerName());
+    } else if (strcmp(command, "power") == 0) {
+      snprintf(reply, 160, "batt:%u mV ext:%s charger:%s",
+              (unsigned)_board->getBattMilliVolts(),
+              _board->isExternalPowered() ? "yes" : "no",
+              _board->isChargerActive() ? "yes" : "no");
     } else if (memcmp(command, "sensor get ", 11) == 0) {
       const char* key = command + 11;
       const char* val = _sensors->getSettingByKey(key);

--- a/variants/thinknode_m6/ThinkNodeM6Board.cpp
+++ b/variants/thinknode_m6/ThinkNodeM6Board.cpp
@@ -15,6 +15,9 @@ void ThinkNodeM6Board::begin() {
   digitalWrite(P_LORA_TX_LED, LOW);
 #endif
 
+  pinMode(EXT_PWR_DETECT, INPUT);
+  pinMode(EXT_CHRG_DETECT, INPUT);
+
   delay(10); // give sx1262 some time to power up
 }
 

--- a/variants/thinknode_m6/ThinkNodeM6Board.h
+++ b/variants/thinknode_m6/ThinkNodeM6Board.h
@@ -36,19 +36,33 @@ public:
     return "Elecrow ThinkNode M6";
   }
 
+  bool hasUsbPowerDetect() const override { return true; }
+
+  bool isUsbPowered() override {
+    // P0.13 is the dedicated USB / external power-detect line on the M6 PCB
+    // (same pin the Meshtastic M6 variant uses for USB detection).
+    return digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE;
+  }
+
+  bool hasSolarChargerDetect() const override { return true; }
+
+  bool isSolarChargerActive() override {
+    // P0.15 is the active-low solar-charger status line. It reports the
+    // charger's state, not photovoltaic voltage or current.
+    return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE;
+  }
+
   bool isExternalPowered() override {
-    if (digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE ||
-        digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE) {
+    if (isUsbPowered() || isSolarChargerActive()) {
       return true;
     }
     return NRF52Board::isExternalPowered();
   }
 
   bool isChargerActive() override {
-    // The charge-status line covers solar input; external USB input is also a
-    // charging source, although the board cannot report charge completion.
-    return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE ||
-           digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE;
+    // Preserve a generic charging indication while also exposing both
+    // source-specific states (USB / solar) separately through the CLI.
+    return isSolarChargerActive() || isUsbPowered();
   }
 
   void powerOff() override {

--- a/variants/thinknode_m6/ThinkNodeM6Board.h
+++ b/variants/thinknode_m6/ThinkNodeM6Board.h
@@ -36,6 +36,21 @@ public:
     return "Elecrow ThinkNode M6";
   }
 
+  bool isExternalPowered() override {
+    if (digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE ||
+        digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE) {
+      return true;
+    }
+    return NRF52Board::isExternalPowered();
+  }
+
+  bool isChargerActive() override {
+    // The charge-status line covers solar input; external USB input is also a
+    // charging source, although the board cannot report charge completion.
+    return digitalRead(EXT_CHRG_DETECT) == EXT_CHRG_DETECT_VALUE ||
+           digitalRead(EXT_PWR_DETECT) == EXT_PWR_DETECT_VALUE;
+  }
+
   void powerOff() override {
 
     // turn off all leds, sd_power_system_off will not do this for us

--- a/variants/thinknode_m6/variant.h
+++ b/variants/thinknode_m6/variant.h
@@ -29,6 +29,12 @@
 
 #define AREF_VOLTAGE            (3.0)
 
+// External power and charger status lines.
+#define EXT_PWR_DETECT          (13)
+#define EXT_PWR_DETECT_VALUE    HIGH
+#define EXT_CHRG_DETECT         (15)
+#define EXT_CHRG_DETECT_VALUE   LOW
+
 ////////////////////////////////////////////////////////////////////////////////
 // Number of pins
 


### PR DESCRIPTION
## What

- adds `MainBoard::isChargerActive()` with a safe default of `false`;
- defines the ThinkNode M6 external-power and charger-status lines using the
  existing `EXT_PWR_DETECT` / `EXT_CHRG_DETECT` conventions;
- overrides `isExternalPowered()` and `isChargerActive()` on the M6;
- adds an exact `power` CLI command returning battery millivolts, external-power
  state and charger-source state.

Example:

```text
batt:4012 mV ext:yes charger:yes
```

## Why

The generic nRF52 implementation only checks MCU USB VBUS. The ThinkNode M6 also
has dedicated board signals for external input (P0.13, active HIGH) and its solar
charger (P0.15, active LOW). Exposing both makes USB/powerbank and solar behavior
observable without changing the charging path.

## Semantics

- `ext:yes` means that the dedicated external-input line, the active charger
  line, or the nRF52 USB-VBUS fallback detects an external source;
- `charger:yes` means that the solar charger signal is active or an external USB
  charging source is present;
- with USB input, the available board signals cannot distinguish active battery
  current from charge completion.

## Scope

- other boards retain the default `isChargerActive() == false`;
- no change to GPS, ADC conversion, charger control, sleep policy or radio
  configuration;
- the command uses an exact `strcmp`, so it does not overlap with `poweroff`;
- no Meshtastic code is copied; only documented board pin facts are reused.

## Testing

The board-state logic was compiled and exercised in an isolated C++11 harness
for no source, external USB input and active solar charging. Full target build
and on-device validation remain for CI/hardware.

Expected hardware checks:

1. no external source: `ext:no charger:no`;
2. USB-C/powerbank connected: `ext:yes charger:yes`;
3. solar charging in sufficient light: `ext:yes charger:yes`;
4. unplugging the source restores `ext:no charger:no` once the charger line is
   inactive.