### PR TITLE
Companion USB interface: report real connection state, add flow control 🤖🤖

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -290,7 +290,7 @@ uint8_t MyMesh::getExtraAckTransmitCount() const {
 }
 
 void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
-  if (_serial->isConnected() && len + 3 <= MAX_FRAME_SIZE) {
+  if (_serial->isSessionEstablished() && len + 3 <= MAX_FRAME_SIZE) {
     int i = 0;
     out_frame[i++] = PUSH_CODE_LOG_RX_DATA;
     out_frame[i++] = (int8_t)(snr * 4);
@@ -342,7 +342,7 @@ uint8_t MyMesh::getAutoAddMaxHops() const {
 
 void MyMesh::onContactOverwrite(const uint8_t* pub_key) {
     _store->deleteBlobByKey(pub_key, PUB_KEY_SIZE); // delete from storage
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     out_frame[0] = PUSH_CODE_CONTACT_DELETED;
     memcpy(&out_frame[1], pub_key, PUB_KEY_SIZE);
     _serial->writeFrame(out_frame, 1 + PUB_KEY_SIZE);
@@ -350,14 +350,14 @@ void MyMesh::onContactOverwrite(const uint8_t* pub_key) {
 }
 
 void MyMesh::onContactsFull() {
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     out_frame[0] = PUSH_CODE_CONTACTS_FULL;
     _serial->writeFrame(out_frame, 1);
   }
 }
 
 void MyMesh::onDiscoveredContact(ContactInfo &contact, bool is_new, uint8_t path_len, const uint8_t* path) {
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     if (is_new) {
       writeContactRespFrame(PUSH_CODE_NEW_ADVERT, contact);
     } else {
@@ -511,7 +511,7 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   i += tlen;
   addToOfflineQueue(out_frame, i);
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {   // an idle listener still gets the tickle
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
@@ -522,7 +522,7 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   bool should_display = txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN;
   if (should_display && _ui) {
     _ui->newMsg(path_len, from.name, text, offline_queue_len);
-    if (!_serial->isConnected()) {
+    if (!_serial->isSessionEstablished()) {   // an idle listener gets the push instead
       _ui->notify(UIEventType::contactMessage);
     }
   }
@@ -633,7 +633,7 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
   i += tlen;
   addToOfflineQueue(out_frame, i);
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {   // an idle listener still gets the tickle
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
@@ -681,7 +681,7 @@ void MyMesh::onChannelDataRecv(const mesh::GroupChannel &channel, mesh::Packet *
   }
   addToOfflineQueue(out_frame, i);
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {   // an idle listener still gets the tickle
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
@@ -858,7 +858,7 @@ void MyMesh::onControlDataRecv(mesh::Packet *packet) {
   memcpy(&out_frame[i], packet->payload, packet->payload_len);
   i += packet->payload_len;
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     _serial->writeFrame(out_frame, i);
   } else {
     MESH_DEBUG_PRINTLN("onControlDataRecv(), data received while app offline");
@@ -878,7 +878,7 @@ void MyMesh::onRawDataRecv(mesh::Packet *packet) {
   memcpy(&out_frame[i], packet->payload, packet->payload_len);
   i += packet->payload_len;
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     _serial->writeFrame(out_frame, i);
   } else {
     MESH_DEBUG_PRINTLN("onRawDataRecv(), data received while app offline");
@@ -908,7 +908,7 @@ void MyMesh::onTraceRecv(mesh::Packet *packet, uint32_t tag, uint32_t auth_code,
   i += path_len >> path_sz;
   out_frame[i++] = (int8_t)(packet->getSNR() * 4); // extra/final SNR (to this node)
 
-  if (_serial->isConnected()) {
+  if (_serial->isSessionEstablished()) {
     _serial->writeFrame(out_frame, i);
   } else {
     MESH_DEBUG_PRINTLN("onTraceRecv(), data received while app offline");
@@ -2395,6 +2395,11 @@ void MyMesh::loop() {
   }
 
 #ifdef DISPLAY_CLASS
+  // Recent activity, deliberately: this flag also gates PIN visibility in all
+  // three UIs, and that ten minute recovery is the point of this change -- a
+  // client that merely holds the port open must not hide the pairing PIN
+  // forever. The cost is that an attached but idle client sees message-driven
+  // screen wakes again after ten minutes; recorded as a known limit.
   if (_ui) _ui->setHasConnection(_serial->isConnected());
 #endif
 }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -48,7 +48,69 @@ MultiSerialInterface interface_manager;
 // include usb interface
 #if defined(ENABLE_USB_INTERFACE)
   #include <helpers/ArduinoSerialInterface.h>
+  #if defined(ESP32) && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT \
+      && !(defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE == 1)
+    #include <tusb.h>    // tud_cdc_n_get_line_state(): real DTR, see setup()
+  #endif
   ArduinoSerialInterface usb_serial_interface;
+  #ifndef USB_CLIENT_IDLE_TIMEOUT
+    // how long a USB client is still considered present after its last frame,
+    // for targets which cannot report DTR (see setConnectedCheck below)
+    #define USB_CLIENT_IDLE_TIMEOUT   (10*60*1000UL)
+  #endif
+  #if defined(ESP32) && defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE == 1 \
+      && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // Debounced link state: the HWCDC indication drops out on isolated missed
+  // SOF ticks, and acting on a single false sample retires a live session.
+  //
+  // Confirmation is measured over OBSERVED down samples, not as time since the
+  // link was last seen up. Those differ whenever nobody looked in between: a
+  // synchronous flash save can block for longer than the whole window, and
+  // "last seen up is old" would then make the very first false sample count as
+  // a sustained loss. So: start confirming at the first observed down sample,
+  // cancel on any observed up, and start over after a sampling gap that is
+  // itself longer than the window.
+  #define USB_LINK_DOWN_CONFIRM_MS  500
+  static bool usb_link_down_pending = false;
+  static uint32_t usb_link_down_since = 0;
+  static uint32_t usb_link_last_sample_ms = 0;
+  static bool usb_link_sampled = false;
+  static bool usb_link_up() {
+    uint32_t now = millis();
+    bool sampled_before = usb_link_sampled;
+    uint32_t since_sample = now - usb_link_last_sample_ms;
+    usb_link_last_sample_ms = now; usb_link_sampled = true;
+
+    if ((bool)Serial) { usb_link_down_pending = false; return true; }
+
+    // no usable observation history -> this down sample is the first one
+    if (!sampled_before || since_sample > USB_LINK_DOWN_CONFIRM_MS) {
+      usb_link_down_pending = true; usb_link_down_since = now;
+      return true;
+    }
+    if (!usb_link_down_pending) { usb_link_down_pending = true; usb_link_down_since = now; }
+
+    // A frame that completed AFTER the suspicion started proves the link is
+    // alive, whatever the SOF flag says: on resume the RX path can deliver
+    // before the SOF tick publishes recovery, and retiring then would erase
+    // activity newer than the doubt and drop the reply with it.
+    uint32_t last = usb_serial_interface.getLastFrameMillis();
+    if (last != 0 && (int32_t)(last - usb_link_down_since) >= 0) {
+      usb_link_down_pending = false;
+      return true;
+    }
+    if ((now - usb_link_down_since) <= USB_LINK_DOWN_CONFIRM_MS) return true;
+
+    // Confirmed. Retire the activity mark HERE, not from the outer loop: any
+    // caller may be the one that confirms it, and a link that returns before
+    // the loop looks again would otherwise cancel the pending loss and leave
+    // the next session inheriting eligibility it never earned.
+    if (usb_serial_interface.getLastFrameMillis() != 0) {
+      usb_serial_interface.resetActivity();
+    }
+    return false;
+  }
+  #endif
 #endif
 
 // include ethernet interface
@@ -114,6 +176,14 @@ void halt() {
 #endif
 
 void setup() {
+#if defined(ENABLE_USB_INTERFACE) && defined(ESP32) \
+    && defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE == 1 \
+    && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // BEFORE begin(): setTxBufferSize() frees the old ring without masking the
+  // HWCDC interrupt, so resizing a live buffer can hand a TX-empty ISR freed
+  // memory. While the ISR is still inactive the same call is harmless.
+  Serial.setTxBufferSize(4096);
+#endif
   Serial.begin(115200);
   board.begin();
 
@@ -213,6 +283,56 @@ void setup() {
 // add usb interface
 #if defined(ENABLE_USB_INTERFACE)
   usb_serial_interface.begin(Serial);
+  // NOTE: flow control is enabled per transport below, NOT unconditionally.
+  // It must only run on native CDC links whose TX buffer can hold a whole
+  // frame; on a UART-backed Serial (no CDC-on-boot) it would pace and drop
+  // against a buffer whose size the sketch may change, while isConnected()
+  // there has no link state to go by and always answers "connected".
+#if defined(ESP32) && defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE == 1 \
+    && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // ESP32 USB-Serial-JTAG (HWCDC): has NO DTR concept -- (bool)Serial is true
+  // as soon as the host has merely enumerated the device (SOF/IN-EMPTY), and
+  // write() blocks up to 100ms per call against a stalled host with only a
+  // 256 byte TX buffer. Bigger buffer + short timeout + activity-based
+  // connection detection (a real client must have sent a frame recently).
+  // whole-frame writes + pacing of the contact sync stream: prevents torn
+  // frames / blocking writes when the host stalls or nothing drains the port
+  usb_serial_interface.enableFlowControl(true);
+  Serial.setTxTimeoutMs(5);   // buffer was sized before begin(), see setup()
+  usb_serial_interface.setConnectedCheck([]() {
+    uint32_t last = usb_serial_interface.getLastFrameMillis();
+    return usb_link_up() && last != 0 && (millis() - last) < USB_CLIENT_IDLE_TIMEOUT;
+  });
+  // Push notifications must survive a client that only listens: the ten minute
+  // window above exists to stop a merely enumerated port (a charger) from
+  // looking connected, and once a real frame has arrived that question is
+  // settled. resetActivity() clears _last_frame_ms on link-down, so this does
+  // not resurrect a ghost session.
+  usb_serial_interface.setEstablishedCheck([]() {
+    return usb_link_up() && usb_serial_interface.getLastFrameMillis() != 0;
+  });
+#elif defined(ESP32) && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // ESP32 USB-OTG (TinyUSB CDC): USBCDC::operator bool() is NOT a DTR test --
+  // it only turns true once the host asserts DTR *and* RTS. Clients that leave
+  // RTS low on purpose (the usual way to keep the auto-reset circuit on these
+  // boards quiet) can exchange data perfectly well, and would have every reply
+  // silently dropped. Ask TinyUSB for the line state instead: bit 0 is DTR.
+  // Queried live rather than latched from the line-state event, because USB is
+  // up before setup() runs -- a host that asserts DTR before we could register
+  // a handler would never be seen, and USBCDC suppresses duplicate events.
+  usb_serial_interface.enableFlowControl(true);
+  usb_serial_interface.setConnectedCheck([]() {
+    return (tud_cdc_n_get_line_state(0) & 1) != 0;   // bit 0 = DTR
+  });
+#elif defined(NRF52_PLATFORM) || defined(RP2040_PLATFORM)
+  // TinyUSB-CDC: (bool)Serial reflects real DTR (host has the port open); a
+  // false "always connected" would hide the BLE pairing PIN on the display
+  // and suppress new-message notifications.
+  // (classic ESP32 with a UART bridge keeps the old assume-connected behaviour
+  //  AND stays without flow control -- see the note above)
+  usb_serial_interface.enableFlowControl(true);
+  usb_serial_interface.setConnectedCheck([]() { return (bool)Serial; });
+#endif
   interface_manager.addInterface(InterfaceType::USB, &usb_serial_interface);
 #endif
 
@@ -245,6 +365,22 @@ void setup() {
 }
 
 void loop() {
+#if defined(ENABLE_USB_INTERFACE) && defined(ESP32) \
+    && defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE == 1 \
+    && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // HWCDC: client activity must not survive the USB session it happened in.
+  // (bool)Serial goes true on mere enumeration, so without this a re-plug
+  // within the 10min activity window counts as "client connected" before the
+  // new session has sent a single frame -- mirrored traffic then fills the TX
+  // Poll the link so a loss is noticed even when nothing else asks: the
+  // retirement itself happens inside usb_link_up(), at the moment the loss is
+  // confirmed. Nothing is drained and the parser is not touched. Deliberate
+  // trade-off: a host SUSPEND reads as link-down too (SOF loss is
+  // indistinguishable from an unplug without DTR), so after a resume the
+  // client sends one frame before paced mirroring restarts -- notifications
+  // are unaffected, they use the session predicate.
+  (void)usb_link_up();
+#endif
   the_mesh.loop();
   interface_manager.loop();
   sensors.loop();

--- a/src/helpers/ArduinoSerialInterface.cpp
+++ b/src/helpers/ArduinoSerialInterface.cpp
@@ -13,11 +13,46 @@ void ArduinoSerialInterface::disable() {
   _isEnabled = false;
 }
 
-bool ArduinoSerialInterface::isConnected() const { 
+bool ArduinoSerialInterface::isConnected() const {
+  if (_conn_check) return _conn_check();
   return true;   // no way of knowing, so assume yes
 }
 
+bool ArduinoSerialInterface::isSessionEstablished() const {
+  if (_estab_check) return _estab_check();
+  return isConnected();
+}
+
+void ArduinoSerialInterface::resetActivity() {
+  // ONLY the activity timestamp. The parser is deliberately left alone: a new
+  // session must prove itself with a fresh frame, but resetting the framing
+  // state mid-stream makes the remainder of an interrupted transfer be scanned
+  // as headers, and binary payload then reads as real commands. Letting the
+  // in-flight frame absorb the continuation is what this parser has always
+  // done, and it recovers on its own.
+  _last_frame_ms = 0;
+}
+
 bool ArduinoSerialInterface::isWriteBusy() const {
+  if (_flow_ctl) {
+    // never report busy while no client is attached: with nothing draining
+    // the port the TX buffer sits permanently full (ESP32 HWCDC keeps the
+    // ring filled with discarded frames) and a busy=true here would starve
+    // the paced bulk streams (contact sync) on ALL other interfaces forever
+    if (!isConnected()) return false;
+    int avail = const_cast<Stream*>(_serial)->availableForWrite();
+    if (avail > _max_afw) _max_afw = avail;
+    if (_max_afw < (int)(MAX_FRAME_SIZE + 3)) {
+      // this stream's TX buffer can never hold a max-size frame (classic ESP32
+      // UART FIFO 128, TinyUSB CDC 64, STM32 serial ring 63): pacing against
+      // MAX_FRAME_SIZE would report busy forever and starve the paced bulk
+      // streams -> fall back to unpaced (possibly blocking) writes instead
+      return false;
+    }
+    // pace bulk streams (contact sync) so a slow/stalled host can't force
+    // blocking writes or torn frames
+    return avail < (int)(MAX_FRAME_SIZE + 3);
+  }
   return false;
 }
 
@@ -25,6 +60,25 @@ size_t ArduinoSerialInterface::writeFrame(const uint8_t src[], size_t len) {
   if (len > MAX_FRAME_SIZE) {
     // frame is too big!
     return 0;
+  }
+  if (_flow_ctl) {
+    if (!isSessionEstablished()) {
+      // nobody ever talked to us on this port: drop silently instead of
+      // clogging the TX buffer with frames no one will ever read.
+      // (an established but idle client still gets its frames -- the
+      // whole-frame check below keeps that bounded and non-blocking)
+      return len;
+    }
+    int avail = _serial->availableForWrite();
+    if (avail > _max_afw) _max_afw = avail;
+    if (_max_afw >= (int)(MAX_FRAME_SIZE + 3) && avail < (int)(len + 3)) {
+      // drop the frame as a whole: a short write would tear the length-prefixed
+      // framing and permanently desync the receiver.
+      // (only on streams whose buffer has proven it can hold a max-size frame;
+      // small-buffer transports write through and block like they always did
+      // before flow control existed)
+      return 0;
+    }
   }
 
   uint8_t hdr[3];
@@ -41,6 +95,7 @@ size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {
     int c = _serial->read();
     if (c < 0) break;
 
+
     switch (_state) {
       case RECV_STATE_IDLE:
         if (c == '<') {
@@ -54,6 +109,12 @@ size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {
       case RECV_STATE_LEN1_FOUND:
         _frame_len |= ((uint16_t)c) << 8;   // MSB
         rx_len = 0;
+        // Any declared length is accepted and truncated on delivery, as this
+        // parser has always done -- clients rely on it, and how far they
+        // overshoot is not ours to bound (the Python client encodes the whole
+        // string, so a channel message of multibyte characters runs to several
+        // hundred bytes). A corrupt length costs exactly what it costs the
+        // base: its declared bytes are counted down, then the parser resyncs.
         _state = _frame_len > 0 ? RECV_STATE_LEN2_FOUND : RECV_STATE_IDLE;
         break;
       default:
@@ -65,6 +126,7 @@ size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {
           if (_frame_len > MAX_FRAME_SIZE) _frame_len = MAX_FRAME_SIZE;    // truncate
           memcpy(dest, rx_buf, _frame_len);
           _state = RECV_STATE_IDLE;  // reset state, for next frame
+          _last_frame_ms = millis(); // proof that a real client is talking to us
           return _frame_len;
         }
     }

--- a/src/helpers/ArduinoSerialInterface.h
+++ b/src/helpers/ArduinoSerialInterface.h
@@ -4,22 +4,56 @@
 #include <Arduino.h>
 
 class ArduinoSerialInterface : public BaseSerialInterface {
+public:
+  typedef bool (*ConnectedCheck)();
+
+private:
   bool _isEnabled;
+  bool _flow_ctl;
   uint8_t _state;
   uint16_t _frame_len;
   uint16_t rx_len;
+  uint32_t _last_frame_ms;
+  // high-water mark of availableForWrite(): probes the stream's real TX buffer
+  // capacity at runtime (Print's default is 0, USB-CDC reports 0 while nothing
+  // is connected -- only the peak ever observed reveals the true ceiling)
+  mutable int _max_afw;
   Stream* _serial;
+  ConnectedCheck _conn_check;
+  ConnectedCheck _estab_check;
   uint8_t rx_buf[MAX_FRAME_SIZE];
 
 public:
-  ArduinoSerialInterface() { _isEnabled = false; _state = 0; }
+  ArduinoSerialInterface() { _isEnabled = false; _flow_ctl = false; _state = 0; _last_frame_ms = 0; _max_afw = 0; _conn_check = NULL; _estab_check = NULL; }
 
-  void begin(Stream& serial) { 
-    _serial = &serial; 
+  void begin(Stream& serial) {
+    _serial = &serial;
   #ifdef RAK_4631
     pinMode(WB_IO2, OUTPUT);
-  #endif  
+  #endif
   }
+
+  // optional: lets the target report the real link state (e.g. USB-CDC DTR).
+  // Without this, isConnected() assumes true (plain UARTs have no way of knowing).
+  void setConnectedCheck(ConnectedCheck fn) { _conn_check = fn; }
+
+  // optional: reports whether a client session was ever established on a link
+  // that is still up -- without the recent-traffic requirement isConnected()
+  // may carry. Used for push notifications, so an idle listener is not cut off.
+  void setEstablishedCheck(ConnectedCheck fn) { _estab_check = fn; }
+
+  // optional: only write a frame when it fits into the stream's TX buffer as a
+  // whole (and report busy to pace bulk streams like the contact sync).
+  // A partially written frame permanently desyncs the length-prefixed framing
+  // (no checksum/resync), so dropping whole frames is strictly better.
+  void enableFlowControl(bool enable) { _flow_ctl = enable; }
+
+  // millis() of the last completely received frame, 0 = none since boot/unplug
+  uint32_t getLastFrameMillis() const { return _last_frame_ms; }
+
+  // Forget the activity timestamp, so a new session has to prove itself with a
+  // fresh frame. Does NOT touch the parser or the queue -- see the definition.
+  void resetActivity();
 
   // BaseSerialInterface methods
   void enable() override;
@@ -27,6 +61,7 @@ public:
   bool isEnabled() const override { return _isEnabled; }
 
   bool isConnected() const override;
+  bool isSessionEstablished() const override;
 
   bool isWriteBusy() const override;
   size_t writeFrame(const uint8_t src[], size_t len) override;

--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -14,6 +14,13 @@ public:
   virtual bool isEnabled() const = 0;
 
   virtual bool isConnected() const = 0;
+
+  // Notification eligibility, as opposed to isConnected()'s "a client is
+  // actively talking to us". Defaults to isConnected(); transports whose
+  // isConnected() additionally demands RECENT traffic (USB-CDC without DTR)
+  // override it, so a client that only listens keeps getting push frames.
+  virtual bool isSessionEstablished() const { return isConnected(); }
+
   virtual void loop() {};
 
   virtual bool isWriteBusy() const = 0;

--- a/src/helpers/MultiSerialInterface.h
+++ b/src/helpers/MultiSerialInterface.h
@@ -114,6 +114,21 @@ public:
     return _enabled; 
   }
 
+  bool isSessionEstablished() const override {
+    // mirrors isConnected(), but asks each interface for its own session
+    // eligibility -- a transport whose isConnected() demands RECENT traffic
+    // (USB-CDC without DTR) would otherwise silence push notifications here
+    if(!_enabled){
+      return false;
+    }
+    for(auto iface : _interfaces){
+      if(iface.instance && iface.instance->isSessionEstablished()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool isConnected() const override {
     // not connected when disabled
     if(!_enabled){


### PR DESCRIPTION
Two related fixes for the companion USB interface, found while running the `*_companion_radio_usb` / multi-interface builds on a small fleet of devices.

## 1. The device always believes a client is connected

`ArduinoSerialInterface::isConnected()` returns `true` unconditionally, so from boot onwards the companion thinks somebody is attached to the USB port. That leaks into two places:

* `MyMesh` only calls `_ui->notify()` while no client is connected, so **new message notifications (display, buzzer) never fire** on a USB companion build.
* `UITask` shows `< Connected >` in place of the BLE pairing PIN. On a build that exposes both BLE and USB this means **a freshly flashed device cannot be paired at all** - the PIN is simply never shown.

The commit adds an optional `setConnectedCheck()` hook and wires it up per platform:

| target | source of truth |
|---|---|
| TinyUSB CDC (nRF52, RP2040) | `(bool)Serial` = real DTR, ie. the host has the port open |
| ESP32 USB-OTG (`ARDUINO_USB_MODE=0`, CDC on boot) | `tud_cdc_n_get_line_state()` bit 0 = DTR (see the edit note below) |
| ESP32 USB-Serial-JTAG (`ARDUINO_USB_MODE=1`) | frame activity, see below |
| plain UART | unchanged, still assumes connected |

The USB-Serial-JTAG peripheral has no DTR concept at all - `HWCDC::isCDC_Connected()` is driven by SOF frames plus an IN-EMPTY interrupt, so it goes true as soon as the cable sits in a powered port, whether or not anything opened the port. There is no register that exposes the CDC line state, so the only honest signal left is "a client has actually sent us a frame recently" (`USB_CLIENT_IDLE_TIMEOUT`, 10 minutes, overridable per build).

## 2. No flow control on the USB write path

`CMD_GET_CONTACTS` streams up to `MAX_CONTACTS` frames back to back (~150 bytes each, so ~50 KB with the companion default of 350). `MyMesh::checkSerialInterface()` does gate this on `!_serial->isWriteBusy()`, but `ArduinoSerialInterface::isWriteBusy()` returns `false` unconditionally, and `writeFrame()` calls `write()` without ever looking at `availableForWrite()`.

On ESP32 that meets a 256 byte TX ring: when the host stalls for longer than the write timeout, HWCDC latches itself disconnected and `flushTXBuffer()` silently discards queued bytes, ie. it tears a frame in half. The framing is a length prefix with no checksum and no resync marker, so the client stays desynchronised for the rest of the session. In practice this shows up as "the app disconnects while syncing contacts", and only on devices that already have a decent contact list - a fresh device sends a few hundred bytes and never hits it.

The commit makes flow control an opt-in feature of `ArduinoSerialInterface` (the `Print` default for `availableForWrite()` is 0, so it must not be on by default for arbitrary streams) and enables it for the companion USB interface: report busy until a whole frame fits, and drop a frame as a unit rather than tearing it. It also gives HWCDC a larger TX buffer and a short write timeout, the same reasoning as the existing `kiss_modem` tuning in #2819.

Note the ordering: while no client is connected, writes are dropped and `isWriteBusy()` returns false. Otherwise a port that nobody drains keeps its buffer full forever, and the busy flag would stall the paced streams on *all* interfaces, including BLE.

## Testing

* Built for `heltec_v4_r8_companion_radio_usb` and `GAT562_30S_Mesh_Kit_companion_radio_usb` (ESP32-S3 HWCDC and nRF52 TinyUSB).
* Running in daily use on Heltec V4-R8, MTools GAT562 30s, RAK WisMesh Pocket, LilyGo T-Beam Supreme, LilyGo T-Echo, Heltec T114, Seeed T1000-E and Meshnology W12 in combined BLE+USB builds.
* Verified on device: BLE pairing PIN is shown again on a freshly flashed unit, and a full contact sync from a third party client (KiekR) that previously hung part way through now completes.

The two commits are independent in spirit but the second one uses the connection state from the first, so they are submitted together. Happy to split or rework either of them.

---

*Disclosure: this pull request was prepared by an AI agent (Claude) working together with the repository owner of the fork, who runs the affected devices. The bugs were found in daily use on real hardware, the analysis and patches are the agent's work and were reviewed and tested by a human before submission. Marked with 🤖🤖 per CONTRIBUTING.md. Happy to answer any questions or rework the patches.*

---

**Edited 2026-09-05.** A cross-model adversarial review of this PR's own code found four defects in it. All are fixed in the current head, and two of them change what the patch does to other people's boards, so the description above has been corrected rather than left standing.

* **It broke three existing builds.** The HWCDC block was guarded on `ARDUINO_USB_MODE == 1` alone, but `Heltec_v3_companion_radio_usb`, `Heltec_Wireless_Paper_companion_radio_usb` and `Heltec_WSL3_companion_radio_usb` set that while leaving `ARDUINO_USB_CDC_ON_BOOT` unset — their `Serial` is a `HardwareSerial`, which has neither `setTxTimeoutMs()` nor `onEvent()`. Every HWCDC guard now requires CDC-on-boot as well, and automatic flow control is scoped to native CDC transports, so those three keep exactly the behaviour they had before this PR. Verified by building all three.
* **`(bool)Serial` is not a DTR test on ESP32 USB-OTG.** `USBCDC::operator bool()` only becomes true once the host asserts DTR *and* RTS, so a client that deliberately leaves RTS low — the usual way to keep these boards' auto-reset circuit quiet — had every reply silently discarded. That path now reads DTR directly from `tud_cdc_n_get_line_state()`. Affects `Station_G2`, `Station_G3_ESP32`, `Heltec_E213`, `Heltec_T190`, `heltec_tracker_v2` and `LilyGo_TBeam_1W`.
* **Clients that only listen stopped receiving pushes.** Gating notifications on the ten minute activity window cut off a client that sends its opening commands and then only reads. Notification eligibility is now a predicate of its own — link up and a frame seen at least once — while pacing, PIN visibility and the connection indicator keep the stricter test. `MultiSerialInterface` aggregates it, otherwise it never reaches `MyMesh` at all.
* **The TX buffer was resized after `Serial.begin()`.** `HWCDC::setTxBufferSize()` frees the old ring without masking the interrupt, so resizing a live buffer can hand a TX-empty ISR freed memory. It is now sized before `begin()`, while the ISR is still inactive.

**Removed since the previous version of this branch:** the bus-reset event hook and the RX drain that went with it. They existed to stop a dead session's leftover bytes from confusing the next one, and four different implementations of that idea each turned out worse than the problem — the last of them could splice a frame together across a session boundary and hand `MyMesh` a contact record with framing bytes spliced into it. Without them the parser behaves as it does with no patch at all, which is the behaviour that actually recovers.

Known limits, deliberately not addressed here:

* On link loss the receive parser is left untouched, exactly as it is without this PR: the continuation of an interrupted transfer is absorbed by the in-flight frame and the stream resynchronises by itself. Several attempts to do better each produced a worse failure than the one they removed.
* An attached client that only listens can still see message-driven screen wakes after ten minutes, because that display flag also gates PIN visibility — and restoring the pairing PIN is the point of this change.
* `CMD_SYNC_NEXT_MESSAGE` takes a message out of the offline queue and then ignores `writeFrame()`'s return value. That is pre-existing and outside this PR; it deserves a separate fix.

*The review was run with Codex (`gpt-6-astra`, reasoning effort `max`) as an independent cross-provider second opinion over several rounds; the patches and this description are the work of Claude Code (an AI coding agent), and a human reviewed and approved this edit before it was posted.*
