### PR TITLE
fix(esp32-c3): use FSPI port number for proper SPI pins initialization on esp32-c3

### DIFF
--- a/variants/tenstar_c3/target.cpp
+++ b/variants/tenstar_c3/target.cpp
@@ -4,7 +4,7 @@
 XiaoC3Board board;
 
 #if defined(P_LORA_SCLK)
-  static SPIClass spi;
+  static SPIClass spi(FSPI);
   RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
 #else
   RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
@@ -31,4 +31,3 @@ mesh::LocalIdentity radio_new_identity() {
   RadioNoiseListener rng(radio);
   return mesh::LocalIdentity(&rng);  // create new random identity
 }
-

--- a/variants/xiao_c3/target.cpp
+++ b/variants/xiao_c3/target.cpp
@@ -4,7 +4,7 @@
 XiaoC3Board board;
 
 #if defined(P_LORA_SCLK)
-  static SPIClass spi;
+  static SPIClass spi(FSPI);
   RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
 #else
   RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
@@ -39,4 +39,3 @@ mesh::LocalIdentity radio_new_identity() {
   RadioNoiseListener rng(radio);
   return mesh::LocalIdentity(&rng);  // create new random identity
 }
-


### PR DESCRIPTION
My fix proposal for #3212.
On ESP32-C3, SPIClass defaults to HSPI, but the Arduino-ESP32 core uses FSPI for the default SPI instance. The SPI bus needs to be explicitly set to FSPI when creating a custom SPIClass instance.
Tested on the Tenstar C3 Super Mini and Seeed XIAO ESP32-C3. This fix may also be useful for other ESP32 targets.