### PR TITLE
commenting out the load/save of the fem_ properties

### DIFF
--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -53,8 +53,12 @@ private:
       //def("cad", _parent->cad_enabled);
       //def("int_thr", _parent->interference_threshold);
       def("rxgain", _parent->rx_boosted_gain);
+    #if 0
+      // NOTE: these cannot be set (yet) so don't load/save until we can.
+      //       also, fem_rxgain WAS mapped to wrong JSON property previously
       def("fem_rxgain", _parent->radio_fem_rxgain);
       def("fem_txgain", _parent->radio_fem_txgain);
+    #endif
       def("tx", _parent->tx_power_dbm);
       def("af", _parent->airtime_factor);
       def("rxdelay", _parent->rx_delay_base);

--- a/test/test_companion_node_prefs/test_companion_node_prefs.cpp
+++ b/test/test_companion_node_prefs/test_companion_node_prefs.cpp
@@ -50,6 +50,8 @@ public:
   const std::string& text() const { return _text; }
 };
 
+#if 0
+// Re-enable test once we can SET fem_ values in companion
 TEST(CompanionNodePrefs, RxGainSettingsRoundTripIndependently) {
   NodePrefs saved;
   saved.rx_boosted_gain = 0;
@@ -73,6 +75,7 @@ TEST(CompanionNodePrefs, RxGainSettingsRoundTripIndependently) {
   EXPECT_EQ(0, loaded.radio_fem_rxgain);
   EXPECT_EQ(1, loaded.radio_fem_txgain);
 }
+#endif
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
until they ca be set, should not load/save

Also, v1.17 incorrectly mapped fem_rxgain, so don't want to load bad value