### PR TITLE
ThinkNode M6: make GPS usable in the repeater and room server builds

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -29,6 +29,16 @@
   #define ADVERT_LON 0.0
 #endif
 
+// GPS defaults for a NEW install. Boards with a permanently-fitted GNSS (and no
+// UI to switch it on) override these in their platformio.ini; every other board
+// keeps the historical "GPS off, advertise the configured coordinates" defaults.
+#ifndef GPS_ENABLED_DEFAULT
+  #define GPS_ENABLED_DEFAULT 0
+#endif
+#ifndef ADVERT_LOC_POLICY_DEFAULT
+  #define ADVERT_LOC_POLICY_DEFAULT ADVERT_LOC_PREFS
+#endif
+
 #ifndef ADMIN_PASSWORD
   #define ADMIN_PASSWORD "password"
 #endif
@@ -919,9 +929,9 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   StrHelper::strncpy(_prefs.bridge_secret, "LVSITANOS", sizeof(_prefs.bridge_secret));
 
   // GPS defaults
-  _prefs.gps_enabled = 0;
+  _prefs.gps_enabled = GPS_ENABLED_DEFAULT;
   _prefs.gps_interval = 0;
-  _prefs.advert_loc_policy = ADVERT_LOC_PREFS;
+  _prefs.advert_loc_policy = ADVERT_LOC_POLICY_DEFAULT;
 
   _prefs.adc_multiplier = 0.0f; // 0.0f means use default board multiplier
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -670,9 +670,9 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
 #endif
 
   // GPS defaults
-  _prefs.gps_enabled = 0;
+  _prefs.gps_enabled = GPS_ENABLED_DEFAULT;
   _prefs.gps_interval = 0;
-  _prefs.advert_loc_policy = ADVERT_LOC_PREFS;
+  _prefs.advert_loc_policy = ADVERT_LOC_POLICY_DEFAULT;
 
 #if defined(USE_SX1262) || defined(USE_SX1268)
 #ifdef SX126X_RX_BOOSTED_GAIN

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -61,6 +61,16 @@
   #define  ADVERT_LON  0.0
 #endif
 
+// GPS defaults for a NEW install. Boards with a permanently-fitted GNSS (and no
+// UI to switch it on) override these in their platformio.ini; every other board
+// keeps the historical "GPS off, advertise the configured coordinates" defaults.
+#ifndef GPS_ENABLED_DEFAULT
+  #define  GPS_ENABLED_DEFAULT  0
+#endif
+#ifndef ADVERT_LOC_POLICY_DEFAULT
+  #define  ADVERT_LOC_POLICY_DEFAULT  ADVERT_LOC_PREFS
+#endif
+
 #ifndef ADMIN_PASSWORD
   #define  ADMIN_PASSWORD  "password"
 #endif

--- a/variants/thinknode_m6/platformio.ini
+++ b/variants/thinknode_m6/platformio.ini
@@ -47,6 +47,16 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
+; The L76K GNSS is soldered to the M6 and the enclosure is sealed, so there is
+; no button or screen to switch GPS on with. Skip the 1s "is a GPS attached?"
+; probe (it gates the 'gps' setting, and losing that race leaves GPS
+; unreachable until reboot), enable GPS for new installs, and advertise the
+; position the GNSS actually reports instead of the fixed 0,0 above.
+; All of it stays changeable at runtime over the serial CLI: 'gps on'/'gps off',
+; 'gps advert prefs|share|none', and bare 'gps' to print fix + satellite count.
+  -D ENV_SKIP_GPS_DETECT=1
+  -D GPS_ENABLED_DEFAULT=1
+  -D ADVERT_LOC_POLICY_DEFAULT=ADVERT_LOC_SHARE
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 ;  -D GPS_NMEA_DEBUG=1
@@ -64,6 +74,13 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D ROOM_PASSWORD='"hello"'
+; Same reasoning as the repeater env above: the L76K is soldered on and the
+; enclosure is sealed, so GPS has to come up enabled and advertise the position
+; the GNSS actually reports. Runtime CLI still wins ('gps on'/'gps off',
+; 'gps advert prefs|share|none').
+  -D ENV_SKIP_GPS_DETECT=1
+  -D GPS_ENABLED_DEFAULT=1
+  -D ADVERT_LOC_POLICY_DEFAULT=ADVERT_LOC_SHARE
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${ThinkNode_M6.build_src_filter}


### PR DESCRIPTION
Split out of #3287 as one self-contained fix, per the one-fix-per-PR guideline.
The companion PR covers the M6 status LED and shares no files with this one.

## Problem

On a sealed Elecrow ThinkNode M6 (nRF52840 + SX1262 + soldered-on L76K GNSS,
IP65 solar enclosure) the GNSS could not be used at all:

1. `simple_repeater` and `simple_room_server` both default `gps_enabled = 0`, so
   `sensors.begin()` detected the L76K and then immediately powered it back down
   via `_location->stop()` (which drives `PIN_GPS_EN` low). The M6 has no button
   or screen, so there was no way to switch it on short of a USB console.
2. Both default `advert_loc_policy` to `ADVERT_LOC_PREFS`, so adverts carried
   the fixed `ADVERT_LAT`/`ADVERT_LON` (0,0) and ignored the GNSS entirely.
3. The 1-second "is a GPS attached?" probe in `initBasicGPS()` gates the `gps`
   setting; losing that race leaves GPS unreachable until reboot. The M6 always
   has the module fitted.

## Approach

Rather than changing behaviour for every board, the two example defaults become
build-time overridable:

```c
#ifndef GPS_ENABLED_DEFAULT
  #define GPS_ENABLED_DEFAULT 0
#endif
#ifndef ADVERT_LOC_POLICY_DEFAULT
  #define ADVERT_LOC_POLICY_DEFAULT ADVERT_LOC_PREFS
#endif
```

**Every other board keeps its existing defaults.** Only the M6 `repeater` and
`room_server` envs opt in, and they also set `ENV_SKIP_GPS_DETECT`. Both
settings remain adjustable at runtime via `gps on`/`gps off` and
`gps advert prefs|share|none`.

Each example declares the defines where it already keeps its `ADVERT_*`
fallbacks — `MyMesh.cpp` for the repeater, `MyMesh.h` for the room server — to
match each example's own convention rather than imposing one layout on both.

## Testing

- `ThinkNode_M6_repeater`, `ThinkNode_M6_room_server`, `RAK_4631_repeater` and
  `RAK_4631_room_server` all build against `dev`.
- `pio run -t envdump` confirms the new flags resolve for the M6 envs and are
  **absent** for the RAK envs, so other boards are provably untouched.
- Confirmed on real M6 hardware over the serial CLI: `gps -> on, active, fix,
  13 sats`, `gps advert -> share`, surviving a reboot.

## Note for maintainers

One pre-existing behaviour worth being aware of (not changed by this PR): these
compiled defaults only apply to a *fresh* install. A UF2 update does not erase
InternalFS, so a device that has run MeshCore before keeps its saved prefs and
silently ignores new defaults — it must be reconfigured at runtime or factory
reset. This cost me some debugging and may be worth documenting.

---
Authored with assistance from Claude (see `Co-Authored-By` trailers).
