### PR TITLE
WIO Tracker L1 1W variant

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -886,7 +886,11 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _prefs.gps_enabled = 0;       // GPS disabled by default
   _prefs.gps_interval = 0;      // No automatic GPS updates by default
   _prefs.radio_fem_rxgain = 1;
+#ifdef RADIO_FEM_TXGAIN
+  _prefs.radio_fem_txgain = RADIO_FEM_TXGAIN;   // board-specific default for PA
+#else
   _prefs.radio_fem_txgain = 0;
+#endif
   //_prefs.rx_delay_base = 10.0f;  enable once new algo fixed
   _prefs.setRepeatEn(false);
 #if defined(USE_SX1262) || defined(USE_SX1268)

--- a/variants/wio-tracker-l1-1w/WioTrackerL1Board.cpp
+++ b/variants/wio-tracker-l1-1w/WioTrackerL1Board.cpp
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "WioTrackerL1Board.h"
+
+void WioTrackerL1Board::begin() {
+  NRF52BoardDCDC::begin();
+  btn_prev_state = HIGH;
+
+  pinMode(PIN_VBAT_READ, INPUT); // VBAT ADC input
+  // Set all button pins to INPUT_PULLUP
+  pinMode(PIN_BUTTON1, INPUT_PULLUP);
+  pinMode(PIN_BUTTON2, INPUT_PULLUP);
+  pinMode(PIN_BUTTON3, INPUT_PULLUP);
+  pinMode(PIN_BUTTON4, INPUT_PULLUP);
+  pinMode(PIN_BUTTON5, INPUT_PULLUP);
+  pinMode(PIN_BUTTON6, INPUT_PULLUP);
+  
+
+  #if defined(PIN_WIRE_SDA) && defined(PIN_WIRE_SCL)
+    Wire.setPins(PIN_WIRE_SDA, PIN_WIRE_SCL);
+  #endif
+
+  Wire.begin();
+
+  pinMode(SX126X_POWER_EN, OUTPUT);
+
+  #ifdef P_LORA_TX_LED
+    pinMode(P_LORA_TX_LED, OUTPUT);
+    digitalWrite(P_LORA_TX_LED, LOW);
+  #endif
+
+  delay(10);   // give sx1262 some time to power up
+}
+
+bool WioTrackerL1Board::setLoRaFemPaGainEnabled(bool enable) {
+  _is_pa_enabled = enable;
+  digitalWrite(SX126X_POWER_EN, enable ? HIGH : LOW);   // enable/disable the 1W PA
+  return true;
+}

--- a/variants/wio-tracker-l1-1w/WioTrackerL1Board.h
+++ b/variants/wio-tracker-l1-1w/WioTrackerL1Board.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <Arduino.h>
+#include <helpers/NRF52Board.h>
+
+class WioTrackerL1Board : public NRF52BoardDCDC {
+protected:
+  uint8_t btn_prev_state;
+  bool _is_pa_enabled = false;
+
+public:
+  WioTrackerL1Board() : NRF52Board("WioTrackerL1 OTA") {}
+  void begin();
+
+#if defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+  }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+    int adcvalue = 0;
+    analogReadResolution(12);
+    analogReference(AR_INTERNAL);
+    delay(10);
+    adcvalue = analogRead(PIN_VBAT_READ);
+    return (adcvalue * ADC_MULTIPLIER * AREF_VOLTAGE) / 4.096;
+  }
+
+  const char* getManufacturerName() const override {
+    return "Seeed Wio Tracker L1";
+  }
+
+  bool canControlLoRaFemPaGain() const override { return true; }
+  bool setLoRaFemPaGainEnabled(bool enable) override;
+  bool isLoRaFemPaGainEnabled() const override { return _is_pa_enabled; }
+
+  void powerOff() override {
+    setLoRaFemPaGainEnabled(false);   // turn Off PA
+    NRF52Board::powerOff();
+  }
+};

--- a/variants/wio-tracker-l1-1w/platformio.ini
+++ b/variants/wio-tracker-l1-1w/platformio.ini
@@ -1,0 +1,121 @@
+[WioTrackerL1-1W]
+extends = nrf52_base
+board = seeed-wio-tracker-l1
+board_build.ldscript = boards/nrf52840_s140_v7.ld
+build_flags = ${nrf52_base.build_flags}
+  ${sensor_base.build_flags}
+  -I lib/nrf52/s140_nrf52_7.3.0_API/include
+  -I lib/nrf52/s140_nrf52_7.3.0_API/include/nrf52
+  -I variants/wio-tracker-l1-1w
+  -D WIO_TRACKER_L1
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_OLED_RESET=-1
+  -D GPS_BAUD_RATE=9600
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<WioTrackerL1Board.cpp>
+  +<../variants/wio-tracker-l1-1w>
+  +<helpers/ui/SH1106Display.cpp>
+  +<helpers/sensors>
+lib_deps= ${nrf52_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit SH110X @ ^2.1.13
+  adafruit/Adafruit GFX Library @ ^1.12.1
+
+[env:WioTrackerL1-1W_repeater]
+extends = WioTrackerL1-1W
+build_src_filter = ${WioTrackerL1-1W.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${WioTrackerL1-1W.build_flags}
+  -D ADVERT_NAME='"WioTrackerL1 Repeater"'
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D DISPLAY_CLASS=SH1106Display
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps = ${WioTrackerL1-1W.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+
+[env:WioTrackerL1-1W_room_server]
+extends = WioTrackerL1-1W
+build_src_filter = ${WioTrackerL1-1W.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags = ${WioTrackerL1-1W.build_flags}
+  -D ADVERT_NAME='"WioTrackerL1 Room"'
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D DISPLAY_CLASS=SH1106Display
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps = ${WioTrackerL1-1W.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+
+[env:WioTrackerL1-1W_companion_radio_usb]
+extends = WioTrackerL1-1W
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
+build_flags = ${WioTrackerL1-1W.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=SH1106Display
+  -D UI_HAS_JOYSTICK=1
+  -D OFFLINE_QUEUE_SIZE=256
+  -D PIN_BUZZER=12
+  -D QSPIFLASH=1
+  -D RADIO_FEM_TXGAIN=1
+  -D ENABLE_USB_INTERFACE
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${WioTrackerL1-1W.build_src_filter}
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+  +<helpers/ui/SH1106Display.cpp>
+  +<helpers/ui/buzzer.cpp>
+lib_deps = ${WioTrackerL1-1W.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:WioTrackerL1-1W_companion_radio_ble]
+extends = WioTrackerL1-1W
+board_build.ldscript = boards/nrf52840_s140_v7_extrafs.ld
+board_upload.maximum_size = 708608
+build_flags = ${WioTrackerL1-1W.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+  -D DISPLAY_CLASS=SH1106Display
+  -D UI_HAS_JOYSTICK=1
+  -D PIN_BUZZER=12
+  -D QSPIFLASH=1
+  -D RADIO_FEM_TXGAIN=1
+  -D ADVERT_NAME='"@@MAC"'
+  -D ENV_PIN_SDA=PIN_WIRE1_SDA
+  -D ENV_PIN_SCL=PIN_WIRE1_SCL
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+build_src_filter = ${WioTrackerL1-1W.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps = ${WioTrackerL1-1W.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:WioTrackerL1-1W_kiss_modem]
+extends = WioTrackerL1-1W
+build_src_filter = ${WioTrackerL1-1W.build_src_filter}
+  +<../examples/kiss_modem/>

--- a/variants/wio-tracker-l1-1w/target.cpp
+++ b/variants/wio-tracker-l1-1w/target.cpp
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+#include "target.h"
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/sensors/MicroNMEALocationProvider.h>
+
+WioTrackerL1Board board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#ifdef ENV_INCLUDE_GPS
+MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+EnvironmentSensorManager sensors = EnvironmentSensorManager();
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true, false, false);
+  MomentaryButton joystick_left(JOYSTICK_LEFT, 1000, true, false, false);
+  MomentaryButton joystick_right(JOYSTICK_RIGHT, 1000, true, false, false);
+  MomentaryButton back_btn(PIN_BACK_BTN, 1000, true, false, true);
+#endif
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&SPI);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}
+

--- a/variants/wio-tracker-l1-1w/target.h
+++ b/variants/wio-tracker-l1-1w/target.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <WioTrackerL1Board.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#ifdef DISPLAY_CLASS
+  #if defined(WIO_TRACKER_L1_EINK)
+    #include <helpers/ui/GxEPDDisplay.h>
+  #else
+    #include <helpers/ui/SH1106Display.h>
+  #endif
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+#include <helpers/sensors/EnvironmentSensorManager.h>
+
+extern WioTrackerL1Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+  extern MomentaryButton joystick_left;
+  extern MomentaryButton joystick_right;
+  extern MomentaryButton back_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();
+

--- a/variants/wio-tracker-l1-1w/variant.cpp
+++ b/variants/wio-tracker-l1-1w/variant.cpp
@@ -1,0 +1,78 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+    // D0 .. D10 - Peripheral control pins
+    41, // D0  P1.09    GNSS_WAKEUP
+    7,  // D1  P0.07     LORA_DIO1
+    39, // D2  P1,07     LORA_RESET
+    42, // D3  P1.10     LORA_BUSY
+    46, // D4  P1.14 (A4/SDA) LORA_CS
+    29, // D5  P0.29 (AIN5) LORA_VDET          鈥?Pro 1W: P0.29 (not P1.08)
+    27, // D6  P0.27 (UART_TX) GNSS_TX
+    26, // D7  P0.26 (UART_RX) GNSS_RX
+    30, // D8  P0.30 (SPI_SCK) LORA_SCK
+    3,  // D9  P0.3 (SPI_MISO) LORA_MISO
+    28, // D10 P0.28 (SPI_MOSI) LORA_MOSI
+
+    // D11-D12 - LED outputs
+    33, // D11 P1.01     Mesh_LED (orange)   鈥?Pro 1W: P1.01 (not P1.15)
+    // Buzzzer
+    32, // D12 P1.0 Buzzer
+
+    // D13 - User input
+    8, // D13 P0.08 User Button
+
+    // D14-D15 - OLED
+    6, // D14 P0.06 OLED SDA
+    5, // D15 P0.05 OLED SCL
+
+    // D16 - Battery voltage ADC input
+    31, // D16 P0.31 VBAT_ADC
+    // GROVE
+    43, // D17 P0.00 GROVE SDA
+    44, // D18 P0.01 GROVE SCL
+
+    // FLASH
+    21, // D19 P0.21 (QSPI_SCK)
+    25, // D20 P0.25 (QSPI_CSN)
+    20, // D21 P0.20 (QSPI_SIO_0 DI)
+    24, // D22 P0.24 (QSPI_SIO_1 DO)
+    22, // D23 P0.22 (QSPI_SIO_2 WP)
+    23, // D24 P0.23 (QSPI_SIO_3 HOLD)
+
+    // JOYSTICK
+    36, // D25 TB_UP
+    12, // D26 TB_DOWN
+    11, // D27 TB_LEFT
+    35, // D28 TB_RIGHT
+    37, // D29 TB_PRESS
+
+    // VBAT ENABLE
+    4,  // D30 BAT_CTL
+
+    // D31-D33 - Pro 1W only
+    13, // D31 P0.13     BOOST_EN (Grove 5V Boost)
+    47, // D32 P1.15     nRF_Sig_Charge_State (BQ25616 STAT)
+    14, // D33 P0.14     LORA_PWR_EN (SX1262 + 1 W PA LDO)
+};
+
+void initVariant() {
+    pinMode(PIN_QSPI_CS, OUTPUT);
+    digitalWrite(PIN_QSPI_CS, HIGH);
+
+    // VBAT_ENABLE
+    pinMode(VBAT_ENABLE, OUTPUT);
+    digitalWrite(VBAT_ENABLE, HIGH);
+
+    // set LED pin as output and set it low
+    pinMode(PIN_LED, OUTPUT);
+    digitalWrite(PIN_LED, LOW);
+
+    // set buzzer pin as output and set it low
+    pinMode(12, OUTPUT);
+    digitalWrite(12, LOW);
+    pinMode(12, OUTPUT);
+}

--- a/variants/wio-tracker-l1-1w/variant.h
+++ b/variants/wio-tracker-l1-1w/variant.h
@@ -1,0 +1,130 @@
+#ifndef _SEEED_WIO_TRACKER_L1_H_
+#define _SEEED_WIO_TRACKER_L1_H_
+
+/** Master clock frequency */
+#define VARIANT_MCK             (64000000ul)
+
+#define USE_LFXO                // Board uses 32khz crystal for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#define PINS_COUNT              (34)
+#define NUM_DIGITAL_PINS        (34)
+#define NUM_ANALOG_INPUTS       (8)
+#define NUM_ANALOG_OUTPUTS      (0)
+
+// LEDs
+#define PIN_LED                 (11)
+#define LED_BLUE                (-1) // Disable annoying flashing caused by Bluefruit
+#define LED_BUILTIN             PIN_LED
+#define P_LORA_TX_LED           PIN_LED
+#define LED_STATE_ON            1
+
+// Buttons
+#define PIN_BUTTON1             (13) // Menu / User Button
+#define PIN_BUTTON2             (25) // Joystick Up
+#define PIN_BUTTON3             (26) // Joystick Down
+#define PIN_BUTTON4             (27) // Joystick Left
+#define PIN_BUTTON5             (28) // Joystick Right
+#define PIN_BUTTON6             (29) // Joystick Press
+#define PIN_BACK_BTN            PIN_BUTTON1
+#define JOYSTICK_UP             PIN_BUTTON2
+#define JOYSTICK_DOWN           PIN_BUTTON3
+#define JOYSTICK_LEFT           PIN_BUTTON4
+#define JOYSTICK_RIGHT          PIN_BUTTON5
+#define JOYSTICK_PRESS          PIN_BUTTON6
+#define PIN_USER_BTN            PIN_BUTTON6
+
+// Buzzer
+// #define PIN_BUZZER           (12) // Buzzer pin (defined per firmware type)
+
+#define VBAT_ENABLE             (30)
+
+// Analog pins
+#define PIN_VBAT_READ           (16)
+#define AREF_VOLTAGE            (3.6F)
+#define ADC_MULTIPLIER          (2.0F)
+#define ADC_RESOLUTION          (12)
+
+// Serial interfaces
+#define PIN_SERIAL1_RX          (7)
+#define PIN_SERIAL1_TX          (6)
+
+// SPI Interfaces
+#define SPI_INTERFACES_COUNT    (2)
+
+#define PIN_SPI_MISO            (9)
+#define PIN_SPI_MOSI            (10)
+#define PIN_SPI_SCK             (8)
+
+// BQ25616 single-wire charge status (Pro 1W)
+#define PIN_BOOST_EN (31)           // D31 / P0.13 鈥?Grove 5V Boost enable
+#define EXT_CHRG_DETECT (32)       // D32 / P1.15 鈥?BQ25616 STAT
+#define EXT_CHRG_DETECT_VALUE LOW // 0 = charging, 1 = full / charger sleep
+#define BOOST_EN_ACTIVE HIGH      // HIGH enables Grove 5V Boost
+
+// Lora Pins
+#define  P_LORA_SCLK            PIN_SPI_SCK
+#define  P_LORA_MISO            PIN_SPI_MISO
+#define  P_LORA_MOSI            PIN_SPI_MOSI
+#define  P_LORA_DIO_1           (1)
+#define  P_LORA_RESET           (2)
+#define  P_LORA_BUSY            (3)
+#define  P_LORA_NSS             (4)
+#define  SX126X_RXEN            (5)
+#define  SX126X_TXEN            RADIOLIB_NC
+#define  SX126X_DIO2_AS_RF_SWITCH true
+#define  SX126X_DIO3_TCXO_VOLTAGE (1.8f)
+
+// LORA_PWR_EN (P0.14): external LDO enable for the SX1262 + 1 W PA on the Pro 1W board.
+#define LORA_PWR_EN (33)
+#define SX126X_POWER_EN LORA_PWR_EN
+
+// Wire Interfaces
+#define WIRE_INTERFACES_COUNT   (2)
+
+#define PIN_WIRE_SDA            (14)
+#define PIN_WIRE_SCL            (15)
+#define PIN_WIRE1_SDA           (18)
+#define PIN_WIRE1_SCL           (17)
+#define I2C_NO_RESCAN
+#define DISPLAY_ADDRESS         0x3D  // SH1106 OLED I2C address
+
+// GPS L76KB
+#define GPS_BAUDRATE            9600
+#define PIN_GPS_TX              PIN_SERIAL1_RX
+#define PIN_GPS_RX              PIN_SERIAL1_TX
+#define PIN_GPS_STANDBY         (0)
+#define PIN_GPS_EN              (PIN_GPS_STANDBY)
+
+// QSPI Pins
+#define PIN_QSPI_SCK            (19)
+#define PIN_QSPI_CS             (20)
+#define PIN_QSPI_IO0            (21)
+#define PIN_QSPI_IO1            (22)
+#define PIN_QSPI_IO2            (23)
+#define PIN_QSPI_IO3            (24)
+
+#define EXTERNAL_FLASH_DEVICES P25Q16H
+#define EXTERNAL_FLASH_USE_QSPI
+
+// // EInk on SPI1
+// #define PIN_DISPLAY_CS          (36)
+// #define PIN_DISPLAY_BUSY        (35)
+// #define PIN_DISPLAY_DC          (34)
+// #define PIN_DISPLAY_RST         (32)
+
+#define PIN_SPI1_MISO           (37)
+#define PIN_SPI1_MOSI           (33)
+#define PIN_SPI1_SCK            (31)
+
+// GxEPD2 needs that for a panel that is not even used !
+extern const int MISO;
+extern const int MOSI;
+extern const int SCK;
+
+#endif


### PR DESCRIPTION
1Watt variant support.

Hooks into the Board::setLoRaFemPaGainEnabled() for the PA control. (for repeater/room/sensor nodes).
For companion nodes, have introduced .ini switch for setting PA default:  -D RADIO_FEM_TXGAIN=1