### PR TITLE
Add support for RAK12500 and RAK12501 GPS on RAK3401

### DIFF
--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,6 +6,7 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
+  -D RAK_BOARD
   -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -188,8 +188,8 @@ static const uint8_t AREF = PIN_AREF;
 // Power is on the controllable 3V3_S rail
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
-#define PIN_GPS_RX PIN_SERIAL1_RX
-#define PIN_GPS_TX PIN_SERIAL1_TX
+#define PIN_GPS_TX PIN_SERIAL1_RX
+#define PIN_GPS_RX PIN_SERIAL1_TX
 
 #define PIN_GPS_1PPS PIN_GPS_PPS
 #define GPS_BAUD_RATE 9600


### PR DESCRIPTION
This PR adds support for RAK12500 (u-blox ZOE-M8Q) and RAK12501 (Quectel L76K) on the RAK3401 1W boards.

We already have support for these GPS modules in RAK4631 builds, however these were not working on RAK3401.

There's a couple of other PRs looking to add support for GPS on RAK3401, but they're significantly more complex.

- https://github.com/meshcore-dev/MeshCore/pull/2640
- https://github.com/meshcore-dev/MeshCore/pull/2927
- https://github.com/meshcore-dev/MeshCore/pull/3051

For now, I'm opting for the most simplistic change to get these modules working.

Changes have been tested with both modules on RAK3401, and I've verified satellite lock on both repeater and companion firmwares.

> Note: GPS modules need to be in Slot A on the RAK4631 and RAK3401 boards. Connecting them to Slot D will result in the user button thinking it's being long pressed, which on companion firmware results in the node booting into CLI Rescue Mode, and Bluetooth Companion connections will not work. For now, users should avoid using Slot D.