### PR TITLE
Write the path hash size on zero hop packets 🤖🤖

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1261,7 +1261,7 @@ void MyMesh::handleCmdFrame(size_t len) {
         memcpy(&default_scope.key, _prefs.default_scope_key, sizeof(default_scope.key));
         sendFloodScoped(default_scope, pkt, delay_millis);
       } else {
-        sendZeroHop(pkt);
+        sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
       }
       writeOKFrame();
     } else {
@@ -1970,7 +1970,7 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_SEND_CONTROL_DATA && len >= 2 && (cmd_frame[1] & 0x80) != 0) {
     auto resp = createControlData(&cmd_frame[1], len - 1);
     if (resp) {
-      sendZeroHop(resp);
+      sendZeroHop(resp, (uint32_t)0, _prefs.path_hash_mode + 1);
       writeOKFrame();
     } else {
       writeErrFrame(ERR_CODE_TABLE_FULL);
@@ -2258,7 +2258,7 @@ bool MyMesh::advert() {
     pkt = createSelfAdvert(_prefs.node_name, sensors.node_lat, sensors.node_lon);
   }
   if (pkt) {
-    sendZeroHop(pkt);
+    sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
     return true;
   } else {
     return false;

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -811,7 +811,7 @@ void MyMesh::onControlDataRecv(mesh::Packet* packet) {
       memcpy(&data[6], self_id.pub_key, PUB_KEY_SIZE);
       auto resp = createControlData(data, prefix_only ? 6 + 8 : 6 + PUB_KEY_SIZE);
       if (resp) {
-        sendZeroHop(resp, getRetransmitDelay(resp)*4);  // apply random delay (widened x4), as multiple nodes can respond to this
+        sendZeroHop(resp, getRetransmitDelay(resp)*4, _prefs.path_hash_mode + 1);  // apply random delay (widened x4), as multiple nodes can respond to this
       }
     }
   } else if (type == CTL_TYPE_NODE_DISCOVER_RESP && packet->payload_len >= 6) {
@@ -854,7 +854,7 @@ void MyMesh::sendNodeDiscoverReq() {
 
   auto pkt = createControlData(data, sizeof(data));
   if (pkt) {
-    sendZeroHop(pkt);
+    sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
   }
 }
 
@@ -1035,7 +1035,7 @@ void MyMesh::sendSelfAdvertisement(int delay_millis, bool flood) {
     if (flood) {
       sendFloodScoped(default_scope, pkt, delay_millis, _prefs.path_hash_mode + 1);
     } else {
-      sendZeroHop(pkt, delay_millis);
+      sendZeroHop(pkt, delay_millis, _prefs.path_hash_mode + 1);
     }
   } else {
     MESH_DEBUG_PRINTLN("ERROR: unable to create advertisement packet!");
@@ -1301,7 +1301,7 @@ void MyMesh::loop() {
     updateAdvertTimer();      // also schedule local advert (so they don't overlap)
   } else if (next_local_advert && millisHasNowPassed(next_local_advert)) {
     mesh::Packet *pkt = createSelfAdvert();
-    if (pkt) sendZeroHop(pkt);
+    if (pkt) sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
 
     updateAdvertTimer(); // schedule next local advert
   }

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -799,7 +799,7 @@ void MyMesh::sendSelfAdvertisement(int delay_millis, bool flood) {
     if (flood) {
       sendFloodScoped(default_scope, pkt, delay_millis, _prefs.path_hash_mode + 1);
     } else {
-      sendZeroHop(pkt, delay_millis);
+      sendZeroHop(pkt, delay_millis, _prefs.path_hash_mode + 1);
     }
   } else {
     MESH_DEBUG_PRINTLN("ERROR: unable to create advertisement packet!");
@@ -1047,7 +1047,7 @@ void MyMesh::loop() {
     updateAdvertTimer();      // also schedule local advert (so they don't overlap)
   } else if (next_local_advert && millisHasNowPassed(next_local_advert)) {
     mesh::Packet *pkt = createSelfAdvert();
-    if (pkt) sendZeroHop(pkt);
+    if (pkt) sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
 
     updateAdvertTimer(); // schedule next local advert
   }

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -445,7 +445,7 @@ public:
     } else if (strcmp(command, "advert") == 0) {
       auto pkt = createSelfAdvert(_prefs.node_name, _prefs.node_lat, _prefs.node_lon);
       if (pkt) {
-        sendZeroHop(pkt);
+        sendZeroHop(pkt);   // no path.hash.mode in this example, 1-byte default stands
         Serial.println("   (advert sent, zero hop).");
       } else {
         Serial.println("   ERR: unable to send");

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -652,7 +652,7 @@ void SensorMesh::onControlDataRecv(mesh::Packet* packet) {
       memcpy(&data[6], self_id.pub_key, PUB_KEY_SIZE);
       auto resp = createControlData(data,  prefix_only ? 6 + 8 : 6 + PUB_KEY_SIZE);
       if (resp) {
-        sendZeroHop(resp, getRetransmitDelay(resp)*4);  // apply random delay (widened x4), as multiple nodes can respond to this
+        sendZeroHop(resp, getRetransmitDelay(resp)*4, _prefs.path_hash_mode + 1);  // apply random delay (widened x4), as multiple nodes can respond to this
       }
     }
   }
@@ -826,7 +826,7 @@ void SensorMesh::sendSelfAdvertisement(int delay_millis, bool flood) {
     if (flood) {
       sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
     } else {
-      sendZeroHop(pkt, delay_millis);
+      sendZeroHop(pkt, delay_millis, _prefs.path_hash_mode + 1);
     }
   } else {
     MESH_DEBUG_PRINTLN("ERROR: unable to create advertisement packet!");
@@ -908,7 +908,7 @@ void SensorMesh::loop() {
     updateAdvertTimer();   // also schedule local advert (so they don't overlap)
   } else if (next_local_advert && millisHasNowPassed(next_local_advert)) {
     mesh::Packet* pkt = createSelfAdvert();
-    if (pkt) sendZeroHop(pkt);
+    if (pkt) sendZeroHop(pkt, (uint32_t)0, _prefs.path_hash_mode + 1);
 
     updateAdvertTimer();   // schedule next local advert
   }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -714,24 +714,38 @@ void Mesh::sendDirect(Packet* packet, const uint8_t* path, uint8_t path_len, uin
   sendPacket(packet, pri, delay_millis);
 }
 
-void Mesh::sendZeroHop(Packet* packet, uint32_t delay_millis) {
+void Mesh::sendZeroHop(Packet* packet, uint32_t delay_millis, uint8_t path_hash_size) {
+  if (path_hash_size == 0 || path_hash_size > 3) {
+    MESH_DEBUG_PRINTLN("%s Mesh::sendZeroHop(): invalid path_hash_size", getLogDateTime());
+    return;
+  }
+
   packet->header &= ~PH_ROUTE_MASK;
   packet->header |= ROUTE_TYPE_DIRECT;
 
-  packet->path_len = 0;  // path_len of zero means Zero Hop
+  // Zero hop = zero path segments, but the path hash size still has to be
+  // written: it lives in the upper 2 bits of the same byte, so the previous
+  // `path_len = 0` cleared it as well and every zero hop packet went out
+  // declaring a 1-byte path hash regardless of the node's path.hash.mode.
+  packet->setPathHashSizeAndCount(path_hash_size, 0);
 
   _tables->markSeen(packet); // mark this packet as already sent in case it is rebroadcast back to us
 
   sendPacket(packet, 0, delay_millis);
 }
 
-void Mesh::sendZeroHop(Packet* packet, uint16_t* transport_codes, uint32_t delay_millis) {
+void Mesh::sendZeroHop(Packet* packet, uint16_t* transport_codes, uint32_t delay_millis, uint8_t path_hash_size) {
+  if (path_hash_size == 0 || path_hash_size > 3) {
+    MESH_DEBUG_PRINTLN("%s Mesh::sendZeroHop(): invalid path_hash_size", getLogDateTime());
+    return;
+  }
+
   packet->header &= ~PH_ROUTE_MASK;
   packet->header |= ROUTE_TYPE_TRANSPORT_DIRECT;
   packet->transport_codes[0] = transport_codes[0];
   packet->transport_codes[1] = transport_codes[1];
 
-  packet->path_len = 0;  // path_len of zero means Zero Hop
+  packet->setPathHashSizeAndCount(path_hash_size, 0);   // see note in the overload above
 
   _tables->markSeen(packet); // mark this packet as already sent in case it is rebroadcast back to us
 

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -214,14 +214,16 @@ public:
 
   /**
    * \brief  send a locally-generated Packet to just neighbor nodes (zero hops)
+   * \param path_hash_size   width this node advertises in the path byte (1..3)
   */
-  void sendZeroHop(Packet* packet, uint32_t delay_millis=0);
+  void sendZeroHop(Packet* packet, uint32_t delay_millis=0, uint8_t path_hash_size=1);
 
   /**
    * \brief  send a locally-generated Packet to just neighbor nodes (zero hops), with specific transport codes
    * \param transport_codes   array of 2 codes to attach to packet
+   * \param path_hash_size    width this node advertises in the path byte (1..3)
   */
-  void sendZeroHop(Packet* packet, uint16_t* transport_codes, uint32_t delay_millis=0);
+  void sendZeroHop(Packet* packet, uint16_t* transport_codes, uint32_t delay_millis=0, uint8_t path_hash_size=1);
 
 };
 


### PR DESCRIPTION
`sendZeroHop()` sets `packet->path_len = 0` to mean "no path segments". That byte also carries the path hash size in its upper 2 bits (`Packet.h`), so the assignment clears the size too, and **every zero hop packet goes out declaring a 1-byte path hash regardless of the node's `path.hash.mode`**. `sendFlood()` already takes a `path_hash_size` and writes it through `setPathHashSizeAndCount()`; this makes `sendZeroHop()` do the same.

### Why it matters

Routing is unaffected — a zero hop packet carries no path and is never repeated (`Mesh.cpp` gates on `getPathHashCount() > 0`). What it affects is what a node *reports about itself*, because observers derive a node's hash size from the packets they hear. A node configured for 2 bytes sends its flood adverts as 2-byte and its periodic local adverts as 1-byte, so it appears inconsistent and downstream tooling has had to special-case zero hop adverts.

This was reported in #2154. The mechanism was identified correctly there ("`sendFlood` is now correctly using the path hash mode ... however `sendZeroHop` ... doesn't") but the behaviour was left as is, and it was independently reproduced in that thread across firmware 14.0–15.0 on several boards. The question asked there and not answered was whether changing it would break older firmware — see the next section.

Measured on the Czech community mesh, counting only packets that carry at least one hop (where the width is corroborated by the path length rather than just declared): **849 packets from 158 senders at 2 bytes, 107 from 4 senders at 3 bytes, 85 from 32 senders at 1 byte.** Zero hop packets have to be excluded from that kind of census entirely, which is exactly the workaround this change removes the need for.

### Backwards compatibility

Receivers already tolerate a non-zero size on a zero hop packet. `Dispatcher.cpp` reads

```cpp
uint8_t path_mode = pkt->path_len >> 6;  // upper 2 bits (legacy firmware: 00)
...
uint8_t path_byte_len = (pkt->path_len & 63) * pkt->getPathHashSize();
```

so the size is masked out of the hop count and the legacy `00` is already accounted for. Nothing in the tree compares the whole `path_len` byte against zero to detect a zero hop packet. A zero hop packet that now declares 2 or 3 bytes parses correctly on existing firmware.

### Scope

`path_hash_size` defaults to `1`, so any caller that does not pass a size produces **byte-identical output to today**. Examples that have a `path.hash.mode` setting now pass it, mirroring their adjacent `sendFlood()` calls. Two call sites deliberately keep the default:

- `BaseChatMesh::shareContactZeroHop()` rebroadcasts *another* node's stored advert blob, so this node's setting does not apply.
- `simple_secure_chat` has no `path.hash.mode` in its `NodePrefs` at all.

Note that the second `sendZeroHop()` overload takes `uint16_t* transport_codes`, so a bare `0` for `delay_millis` becomes ambiguous once a fourth parameter exists; the affected call sites pass `(uint32_t)0`.

### Testing

- `pio test -e native -e native_kiss_modem` — 48/48 pass.
- Built `Heltec_v3_repeater`, `Heltec_v3_companion_radio_ble`, `Heltec_v3_room_server`, `RAK_4631_repeater`, `PicoW_repeater`, `wio-e5-mini_repeater`, plus `Heltec_t096_sensor` and `PicoW_terminal_chat` — the last two cover `simple_sensor` and `simple_secure_chat`, which the PR build matrix does not include but this change touches.

Related to #2154.
