### PR TITLE
BME680 BSEC for RAK3401 variant

### DIFF
--- a/variants/rak3401/fix_bsec_lib.py
+++ b/variants/rak3401/fix_bsec_lib.py
@@ -1,0 +1,15 @@
+Import('env')
+import os
+
+# Bosch has a goof in their PlatformIO packaging making linking fail.
+# The BSEC library's extra_script.py selects cortex-m4/libalgobsec.a (soft-float ABI).
+# nRF52840 compiles with -mfloat-abi=hard, requiring the fpv4-sp-d16-hard blob.
+# Workaround to prepend the hard-float path so the linker finds it before the 
+# soft-float one.
+bsec_hard = os.path.join(
+    env.subst('$PROJECT_DIR'),
+    '.pio', 'libdeps', env.subst('$PIOENV'),
+    'BSEC Software Library', 'src',
+    'cortex-m4', 'fpv4-sp-d16-hard'
+)
+env.Prepend(LIBPATH=[bsec_hard])

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -2,6 +2,8 @@
 extends = nrf52_base
 board = rak3401
 board_check = true
+extra_scripts = ${nrf52_base.extra_scripts}
+  post:variants/rak3401/fix_bsec_lib.py
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
@@ -14,6 +16,8 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
   -D SX126X_REGISTER_PATCH=1       ; Patch register 0x8B5 for improved RX with SKY66122 FEM
+  -UENV_INCLUDE_BME680
+  -D ENV_INCLUDE_BME680_BSEC=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak3401>
   +<helpers/sensors>
@@ -24,6 +28,7 @@ lib_deps =
   ${sensor_base.lib_deps}
   adafruit/Adafruit SSD1306 @ ^2.5.13
   sparkfun/SparkFun u-blox GNSS Arduino Library@^2.2.27
+  boschsensortec/BSEC Software Library @ ^1.8.1492
 
 [env:RAK_3401_repeater]
 extends = rak3401


### PR DESCRIPTION
This is a copy of the current implementation of BME680 environment sensor support using the Bosch BSEC library for the RAK4631 #2634.

Tested with RAK3401+RAK19001+RAK13302 and RAK1906 environment sensor for repeater, sensor, companion builds.