### PR TITLE
Added build profiles for sh1106 display with rak4631

### DIFF
--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -271,3 +271,202 @@ build_src_filter = ${rak4631.build_src_filter}
   +<../examples/kiss_modem/>
 lib_deps =
   ${rak4631.lib_deps}
+
+[rak4631_sh1106]
+build_flags =
+  -D DISPLAY_CLASS=SH1106Display
+  -D DISPLAY_CLASS_SH1106
+build_src_filter =
+  -<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/SH1106Display.cpp>
+lib_deps =
+  adafruit/Adafruit SH110X @ ~2.1.13
+
+[env:RAK_4631_repeater_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RAK4631 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+
+[env:RAK_4631_repeater_ethernet_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RAK4631 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D ETHERNET_ENABLED=1
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+  https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+
+[env:RAK_4631_repeater_bridge_rs232_serial1_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RS232 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=Serial1
+  -D WITH_RS232_BRIDGE_RX=PIN_SERIAL1_RX
+  -D WITH_RS232_BRIDGE_TX=PIN_SERIAL1_TX
+  -UENV_INCLUDE_GPS
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<../examples/simple_repeater>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+
+[env:RAK_4631_repeater_bridge_rs232_serial2_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RS232 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=Serial2
+  -D WITH_RS232_BRIDGE_RX=PIN_SERIAL2_RX
+  -D WITH_RS232_BRIDGE_TX=PIN_SERIAL2_TX
+  -UENV_INCLUDE_GPS
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<../examples/simple_repeater>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+
+[env:RAK_4631_room_server_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"Test Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+
+[env:RAK_4631_room_server_ethernet_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RAK4631 Room Server"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+  -D ETHERNET_ENABLED=1
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+  https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+
+[env:RAK_4631_companion_radio_usb_sh1106]
+extends = rak4631
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -I examples/companion_radio/ui-new
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D ENABLE_USB_INTERFACE
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:RAK_4631_companion_radio_ethernet_sh1106]
+extends = rak4631
+board_build.ldscript = boards/nrf52840_s140_v6.ld
+board_upload.maximum_size = 712704
+build_unflags =
+  -D EXTRAFS=1
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -I examples/companion_radio/ui-new
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D ETHERNET_ENABLED=1
+  -D ETHERNET_USE_RAK13800
+  -D ETHERNET_CLASS=RAK13800EthernetInterface
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+  +<helpers/ethernet/*.cpp>
+  +<helpers/ethernet/RAK13800/>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  https://github.com/RAKWireless/RAK13800-W5100S/archive/1.0.2.zip
+
+[env:RAK_4631_companion_radio_ble_sh1106]
+extends = rak4631
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -I examples/companion_radio/ui-new
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:RAK_4631_sensor_sh1106]
+extends = rak4631
+build_flags = ${rak4631.build_flags}
+  ${rak4631_sh1106.build_flags}
+  -D ADVERT_NAME='"RAK4631 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+build_src_filter = ${rak4631.build_src_filter}
+  ${rak4631_sh1106.build_src_filter}
+  +<../examples/simple_sensor>
+lib_deps = ${rak4631.lib_deps}
+  ${rak4631_sh1106.lib_deps}
+

--- a/variants/rak4631/target.h
+++ b/variants/rak4631/target.h
@@ -9,7 +9,12 @@
 #include <helpers/sensors/EnvironmentSensorManager.h>
 
 #ifdef DISPLAY_CLASS
-  #include <helpers/ui/SSD1306Display.h>
+  #if defined(DISPLAY_CLASS_SH1106)
+    #include <helpers/ui/SH1106Display.h>
+  #else
+    #include <helpers/ui/SSD1306Display.h>
+  #endif
+
   extern DISPLAY_CLASS display;
   #include <helpers/ui/MomentaryButton.h>
   extern MomentaryButton user_btn;


### PR DESCRIPTION
I had bought a case from https://www.etsy.com/listing/1825734915/wisblock-rak19007-mini-box-secured sometime ago. This display is a sh1106 which wasn't supported on meshcore. It had worked with meshtastic so I knew it wasn't a compatibility issue with the hardware.

Added copies of each rak4631 build profile to work with the sh1106 display.

After starting the PR I noticed this issue: #3296
I'd rather open a PR instead of ignoring the issue even if it is decided to reject the change.