### PR TITLE
fix(prefs): widen ConfigSerializer rd_len to uint16_t

### DIFF
--- a/src/helpers/ConfigSerializer.h
+++ b/src/helpers/ConfigSerializer.h
@@ -25,7 +25,7 @@ protected:
   class Context {
     Stream* _f;
     OP _op;
-    uint8_t rd_len;
+    uint16_t rd_len;  // must hold CONFIG_MAX_TOKEN_LEN (build-flag override may exceed 255)
     uint8_t rd_mode;
     char pending;
     char rd_buf[CONFIG_MAX_TOKEN_LEN];


### PR DESCRIPTION
Update the JSON config length to support `uint16_t` 

We hit this when custom prefs exceed the 256 max length.