### PR TITLE
Add selectable UI color theme for color TFT displays

### DIFF
--- a/examples/companion_radio/AbstractUITask.h
+++ b/examples/companion_radio/AbstractUITask.h
@@ -43,4 +43,6 @@ public:
   virtual void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) = 0;
   virtual void notify(UIEventType t = UIEventType::none) = 0;
   virtual void loop() = 0;
+  virtual bool applyTheme(const char* theme) { return false; }
+  virtual int getThemeCount() { return 0; }
 };

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2050,6 +2050,19 @@ void MyMesh::checkCLIRescueCmd() {
         _prefs.ble_pin = atoi(&config[4]);
         savePrefs();
         Serial.printf("  > pin is now %06d\n", _prefs.ble_pin);
+      } else if (memcmp(config, "theme ", 6) == 0) {
+        if (_ui != NULL && _ui->getThemeCount() > 0) {
+          if (_ui->applyTheme(&config[6])) {
+            strncpy(_prefs.ui_theme, &config[6], sizeof(_prefs.ui_theme) - 1);
+            _prefs.ui_theme[sizeof(_prefs.ui_theme) - 1] = 0;
+            savePrefs();
+            Serial.printf("  > theme is now %s\n", _prefs.ui_theme);
+          } else {
+            Serial.println("  Error: theme not found or not supported by this display");
+          }
+        } else {
+          Serial.println("  Error: this device has no theme-capable display");
+        }
       } else {
         Serial.printf("  Error: unknown config: %s\n", config);
       }

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -38,6 +38,7 @@ public:
   uint8_t _client_repeat = 0;  // DEPRECATED -> use repeat.disable_fwd
   uint8_t path_hash_mode = 0;    // which path mode to use when sending
   uint8_t autoadd_max_hops = 0;  // 0 = no limit, 1 = direct (0 hops), N = up to N-1 hops (max 64)
+  char ui_theme[16];              // UI theme, if supported by the display driver, e.g. "default" (light), "legacy" (dark)
   char default_scope_name[31];
   uint8_t default_scope_key[16];
 
@@ -111,6 +112,7 @@ private:
       def("tel_base", _parent->telemetry_mode_base);
       def("tel_loc", _parent->telemetry_mode_loc);
       def("tel_env", _parent->telemetry_mode_env);
+      def("theme", _parent->ui_theme, sizeof(_parent->ui_theme));
     }
   public:
     CompanionPrefs(NodePrefs* parent) : _parent(parent) { }
@@ -134,6 +136,7 @@ public:
     node_name[0] = 0;
     default_scope_name[0] = 0;
     memset(default_scope_key, 0, sizeof(default_scope_key));
+    strcpy(ui_theme, "default");
   }
   // new accessor methods
   bool isRepeatEn() const { return repeat.disable_fwd == 0; }

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -592,6 +592,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _node_prefs = node_prefs;
 
   if (_display != NULL) {
+    _display->applyTheme(_node_prefs->ui_theme);
     _display->turnOn();
   }
 
@@ -612,6 +613,14 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   home = new HomeScreen(this, &rtc_clock, sensors, node_prefs);
   msg_preview = new MsgPreviewScreen(this, &rtc_clock);
   setCurrScreen(splash);
+}
+
+bool UITask::applyTheme(const char* theme) {
+  return _display != NULL ? _display->applyTheme(theme) : false;
+}
+
+int UITask::getThemeCount() {
+  return _display != NULL ? _display->getThemeCount() : 0;
 }
 
 void UITask::showAlert(const char* text, int duration_millis) {

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -96,6 +96,8 @@ public:
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) override;
   void notify(UIEventType t = UIEventType::none) override;
   void loop() override;
+  bool applyTheme(const char* theme) override;
+  int getThemeCount() override;
 
   void shutdown(bool restart = false);
 };

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -29,6 +29,8 @@ public:
   virtual void startFrame(ColorVal bkg = UIColor::window_bkg) = 0;
   virtual void setTextSize(int sz) = 0;
   virtual void setColor(ColorVal c) = 0;
+  virtual bool applyTheme(const char* theme) { return false; }
+  virtual int getThemeCount() { return 0; }
   virtual void setCursor(int x, int y) = 0;
   virtual void print(const char* str) = 0;
   virtual void printWordWrap(const char* str, int max_width) { print(str); }   // fallback to basic print() if no override

--- a/src/helpers/ui/LGFXDisplay.cpp
+++ b/src/helpers/ui/LGFXDisplay.cpp
@@ -11,6 +11,33 @@ ColorVal UIColor::popup_bkg =  0x07FF;  // CYAN
 ColorVal UIColor::popup_txt = 0x0000;
 ColorVal UIColor::corp_blue = 0x001A;
 
+bool LGFXDisplay::applyTheme(const char* theme) {
+  if (strcmp(theme, "legacy") == 0) {
+    UIColor::window_bkg = 0x0000;
+    UIColor::title_bkg = 0x0000;
+    UIColor::title_txt = 0x07E0;
+    UIColor::primary_txt = 0x07E0;
+    UIColor::secondary_txt = 0xFFE0;
+    UIColor::warning_txt = 0xF800;
+    UIColor::popup_bkg = 0x0000;
+    UIColor::popup_txt = 0xFFFF;
+    UIColor::corp_blue = 0x001F;
+    return true;
+  } else if (strcmp(theme, "default") == 0) {
+    UIColor::window_bkg = 0xFFFF;
+    UIColor::title_bkg = 0x001F;
+    UIColor::title_txt = 0xFFFF;
+    UIColor::primary_txt = 0x0000;
+    UIColor::secondary_txt = (18 << 11) | (36 << 5) | 18;
+    UIColor::warning_txt = 0xFD20;
+    UIColor::popup_bkg = 0x07FF;
+    UIColor::popup_txt = 0x0000;
+    UIColor::corp_blue = 0x001A;
+    return true;
+  }
+  return false;
+}
+
 bool LGFXDisplay::begin() {
   turnOn();
   display->init();

--- a/src/helpers/ui/LGFXDisplay.h
+++ b/src/helpers/ui/LGFXDisplay.h
@@ -35,5 +35,7 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  bool applyTheme(const char* theme) override;
+  int getThemeCount() override { return 2; }
   virtual bool getTouch(int *x, int *y);
 };

--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -107,6 +107,33 @@ ColorVal UIColor::popup_bkg =  0x07FF;  // CYAN
 ColorVal UIColor::popup_txt = 0x0000;
 ColorVal UIColor::corp_blue = 0x001A;
 
+bool NV3001BDisplay::applyTheme(const char* theme) {
+  if (strcmp(theme, "legacy") == 0) {
+    UIColor::window_bkg = 0x0000;
+    UIColor::title_bkg = 0x0000;
+    UIColor::title_txt = 0x07E0;
+    UIColor::primary_txt = 0x07E0;
+    UIColor::secondary_txt = 0xFFE0;
+    UIColor::warning_txt = 0xF800;
+    UIColor::popup_bkg = 0x0000;
+    UIColor::popup_txt = 0xFFFF;
+    UIColor::corp_blue = 0x001F;
+    return true;
+  } else if (strcmp(theme, "default") == 0) {
+    UIColor::window_bkg = 0xFFFF;
+    UIColor::title_bkg = 0x001F;
+    UIColor::title_txt = 0xFFFF;
+    UIColor::primary_txt = 0x0000;
+    UIColor::secondary_txt = (18 << 11) | (36 << 5) | 18;
+    UIColor::warning_txt = 0xFD20;
+    UIColor::popup_bkg = 0x07FF;
+    UIColor::popup_txt = 0x0000;
+    UIColor::corp_blue = 0x001A;
+    return true;
+  }
+  return false;
+}
+
 static int scaleX(int x) {
   return (int)(x * DISPLAY_SCALE_X);
 }

--- a/src/helpers/ui/NV3001BDisplay.h
+++ b/src/helpers/ui/NV3001BDisplay.h
@@ -65,4 +65,6 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  bool applyTheme(const char* theme) override;
+  int getThemeCount() override { return 2; }
 };

--- a/src/helpers/ui/ST7735Display.cpp
+++ b/src/helpers/ui/ST7735Display.cpp
@@ -428,6 +428,33 @@ ColorVal UIColor::popup_bkg = ST77XX_CYAN;
 ColorVal UIColor::popup_txt = ST77XX_BLACK;
 ColorVal UIColor::corp_blue = 0x001A;
 
+bool ST7735Display::applyTheme(const char* theme) {
+  if (strcmp(theme, "legacy") == 0) {
+    UIColor::window_bkg = ST77XX_BLACK;
+    UIColor::title_bkg = ST77XX_BLACK;
+    UIColor::title_txt = ST77XX_GREEN;
+    UIColor::primary_txt = ST77XX_GREEN;
+    UIColor::secondary_txt = ST77XX_YELLOW;
+    UIColor::warning_txt = ST77XX_RED;
+    UIColor::popup_bkg = ST77XX_BLACK;
+    UIColor::popup_txt = ST77XX_WHITE;
+    UIColor::corp_blue = ST77XX_BLUE;
+    return true;
+  } else if (strcmp(theme, "default") == 0) {
+    UIColor::window_bkg = ST77XX_WHITE;
+    UIColor::title_bkg = ST77XX_BLUE;
+    UIColor::title_txt = ST77XX_WHITE;
+    UIColor::primary_txt = ST77XX_BLACK;
+    UIColor::secondary_txt = (18 << 11) | (36 << 5) | 18;
+    UIColor::warning_txt = ST77XX_ORANGE;
+    UIColor::popup_bkg = ST77XX_CYAN;
+    UIColor::popup_txt = ST77XX_BLACK;
+    UIColor::corp_blue = 0x001A;
+    return true;
+  }
+  return false;
+}
+
 bool ST7735Display::begin() {
   if (!sprite) {
     // alloc offscreen canvas

--- a/src/helpers/ui/ST7735Display.h
+++ b/src/helpers/ui/ST7735Display.h
@@ -43,6 +43,8 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  bool applyTheme(const char* theme) override;
+  int getThemeCount() override { return 2; }
 
 protected:
   void _resetAndInit();

--- a/src/helpers/ui/ST7789LCDDisplay.cpp
+++ b/src/helpers/ui/ST7789LCDDisplay.cpp
@@ -34,6 +34,33 @@ ColorVal UIColor::popup_bkg = ST77XX_CYAN;
 ColorVal UIColor::popup_txt = ST77XX_BLACK;
 ColorVal UIColor::corp_blue = 0x001A;
 
+bool ST7789LCDDisplay::applyTheme(const char* theme) {
+  if (strcmp(theme, "legacy") == 0) {
+    UIColor::window_bkg = ST77XX_BLACK;
+    UIColor::title_bkg = ST77XX_BLACK;
+    UIColor::title_txt = ST77XX_GREEN;
+    UIColor::primary_txt = ST77XX_GREEN;
+    UIColor::secondary_txt = ST77XX_YELLOW;
+    UIColor::warning_txt = ST77XX_RED;
+    UIColor::popup_bkg = ST77XX_BLACK;
+    UIColor::popup_txt = ST77XX_WHITE;
+    UIColor::corp_blue = ST77XX_BLUE;
+    return true;
+  } else if (strcmp(theme, "default") == 0) {
+    UIColor::window_bkg = ST77XX_WHITE;
+    UIColor::title_bkg = ST77XX_BLUE;
+    UIColor::title_txt = ST77XX_WHITE;
+    UIColor::primary_txt = ST77XX_BLACK;
+    UIColor::secondary_txt = (18 << 11) | (36 << 5) | 18;
+    UIColor::warning_txt = ST77XX_ORANGE;
+    UIColor::popup_bkg = ST77XX_CYAN;
+    UIColor::popup_txt = ST77XX_BLACK;
+    UIColor::corp_blue = 0x001A;
+    return true;
+  }
+  return false;
+}
+
 bool ST7789LCDDisplay::begin() {
   if (!_isOn) {
     if (_peripher_power) _peripher_power->claim();

--- a/src/helpers/ui/ST7789LCDDisplay.h
+++ b/src/helpers/ui/ST7789LCDDisplay.h
@@ -57,4 +57,6 @@ public:
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
+  bool applyTheme(const char* theme) override;
+  int getThemeCount() override { return 2; }
 };


### PR DESCRIPTION
Adds a runtime-selectable "legacy" dark theme (restoring the pre-refactor black background / green-yellow text palette) as an opt-in alongside the current "default" light theme, for boards using ST7735Display, ST7789LCDDisplay, NV3001BDisplay or LGFXDisplay (e.g. Heltec T096).

Fixes #3169

Selectable via Serial CLI: "set theme legacy" / "set theme default". DisplayDriver::applyTheme() returns false for an unrecognized/unsupported theme name, so the command rejects typos instead of silently falling back.

Persisted in NodePrefs.ui_theme (survives reboots and full power loss, written to flash via DataStore::savePrefs), reapplied at boot and live without reboot. DisplayDriver::getThemeCount() reports per-driver theme support so the command only works on boards with a color-capable display.