### PR TITLE
Fix I2C address claiming and probe both BMP/BME addresses

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -539,6 +539,8 @@ static void query_bme680_bsec(uint8_t ch, uint8_t, CayenneLPP& lpp) {
 // are compiled in. The sentinel at the end keeps the array
 // non-empty regardless of which sensors are enabled.
 //
+// Bosch BMP/BME SDO selects 0x76 or 0x77; probe both.
+//
 // Ordering here determines channel assignment at runtime:
 // the first detected+initialized sensor gets channel 2, the
 // next gets channel 3, and so on.
@@ -551,21 +553,27 @@ struct SensorDef {
   void      (*query)(uint8_t channel, uint8_t sub_channel, CayenneLPP& telemetry);
 };
 
+#define TELEM_BOSCH_ALT_ADDR(addr) ((uint8_t)((addr) == 0x76 ? 0x77 : 0x76))
+
 static const SensorDef SENSOR_TABLE[] = {
 #if ENV_INCLUDE_AHTX0
   { TELEM_AHTX_ADDRESS,    "AHT10/AHT20", init_ahtx0,    query_ahtx0    },
 #endif
 #ifdef ENV_INCLUDE_BME680
-  { TELEM_BME680_ADDRESS,  "BME680",       init_bme680,   query_bme680   },
+  { TELEM_BME680_ADDRESS,                       "BME680",       init_bme680,      query_bme680      },
+  { TELEM_BOSCH_ALT_ADDR(TELEM_BME680_ADDRESS), "BME680",       init_bme680,      query_bme680      },
 #endif
 #if ENV_INCLUDE_BME680_BSEC
-  { TELEM_BME680_ADDRESS,  "BME680+BSEC",   init_bme680_bsec, query_bme680_bsec },
+  { TELEM_BME680_ADDRESS,                       "BME680+BSEC",  init_bme680_bsec, query_bme680_bsec },
+  { TELEM_BOSCH_ALT_ADDR(TELEM_BME680_ADDRESS), "BME680+BSEC",  init_bme680_bsec, query_bme680_bsec },
 #endif
 #if ENV_INCLUDE_BME280
-  { TELEM_BME280_ADDRESS,  "BME280",       init_bme280,   query_bme280   },
+  { TELEM_BME280_ADDRESS,                       "BME280",       init_bme280,      query_bme280      },
+  { TELEM_BOSCH_ALT_ADDR(TELEM_BME280_ADDRESS), "BME280",       init_bme280,      query_bme280      },
 #endif
 #if ENV_INCLUDE_BMP280
-  { TELEM_BMP280_ADDRESS,  "BMP280",       init_bmp280,   query_bmp280   },
+  { TELEM_BMP280_ADDRESS,                       "BMP280",       init_bmp280,      query_bmp280      },
+  { TELEM_BOSCH_ALT_ADDR(TELEM_BMP280_ADDRESS), "BMP280",       init_bmp280,      query_bmp280      },
 #endif
 #if ENV_INCLUDE_SHTC3
   { 0x70,                  "SHTC3",        init_shtc3,    query_shtc3    },
@@ -602,6 +610,8 @@ static const SensorDef SENSOR_TABLE[] = {
 #endif
   { 0, nullptr, nullptr, nullptr }  // sentinel — keeps the array non-empty
 };
+
+#undef TELEM_BOSCH_ALT_ADDR
 
 static const size_t SENSOR_TABLE_SIZE = (sizeof(SENSOR_TABLE) / sizeof(SENSOR_TABLE[0])) - 1;
 
@@ -640,6 +650,12 @@ bool EnvironmentSensorManager::begin() {
   _active_sensor_count = 0;
   for (size_t i = 0; i < SENSOR_TABLE_SIZE && _active_sensor_count < MAX_ACTIVE_SENSORS; i++) {
     const SensorDef& def = SENSOR_TABLE[i];
+    // One static driver instance per type: an alternate address is a fallback, not a second device.
+    bool already_active = false;
+    for (int j = 0; j < _active_sensor_count; j++) {
+      if (_active_sensors[j].query == def.query) { already_active = true; break; }
+    }
+    if (already_active) continue;
     if (!detected[def.address]) {
       MESH_DEBUG_PRINTLN("%s not detected at I2C address %02X", def.name, def.address);
       continue;

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -650,6 +650,7 @@ bool EnvironmentSensorManager::begin() {
       continue;
     }
     MESH_DEBUG_PRINTLN("Found %s at address: %02X", def.name, def.address);
+    detected[def.address] = false;  // consumed; later entries must not re-claim this device
     for (uint8_t sub = 0; sub < n && _active_sensor_count < MAX_ACTIVE_SENSORS; sub++) {
       _active_sensors[_active_sensor_count++] = { def.query, sub };
     }


### PR DESCRIPTION
Bosch BMP/BME parts pick their I2C address from the SDO pin: 0x76 or 0x77. `SENSOR_TABLE` only ever had the 0x76 entry, so anything strapped high got seen by the bus scan and then quietly skipped. That covers Grove modules and most of the cheap BMP280 breakouts. A user hit this and found their sensor only worked once they moved it to 0x76.

There's already a per-variant `TELEM_*_ADDRESS` override, but it doesn't help here.

First commit claims an address once a driver has successfully initialized it. That's mostly groundwork for the second commit, but it fixes something on its own: several table entries share an address, and not every driver bothers to check a chip ID. `INA226::begin()` only checks that the address ACKs. In the default `sensor_base` both SHT4X and INA226 sit at 0x44, so a real SHT4x was also being registered as an INA226 and reporting junk current on a second channel.

Second commit adds the alternate-address entry for each Bosch sensor. There's one static driver instance per sensor type, so an entry whose query function is already active gets skipped—the second address is a fallback, not a second device. Without that check, two same-type parts at 0x76 and 0x77 would register two channels that both read whichever one initialized last.

On safety: entries whose address didn't ACK during `scanI2CBus` still never get touched, and all four drivers verify a chip ID before they'll claim an address (`Adafruit_BMP280` against the `chipid` argument, `Adafruit_BME280` against 0x60, `bme68x_init` against `BME68X_CHIP_ID`, `Adafruit_BMP085` against 0x55). BMP085 stays last in the table, so a real BMP180 at 0x77 still ends up with its address after the newer drivers turn it down.

One flag: `bme68x_init()` does a soft reset before it reads the chip ID, so with BME680 compiled in, anything that ACKs at 0x77 now takes a blind `0xE0 <- 0xB6`. That's the standard soft-reset register on Bosch parts, and it was already happening at 0x76, so I don't think it's a problem—but it is new behavior at the second address.

Built `Heltec_v3_sensor`, `T_Beam_S3_Supreme_SX1262_repeater` and `LilyGo_T-Echo_repeater`. The last two pin `TELEM_BME280_ADDRESS=0x77`, so they reverse the direction. The overrides are redundant now, but I left them alone rather than grow the diff. The fix was tested on a Station G3 using a BMP280 connected via Grove.