### PR TITLE
Fix searchPeersByHash() silently dropping contacts beyond the 8th hash match

### DIFF
--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -9,8 +9,6 @@
 
 #include "ContactInfo.h"
 
-#define MAX_SEARCH_RESULTS   8
-
 #define MSG_SEND_FAILED       0
 #define MSG_SEND_SENT_FLOOD   1
 #define MSG_SEND_SENT_DIRECT  2
@@ -39,6 +37,18 @@ public:
 #endif
 
 #define MAX_ANON_CONTACTS  8
+
+// Must cover every possible contact, not just a small fixed sample: identity
+// hashes are truncated to PATH_HASH_SIZE (1 byte) on the wire for ANON_REQ/
+// REQ/RESPONSE matching (see Identity::isHashMatch()/copyHashTo()), so with
+// enough contacts, multiple can legitimately share the same hash. A fixed
+// cap smaller than the contact list size means searchPeersByHash() can stop
+// after collecting that many same-hash matches and never even look at a
+// later-added contact sharing that byte -- its replies then fail to decrypt
+// permanently, not intermittently, since decryption is tried against every
+// returned candidate's real shared secret (a wrong match simply fails to
+// authenticate, so there's no correctness reason to cap the search early).
+#define MAX_SEARCH_RESULTS   (MAX_CONTACTS+MAX_ANON_CONTACTS)
 
 #ifndef MAX_CONNECTIONS
   #define MAX_CONNECTIONS  16


### PR DESCRIPTION
Fixes #3242

## Summary
- `BaseChatMesh::searchPeersByHash()` stops scanning the contact list after collecting `MAX_SEARCH_RESULTS` (fixed at 8) matches on a contact's 1-byte identity hash prefix.
- Identity hashing for `ANON_REQ`/`REQ`/`RESPONSE` (admin login, telemetry, message delivery) is always exactly 1 byte (`PATH_HASH_SIZE` in `MeshCore.h`), independent of the runtime `hash_mode` path-hash-size setting — a separate mechanism used only for routing path arrays.
- With only 256 possible prefix values, any contact list with 9+ contacts sharing one prefix byte permanently loses the ability to attribute replies from whichever contact(s) fall past the 8th match in scan order — a deterministic, silent, 100%-reproducible failure per affected contact, not an intermittent one.
- Verified against a live regional MeshCore observer dataset (~3790 nodes): average ~14.8 nodes per prefix byte network-wide, well past the cap of 8, confirming this is realistic at normal mesh density, not just a theoretical edge case.

## Fix
Size `MAX_SEARCH_RESULTS` from the actual contact list bound (`MAX_CONTACTS+MAX_ANON_CONTACTS`) instead of a fixed 8, so the search can never be capped before every real candidate has been checked. There's no correctness reason for the cap to exist at all — every returned candidate is tried against its own real shared secret, so a genuine collision simply fails to authenticate rather than needing to be excluded from consideration.

Not attempting a wire-protocol change here (widening the identity hash itself) — that's a bigger, ecosystem-wide compatibility discussion better left to maintainers.

## Testing
Confirmed clean builds (no functional changes beyond the array/macro sizing) on:
- `Heltec_v3_companion_radio_usb` (default `MAX_CONTACTS=32`)
- `Xiao_S3_WIO_companion_radio_usb` (`MAX_CONTACTS=350`) — RAM usage 44.6%, negligible impact from the larger array
- `RAK_4631_companion_radio_ble` (RAM-constrained nRF52) — RAM usage 63.7%, no meaningful impact

Native unit tests currently fail to build on `dev` independent of this change (pre-existing `atoi`/`atol`/`atof` missing-include issue in `ConfigSerializer.cpp`, confirmed via `git stash` on a clean checkout) — unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)