### PR TITLE
Fix T1000-E application reporting the bootloader's USB product name

### DIFF
--- a/boards/tracker-t1000-e.json
+++ b/boards/tracker-t1000-e.json
@@ -13,7 +13,7 @@
       ["0x239A", "0x002A"],
       ["0x239A", "0x802A"]
     ],
-    "usb_product": "T1000-E-BOOT",
+    "usb_product": "MeshCore T1000-E",
     "mcu": "nrf52840",
     "variant": "Seeed_T1000-E",
     "bsp": {


### PR DESCRIPTION
`boards/tracker-t1000-e.json` sets `usb_product` to `T1000-E-BOOT`, so the application ends up carrying the bootloader's name in its USB descriptor. The two firmwares are labelled backwards: the app enumerates as `T1000-E-BOOT` (239a:8029) and the Seeed bootloader as `T1000-E` (2886:0057).

This matters in the web flasher. flasher.meshcore.io calls `requestPort()` with no filters, so the product string in the browser's port chooser is all the user has to go on. The nRF52 flow prompts twice, once for the 1200-baud touch and once for the flash, and at the second prompt the labels point the wrong way.

The same define is the Adafruit core's `CFG_DEFAULT_NAME`, so it is also what a companion advertises over BLE when a long node name fails to apply (#1769).

Named after the firmware rather than the board so it cannot be confused with the bootloader's string.

Tested on a T1000-E: all five `t1000e_*` environments build, flash and run, with the USB descriptor and BLE name both correct. Has also been running on several T1000-E nodes without issue. Not tested on Windows or macOS.

Note this changes the Linux `/dev/serial/by-id` symlink to `usb-Seeed_Studio_MeshCore_T1000-E_<serial>-if00`. Flashing is unaffected (PlatformIO matches on VID:PID), but anything pinned to the old path needs updating.