### PR TITLE
Fix clock on Heltec T1: Do not misidentify IMU as an RTC

### DIFF
--- a/variants/heltec_t1/variant.h
+++ b/variants/heltec_t1/variant.h
@@ -9,6 +9,12 @@
 #define USE_LFXO
 #define VARIANT_MCK (64000000ul)
 
+// This board has no external RTC chip -- the ICM-42607-P IMU sits at 0x68,
+// the same I2C address DS3231 probing checks, so without this the IMU gets
+// misidentified as a DS3231 and its unrelated registers get read/written
+// as if they were time/status registers, producing a bogus, unfixable clock.
+#define DISABLE_DS3231_PROBE
+
 ////////////////////////////////////////////////////////////////////////////////
 // Number of pins
 


### PR DESCRIPTION
The T1 has an ICM-42607-P IMU with the same address as a DS3231 RTC. This completely breaks the clock on the T1. Reading the time results in a garbage value, causing all sorts of strange issues. I noticed this because the time never advances, which breaks logging in to repeaters (due to their time-based replay protection).

This simply disables the probe on the I2C line. The DS3231 doesn't have a WHO_AM_I register that could be used to prevent misidentifying it, so this simpler fix is used.

Here is the schematic showing the IMU: https://resource.heltec.cn/download/Mesh_Node_T1/schematic/Mesh_Node_T1_V1.0.pdf
<img width="561" height="559" alt="image" src="https://github.com/user-attachments/assets/eb13cc57-e297-4614-ae33-b2a348fbff0b" />

Pin 1 is tied to GND, which sets the address to 1101000 or 0x68 ([datasheet](https://www.lcsc.com/datasheet/C5129967.pdf)), same as the DS3231.

<img width="1297" height="78" alt="image" src="https://github.com/user-attachments/assets/8be8c2a2-56ed-45f3-85b1-809c3d33f4e2" />

https://github.com/meshcore-dev/MeshCore/blob/0679dbeffc504d562d2f09eb072fdc223f8ffc2a/src/helpers/AutoDiscoverRTCClock.cpp#L18

# Testing

Without this fix, the time doesn't update:
```
alex@thinkpad ~/w/MeshCore> meshcore-cli -S
40C140D1|* clock
Current time : 1999-12-31 18:09:00 (946688940)
40C140D1|* clock sync
Time synced
40C140D1|* clock
Current time : 1999-12-31 18:09:00 (946688940)
```

With this fix:
```
40C140D1|* clock
Current time : 2024-05-15 05:22:46 (1715772166)
40C140D1|* clock sync
Time synced
40C140D1|* clock
Current time : 2026-08-25 15:29:19 (1787693359)
```

Here's the ble companion firmware if anyone wants to try flashing it at https://meshcore.io and testing it.
[firmware.zip](https://github.com/user-attachments/files/31439182/firmware.zip)