### PR TITLE
Fix Seeed C3 radio BLE exceeding flash size

### DIFF
--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -73,6 +73,7 @@ lib_deps =
 
 [env:Xiao_C3_companion_radio_ble]
 extends = Xiao_esp32_C3
+board_build.partitions = min_spiffs.csv ; get around 4mb flash limit
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<helpers/esp32/*.cpp>


### PR DESCRIPTION
Fixes an issue where the Seeed XIAO ESP32-C3 firmware exceeds the available flash size when BLE is enabled.

Without this change, the firmware can be flashed successfully but the board enters a boot loop during startup and never reaches the setup() stage.