### PR TITLE
Update GCC toolchain for nRF52 boards to fix builds on Raspberry Pi

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,7 @@ platform_packages =
   ; https://github.com/meshcore-dev/MeshCore/pull/1177
   ; https://github.com/meshcore-dev/MeshCore/pull/1295
   framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301
+  platformio/toolchain-gccarmnoneeabi@^1.140201.0
 extra_scripts = create-uf2.py
 build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM

--- a/src/armstubs.cpp
+++ b/src/armstubs.cpp
@@ -1,0 +1,9 @@
+// https://github.com/meshcore-dev/MeshCore/issues/2469
+// armstubs.cpp exists to silence warnings introduced after upgrading platformio/toolchain-gccarmnoneeabi
+extern "C" __attribute__((weak)) int _close(int fd)  { return -1; }
+extern "C" __attribute__((weak)) int _lseek(int fd, int offset, int whence) { return 0; }
+extern "C" __attribute__((weak)) int _read(int fd, char *buf, int len)  { return 0; }
+extern "C" __attribute__((weak)) int _fstat(int fd, struct stat *st) { return 0; }
+extern "C" __attribute__((weak)) int _isatty(int fd) { return 1; }
+extern "C" __attribute__((weak)) int _getpid(void) { return 1; }
+extern "C" __attribute__((weak)) int _kill(int pid, int sig) { return -1; }


### PR DESCRIPTION
This PR updates the GCC toolchain for nRF52 boards to `^1.140201.0`.

Without this change, attempting to compile firmware on a Raspberry Pi 4B or 5 results in the following error:

```
Tool Manager: Installing platformio/toolchain-gccarmnoneeabi @ >=1.60301.0,<1.80000.0
UnknownPackageError: Could not find the package with 'platformio/toolchain-gccarmnoneeabi @ >=1.60301.0,<1.80000.0' requirements
```

Updating the toolchain resolves this error, and allows the firmware to compile successfully.

This however, introduces a few warning messages about unimplemented methods. Screenshots can be seen in the discussion on issue https://github.com/meshcore-dev/MeshCore/issues/2469.

This PR includes a new `armstubs.cpp` file, which weakly implements the unimplemented methods, which silences those warnings during compilation. As far as I'm aware, none of those methods are used in the code base.

I can now successfully compile firmware on my Raspberry Pi 4B.

Closes https://github.com/meshcore-dev/MeshCore/issues/2469