### PR TITLE
allow using AIN1 for VBAT on RAK19007 boards

### DIFF
--- a/variants/rak4631/RAK4631Board.h
+++ b/variants/rak4631/RAK4631Board.h
@@ -5,8 +5,12 @@
 #include <helpers/NRF52Board.h>
 
 // built-ins
-#define  PIN_VBAT_READ    5
-#define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+#ifndef PIN_VBAT_READ
+  #define  PIN_VBAT_READ    5
+#endif
+#ifndef ADC_MULTIPLIER
+  #define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+#endif
 
 class RAK4631Board : public NRF52BoardDCDC {
 protected:

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -108,7 +108,9 @@ extern "C"
 // Set to 0 to disable boot protection
 #define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
 // LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
-// AIN3 = P0.05 = PIN_A0 / PIN_VBAT_READ
+// Defaults to AIN3 = P0.05 = PIN_A0 = the default PIN_VBAT_READ. Boards that
+// sense VBAT elsewhere (e.g. a RAK19007 fed from J11 AIN1 = P0.03) can override
+// this; keep it on the same pin as PIN_VBAT_READ.
 #ifndef PWRMGT_LPCOMP_AIN
   #define PWRMGT_LPCOMP_AIN 3
 #endif

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -109,8 +109,12 @@ extern "C"
 #define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
 // LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
 // AIN3 = P0.05 = PIN_A0 / PIN_VBAT_READ
-#define PWRMGT_LPCOMP_AIN 3
-#define PWRMGT_LPCOMP_REFSEL 4  // 5/8 VDD (~3.13-3.44V)
+#ifndef PWRMGT_LPCOMP_AIN
+  #define PWRMGT_LPCOMP_AIN 3
+#endif
+#ifndef PWRMGT_LPCOMP_REFSEL
+  #define PWRMGT_LPCOMP_REFSEL 4  // 5/8 VDD (~3.13-3.44V)
+#endif
 
 // Other pins
 #define PIN_AREF (2)


### PR DESCRIPTION
This allows someone using the RAK19007 board to use AIN1 on the J11 header to get VBAT. Handy if using an external supply like a Voltaic pack.