### PR TITLE
Fix ESP32 repeater boot crash-loop on blank/first-boot flash

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -73,7 +73,18 @@ void setup() {
   fs = &InternalFS;
   IdentityStore store(InternalFS, "");
 #elif defined(ESP32)
-  SPIFFS.begin(true);
+  if (!SPIFFS.begin(true)) {
+    // format-on-mount-fail can itself fail on some boards/first-boots (blank flash).
+    // Retry with an explicit format before giving up, otherwise callers below will
+    // read/write against a non-mounted filesystem and get garbage back instead of
+    // clean failures (observed as SPIFFS mount errors followed by a boot crash-loop).
+    MESH_DEBUG_PRINTLN("SPIFFS mount failed, retrying with explicit format");
+    SPIFFS.format();
+    if (!SPIFFS.begin(true)) {
+      MESH_DEBUG_PRINTLN("SPIFFS mount failed after format, halting");
+      halt();
+    }
+  }
   fs = &SPIFFS;
   IdentityStore store(SPIFFS, "/identity");
 #elif defined(RP2040_PLATFORM)


### PR DESCRIPTION
## Summary

Fixes #2506 ("Constant rebooting when the repeater is started on Heltec V4 with MeshCore V1.15.0").

`SPIFFS.begin(true)` in `examples/simple_repeater/main.cpp` never checked its return value. On a freshly erased/first-boot flash, the initial SPIFFS mount can fail, and the format-on-mount-fail path built into `SPIFFS.begin()` can itself fail on the first attempt. The code previously proceeded regardless, leaving `fs`/`IdentityStore`/`CommonCLI`/`ClientACL`/`RegionMap` all operating against a non-functional filesystem object. Reads against SPIFFS in that broken state don't fail cleanly — they can return stale/garbage data — which corrupts node prefs/ACL/region state in memory and crashes shortly after boot (observed as `StoreProhibited`/`IllegalInstruction` exceptions, with register contents matching raw erased-flash byte patterns, e.g. `0xff`/`0xff00`/`0xff0000`/`0xff000000`). The device then reboots into the same broken state, producing a permanent crash-loop that only a full erase-and-reflash without hitting the same race would clear (unreliable in practice).

## Fix

Check `SPIFFS.begin(true)`'s return value. On failure, retry once with an explicit `SPIFFS.format()` followed by `SPIFFS.begin()`, and `halt()` with a clear debug log message if it still fails — instead of silently continuing with a broken filesystem.

This only changes the ESP32 failure path; the working case (mount succeeds first try) is untouched.

## Testing

Reproduced and verified the fix on physical hardware — a Heltec V4 (ESP32-S3, 2MB PSRAM / 16MB flash):
- Built `heltec_v4_repeater` via PlatformIO from this branch.
- Full chip `erase_flash` + reflash on the unpatched firmware (v1.14.1 through v1.17.1 all reproduce): device crash-loops every boot on the blank flash, matching the symptoms in #2506.
- Same erase + reflash with this patch applied: device boots cleanly, generates/prints its Repeater ID, completes `MyMesh::begin()`, sends the boot advertisement, and runs stably (verified over multiple clean test windows with the serial port in raw/no-echo mode to rule out host-side artifacts).

## Test plan
- [ ] CI build passes for the `heltec_v4_repeater` (and other ESP32 repeater/room-server/companion) environments
- [ ] Maintainer confirms this doesn't regress the normal (non-blank-flash) boot path