### PR TITLE
Fix duplicate MAX_CLIENTS definition

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -59,10 +59,6 @@ struct RepeaterStats {
   uint32_t n_recv_errors;
 };
 
-#ifndef MAX_CLIENTS
-  #define MAX_CLIENTS           32
-#endif
-
 struct NeighbourInfo {
   mesh::Identity id;
   uint32_t advert_timestamp;

--- a/src/helpers/ClientACL.h
+++ b/src/helpers/ClientACL.h
@@ -34,7 +34,7 @@ struct ClientInfo {
 };
 
 #ifndef MAX_CLIENTS
-  #define MAX_CLIENTS           20
+  #define MAX_CLIENTS           32
 #endif
 
 class ClientACL {


### PR DESCRIPTION
MAX_CLIENTS is defined in both src/helpers/ClientACL.h and examples/simple_repeater/MyMesh.h. Appears it was centralised in the former header file some time ago. Both are included in some places and, depending on which order they're in, either value can win.

This change drops the duplicate entry from the repeater firmware and bumps the central limit up to 32 (per the original repeater firmware value).

Changes:
- Remove MAX_CLIENTS from repeater MyMesh.h
- Increase MAX_CLIENTS limit in ClientACL.h to 32