### PR TITLE
add variant for Adafruit Feather RP2040 with RFM95 LoRa Radio

### DIFF
--- a/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.cpp
+++ b/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.cpp
@@ -1,0 +1,33 @@
+#include "FeatherRP2040RFMBoard.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+void FeatherRP2040RFMBoard::begin() {
+  startup_reason = BD_STARTUP_NORMAL;
+
+#ifdef P_LORA_TX_LED
+  pinMode(P_LORA_TX_LED, OUTPUT);
+#endif
+
+#ifdef PIN_VBAT_READ
+  pinMode(PIN_VBAT_READ, INPUT);
+#endif
+
+#ifdef PIN_USER_BTN
+  pinMode(PIN_USER_BTN, INPUT_PULLUP);
+#endif
+
+#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
+  Wire.setSDA(PIN_BOARD_SDA);
+  Wire.setSCL(PIN_BOARD_SCL);
+#endif
+
+  Wire.begin();   // STEMMA QT connector
+
+  delay(10);   // give the RFM95 some time to power up
+}
+
+bool FeatherRP2040RFMBoard::startOTAUpdate(const char* id, char reply[]) {
+  return false;
+}

--- a/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.h
+++ b/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+
+/*
+ * Adafruit Feather RP2040 with RFM95 LoRa Radio (product 5714)
+ *   https://learn.adafruit.com/feather-rp2040-rfm95
+ *
+ * The RFM95 (SX1276) is hard-wired to the RP2040's SPI1 block, which the
+ * Arduino core exposes as the default `SPI` object on this board.
+ *
+ * NOTE: this board has no battery voltage divider, so getBattMilliVolts()
+ * returns 0. Wiring a divider from VBAT to one of A0..A3 and defining
+ * PIN_VBAT_READ / ADC_MULTIPLIER in the build flags will enable it.
+ */
+
+class FeatherRP2040RFMBoard : public mesh::MainBoard {
+protected:
+  uint8_t startup_reason;
+
+public:
+  void begin();
+  uint8_t getStartupReason() const override { return startup_reason; }
+
+#ifdef P_LORA_TX_LED
+  void onBeforeTransmit() override { digitalWrite(P_LORA_TX_LED, HIGH); }
+  void onAfterTransmit() override { digitalWrite(P_LORA_TX_LED, LOW); }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+#if defined(PIN_VBAT_READ) && defined(ADC_MULTIPLIER)
+    analogReadResolution(12);
+
+    uint32_t raw = 0;
+    for (int i = 0; i < BATTERY_SAMPLES; i++) {
+      raw += analogRead(PIN_VBAT_READ);
+    }
+    raw = raw / BATTERY_SAMPLES;
+
+    return (ADC_MULTIPLIER * raw) / 4096;
+#else
+    return 0;
+#endif
+  }
+
+  const char* getManufacturerName() const override { return "Adafruit Feather RP2040 RFM"; }
+
+  void reboot() override { rp2040.reboot(); }
+
+  bool startOTAUpdate(const char* id, char reply[]) override;
+};

--- a/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.h
+++ b/variants/adafruit_feather_rp2040_rfm/FeatherRP2040RFMBoard.h
@@ -11,9 +11,26 @@
  * Arduino core exposes as the default `SPI` object on this board.
  *
  * NOTE: this board has no battery voltage divider, so getBattMilliVolts()
- * returns 0. Wiring a divider from VBAT to one of A0..A3 and defining
- * PIN_VBAT_READ / ADC_MULTIPLIER in the build flags will enable it.
+ * returns 0 and the node reports 0.00% battery. That is a hardware limit, not
+ * a firmware bug.
+ *
+ * A LiPo can reach 4.2V, so it must be divided before it can be read by the
+ * 3.3V ADC. Two 100k 1% resistors from BAT to A0 give a 2:1 divider:
+ *
+ *      BAT --+ -/\/\/\/\- --+
+ *                  100k     |
+ *                           +-- A0 (GPIO26)
+ *                           |
+ *      GND --+ -/\/\/\/\- --+
+ *                  100k
+ *
+ * then add to the env's build_flags:
+ *
+ *   -D PIN_VBAT_READ=26
+ *   -D ADC_MULTIPLIER='(2.0f * 3.3f * 1000)'
  */
+
+#define BATTERY_SAMPLES 8
 
 class FeatherRP2040RFMBoard : public mesh::MainBoard {
 protected:

--- a/variants/adafruit_feather_rp2040_rfm/platformio.ini
+++ b/variants/adafruit_feather_rp2040_rfm/platformio.ini
@@ -1,0 +1,60 @@
+; Adafruit Feather RP2040 with RFM95 LoRa Radio (SX1276)
+; https://www.adafruit.com/product/5714
+; https://learn.adafruit.com/feather-rp2040-rfm95/pinouts
+
+[adafruit_feather_rp2040_rfm]
+extends = rp2040_base
+board = adafruit_feather_rfm
+board_build.filesystem_size = 1m
+build_flags = ${rp2040_base.build_flags}
+  -I variants/adafruit_feather_rp2040_rfm
+  -D USE_SX1276
+  -D RADIO_CLASS=CustomSX1276
+  -D WRAPPER_CLASS=CustomSX1276Wrapper
+; RFM95 module, hard-wired to the RP2040 SPI1 block (exposed as the `SPI` object)
+  -D P_LORA_NSS=16
+  -D P_LORA_RESET=17
+  -D P_LORA_DIO_0=21   ; IRQ
+  -D P_LORA_DIO_1=22   ; used for CAD / preamble detect
+  -D P_LORA_SCLK=14
+  -D P_LORA_MISO=8
+  -D P_LORA_MOSI=15
+  -D P_LORA_TX_LED=13  ; red LED next to the USB connector
+; the RFM95 is PA_BOOST only, 20dBm is the chip maximum
+  -D LORA_TX_POWER=20
+  -D SX127X_CURRENT_LIMIT=120
+; the 433MHz model (product 5714 is the 900MHz one) needs eg. -D LORA_FREQ=433.0
+build_src_filter = ${rp2040_base.build_src_filter}
+  +<../variants/adafruit_feather_rp2040_rfm>
+lib_deps = ${rp2040_base.lib_deps}
+
+[env:Adafruit_Feather_RP2040_RFM_repeater]
+extends = adafruit_feather_rp2040_rfm
+build_flags = ${adafruit_feather_rp2040_rfm.build_flags}
+  -D ADVERT_NAME='"Feather RFM Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${adafruit_feather_rp2040_rfm.build_src_filter}
+  +<../examples/simple_repeater>
+
+[env:Adafruit_Feather_RP2040_RFM_companion_radio_usb]
+extends = adafruit_feather_rp2040_rfm
+build_flags = ${adafruit_feather_rp2040_rfm.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D ENABLE_USB_INTERFACE
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${adafruit_feather_rp2040_rfm.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps = ${adafruit_feather_rp2040_rfm.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+lib_ignore = BLE
+
+; NOTE: no BLE or WiFi companion envs for this board. The Feather RP2040 RFM has
+; no wireless hardware other than the RFM95 itself, and MeshCore only implements
+; SerialBLEInterface for esp32/nrf52 and SerialWifiInterface for esp32.

--- a/variants/adafruit_feather_rp2040_rfm/target.cpp
+++ b/variants/adafruit_feather_rp2040_rfm/target.cpp
@@ -1,0 +1,26 @@
+#include "target.h"
+
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+FeatherRP2040RFMBoard board;
+
+// SX127x has no BUSY line: the Module() args are (cs, irq=DIO0, rst, gpio=DIO1)
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_0, P_LORA_RESET, P_LORA_DIO_1, SPI);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  return radio.std_init(&SPI);   // the RFM95 is on the default SPI object (hw SPI1)
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);   // create new random identity
+}

--- a/variants/adafruit_feather_rp2040_rfm/target.h
+++ b/variants/adafruit_feather_rp2040_rfm/target.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+
+#include <RadioLib.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/radiolib/CustomSX1276Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/SensorManager.h>
+#include <FeatherRP2040RFMBoard.h>
+
+extern FeatherRP2040RFMBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
Adds a variant for the [Adafruit Feather RP2040 RFM95](https://www.adafruit.com/product/5714), which pairs an RP2040 with an SX1276-based RFM95 module.

The RFM95 is wired to the RP2040's spi1 block, which this board's Arduino variant exposes as the default SPI object. Pin mapping is taken from the framework-arduinopico adafruit_feather_rfm variant: NSS=16, RST=17, DIO0=21, DIO1=22, SCK=14, MISO=8, MOSI=15.

TX power is capped at 20dBm as the RFM95 is PA_BOOST only.

Provides repeater and USB companion environments. BLE and WiFi companion environments are not included: the board has no wireless hardware other than the RFM95, and SerialBLEInterface/SerialWifiInterface are only implemented for esp32 and nrf52.

Credits to Matt Hixson for testing this.