### PR TITLE
Add a 'batt' CLI command to report battery voltage locally

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -194,6 +194,19 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+### Show the current battery voltage
+**Usage:** `batt`
+
+**Notes:**
+- Reports the board's raw battery reading in millivolts, e.g. `> 4051 mV`.
+- Reads the same value the node reports over the mesh in its repeater stats, so
+  a headless node can be checked locally over USB without a second radio to
+  query it.
+- On a node running from USB this reflects the charging voltage rather than the
+  battery's resting state.
+
+---
+
 ## Configuration
 
 ### Radio

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -273,6 +273,11 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       sprintf(reply, "%s (Build: %s)", _callbacks->getFirmwareVer(), _callbacks->getBuildDate());
     } else if (memcmp(command, "board", 5) == 0) {
       sprintf(reply, "%s", _board->getManufacturerName());
+    } else if (memcmp(command, "batt", 4) == 0) {
+      // Live battery reading. Until now this was only reachable over the mesh
+      // via REQ_TYPE_GET_STATUS, so a headless node on the bench could not be
+      // checked without a second radio to ask it.
+      sprintf(reply, "> %u mV", _board->getBattMilliVolts());
     } else if (memcmp(command, "sensor get ", 11) == 0) {
       const char* key = command + 11;
       const char* val = _sensors->getSettingByKey(key);


### PR DESCRIPTION
## Problem

Battery voltage is currently only reachable **over the mesh**, via
`REQ_TYPE_GET_STATUS` in the repeater / room-server stats reply. There is no way
to read it from the serial console.

That makes it unavailable in exactly the situation where you most want it:
bringing up a new headless node. A repeater has no screen, no button and (in the
repeater build) no BLE, so checking its battery requires a second radio to query
it over the air. On a solar node that is the first number you want to look at.

The existing `pwrmgt.*` get-keys do not fill this gap — they are gated behind
`NRF52_POWER_MANAGEMENT`, which many variants (ThinkNode M6 among them) do not
enable, and they report *boot* voltage rather than a live reading:

```
> get pwrmgt.bootmv
  -> ERROR: Power management not supported
```

## Change

Adds a `batt` command that returns the live reading:

```
> batt
  -> 4174 mV
```

It calls `MainBoard::getBattMilliVolts()`, which is pure-virtual and already
implemented by every board, and returns the same value the node already reports
in its stats. No new board API, no per-variant work, nothing gated on
`NRF52_POWER_MANAGEMENT`.

Documented in `docs/cli_commands.md` alongside `board`, including the caveat
that the value reflects charging voltage while the node is on USB.

## Testing

- `ThinkNode_M6_repeater`, `ThinkNode_M6_room_server` and `RAK_4631_repeater`
  all build against `dev` (the change is in shared CLI code, so a non-M6 board
  was built deliberately).
- Verified on real ThinkNode M6 hardware: `batt -> 4174 mV`, consistent with a
  near-full 18650 pack on USB charge.
- The added lines are already `.clang-format` clean.

## Note on process

`CONTRIBUTING.md` asks for an issue first on new features, and this is
technically a new command rather than a bug fix. I've opened it directly since
it is 5 lines against an existing interface with no new API surface — but very
happy to close this and file an issue instead if you would rather discuss the
idea first, or if you would prefer this exposed as `get batt` for consistency
with the other read-only values rather than as a top-level command.

---
Authored with assistance from Claude (see `Co-Authored-By` trailer).
