### PR TITLE
Send flood ACK on DM retries

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -722,7 +722,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
 
         mesh::Packet *ack = createAck(ack_hash);
         if (ack) {
-          if (client->out_path_len == OUT_PATH_UNKNOWN) {
+          if (client->out_path_len == OUT_PATH_UNKNOWN || is_retry) {
             sendFloodReply(ack, TXT_ACK_DELAY, packet->getPathHashSize());
           } else {
             sendDirect(ack, client->out_path, client->out_path_len, TXT_ACK_DELAY);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -491,7 +491,7 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
 
       uint32_t delay_millis;
       if (send_ack) {
-        if (client->out_path_len == OUT_PATH_UNKNOWN) {
+        if (client->out_path_len == OUT_PATH_UNKNOWN || is_retry) {
           mesh::Packet *ack = createAck(ack_hash);
           if (ack) sendFloodReply(ack, TXT_ACK_DELAY, packet->getPathHashSize());
           delay_millis = TXT_ACK_DELAY + REPLY_DELAY_MILLIS;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -38,8 +38,8 @@ mesh::Packet* BaseChatMesh::createSelfAdvert(const char* name, double lat, doubl
   return createAdvert(self_id, app_data, app_data_len);
 }
 
-void BaseChatMesh::sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len) {
-  if (dest.out_path_len == OUT_PATH_UNKNOWN) {
+void BaseChatMesh::sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len, bool is_retry) {
+  if (dest.out_path_len == OUT_PATH_UNKNOWN || is_retry) {
     mesh::Packet* ack = createAck(ack_hash, ack_len);
     if (ack) sendFloodScoped(dest, ack, TXT_ACK_DELAY);
   } else {
@@ -230,6 +230,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
     uint32_t timestamp;
     memcpy(&timestamp, data, 4);  // timestamp (by sender's RTC clock - which could be wrong)
     uint8_t flags = data[4] >> 2;   // message attempt number, and other flags
+    bool is_retry = (data[4] & 3) != 0;  // the send attempt: >0 means the sender is retransmitting,
 
     // len can be > original length, but 'text' will be padded with zeroes
     data[len] = 0; // need to make a C string again, with null terminator
@@ -251,7 +252,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
                                                 PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 6);
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
-        sendAckTo(from, ack_hash, 6);
+        sendAckTo(from, ack_hash, 6, is_retry);
       }
     } else if (flags == TXT_TYPE_CLI_DATA) {
       onCommandDataRecv(from, packet, timestamp, (const char *) &data[5]);  // let UI know
@@ -278,7 +279,7 @@ void BaseChatMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender
                                                 PAYLOAD_TYPE_ACK, (uint8_t *) &ack_hash, 4);
         if (path) sendFloodScoped(from, path, TXT_ACK_DELAY);
       } else {
-        sendAckTo(from, (uint8_t *) &ack_hash);
+        sendAckTo(from, (uint8_t *) &ack_hash, 4, is_retry);
       }
     } else {
       MESH_DEBUG_PRINTLN("onPeerDataRecv: unsupported message type: %u", (uint32_t) flags);

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -75,7 +75,7 @@ class BaseChatMesh : public mesh::Mesh {
   ConnectionInfo connections[MAX_CONNECTIONS];
 
   mesh::Packet* composeMsgPacket(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char *text, uint32_t& expected_ack);
-  void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4);
+  void sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, uint8_t ack_len=4, bool is_retry=false);
 
 protected:
   BaseChatMesh(mesh::Radio& radio, mesh::MillisecondClock& ms, mesh::RNG& rng, mesh::RTCClock& rtc, mesh::PacketManager& mgr, mesh::MeshTables& tables)


### PR DESCRIPTION
## Improve DM ACK delivery on weak / asymmetric links

### Problem

On weak or asymmetric links (and with moving nodes) direct messages ACKs often have a low delivery rate. The message itself gets through, but the ACK sent back along the reverse path does not. The sender keeps retrying and the recipient keeps replying with ACKs, yet none of them arrive, so the sender shows the message as undelivered even though it was actually delivered.

The root cause: once a path is established, the recipient always sends the ACK back along the stored reverse path. If that reverse direction doesn't work (asymmetric link), every ACK (including the ones for retries) goes down the same dead path.

### Change

When a message arrives as a retry (meaning the sender didn't receive the ACK for the previous attempt), the recipient sends the ACK by flood instead of along the failing saved path. Flooding reaches the sender by any working route.

The first attempt still uses a normal direct ACK, so nothing changes on healthy links. The flood only happens when the direct ACK has already failed. The retry is detected from the message's existing attempt counter, so there is no new field, config, or protocol change.

#### Current flow:

```
A --DM(attempt 0)--> B      ✓ delivered
A <--ACK(reverse path)-- B  ✗ lost (reverse path broken)
```
A times out, retransmits:
```
A --DM(attempt 1)--> B      ✓ delivered AGAIN
A <--ACK(reverse path)-- B  ✗ lost AGAIN (same broken path)
```
And every retry's ACK goes down the same dead reverse path.
And result shows "NOT DELIVERED", but B actually got it.

#### With this changes:

```
A --DM(attempt 0)--> B      ✓ delivered
A <--ACK(reverse path)-- B  ✗ lost (first attempt, still saved path)
```
A times out, retransmits:
```
A --DM(attempt 1)--> B      ✓ delivered; B sees attempt>0 = "retry"
A <==ACK(flood)== B         ✓ reaches A by ANY working route
```
Result: A marks DELIVERED, stops retrying


Yes, this adds some flood load. But only one tiny ACK packet, and only on a retry.
In practice it reduces load overall: now some people work around the poor ACK rate by using a private channel for two people instead of DMs, and channel messages generate more flood traffic than a single ACK.

I tested this change in my city and found that It noticeably improves DM delivery confirmation and the overall DM experience.

And the same changes applies to the other roles that generate DM ACKs:
* Repeaters (admin CLI commands are sent as DMs)
* Room servers (receive client DMs and ACK them)