### PR TITLE
Fix PA on RAK3401 when GPS missing

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -831,11 +831,15 @@ bool EnvironmentSensorManager::gpsIsAwake(uint8_t ioPin){
     }
   #endif
 
+  #ifndef RAK_3401
   //set initial waking state
   pinMode(ioPin,OUTPUT);
   digitalWrite(ioPin,LOW);
   delay(500);
   digitalWrite(ioPin,HIGH);
+  #endif
+
+  // give gps time to power up
   delay(500);
 
   //Try to init RAK12500 on I2C
@@ -871,7 +875,9 @@ bool EnvironmentSensorManager::gpsIsAwake(uint8_t ioPin){
     return true;
   }
 
+  #ifndef RAK_3401
   pinMode(ioPin, INPUT);
+  #endif
   MESH_DEBUG_PRINTLN("GPS did not init with this IO pin... try the next");
   return false;
 }
@@ -880,8 +886,10 @@ bool EnvironmentSensorManager::gpsIsAwake(uint8_t ioPin){
 void EnvironmentSensorManager::start_gps() {
   gps_active = true;
   #ifdef RAK_WISBLOCK_GPS
+    #ifndef RAK_3401
     pinMode(gpsResetPin, OUTPUT);
     digitalWrite(gpsResetPin, HIGH);
+    #endif
     return;
   #endif
 
@@ -896,8 +904,10 @@ void EnvironmentSensorManager::start_gps() {
 void EnvironmentSensorManager::stop_gps() {
   gps_active = false;
   #ifdef RAK_WISBLOCK_GPS
+    #ifndef RAK_3401 // rak3401 shouldn't turn off WB_IO2 as it powers the PA
     pinMode(gpsResetPin, OUTPUT);
     digitalWrite(gpsResetPin, LOW);
+    #endif
     return;
   #endif
 


### PR DESCRIPTION
This PR fixes a bug I introduced in https://github.com/meshcore-dev/MeshCore/pull/3268 where the PA on RAK3401 would not be powered if a GPS module was not present.

The existing logic to probe for GPS modules at boot turns on a few IO pins, and then turns them off.
This included the 3V3 rail on `WB_IO2`. We must not turn off `WB_IO2` on RAK3401.

I've tested PA output power with GPS present and GPS missing.

Turning GPS on and off will no longer toggle these IO pins.

Ideally we wouldn't add board specific defines like this into the `EnvironmentSensorManager`, but we already have `RAK_WISBLOCK_GPS` anyway...