### PR TITLE
Allow external battery packs to drive battery percentage on RAK boards

### DIFF
--- a/variants/rak3401/RAK3401Board.h
+++ b/variants/rak3401/RAK3401Board.h
@@ -5,8 +5,19 @@
 #include <helpers/NRF52Board.h>
 
 // built-ins
-#define  PIN_VBAT_READ    5
-#define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+// Battery sense defaults to the WisBlock base board divider (VBAT -> 1M/1.5M -> AIN0/P0.05).
+// Both defines can be overridden from build flags to read an externally supplied battery
+// voltage on another analog pin, e.g. the USB-C SBU pin of a Voltaic V25/V50/V75 pack
+// (1/2 of its cell voltage) wired to the base board J11 AIN1 pin:
+//   -D PIN_VBAT_READ=31 -D ADC_MULTIPLIER=7200
+// ADC_MULTIPLIER is the reported millivolts at ADC full scale (3.6V): 3600 reports the
+// pin voltage as-is, 7200 doubles it (for 1/2-scale sources like the V25 SBU pin).
+#ifndef PIN_VBAT_READ
+  #define  PIN_VBAT_READ    5
+#endif
+#ifndef ADC_MULTIPLIER
+  #define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+#endif
 
 #define PIN_3V3_EN (34)
 #define WB_IO2 PIN_3V3_EN

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -41,6 +41,24 @@ build_src_filter = ${rak3401.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 
+; Repeater powered by a USB PD battery pack that reports its charge level on the USB-C
+; SBU pins as 1/2 cell voltage (e.g. Voltaic V25/V50/V75 with Always-On firmware).
+; Wire the pack's SBU pin to J11 pin 1 (AIN1/P0.31) on the RAK19007; the node then
+; reports the pack's true cell voltage (~3.2V empty to ~4.2V full) as its battery.
+; Power management stays enabled but is rerouted to the SBU input: below 3.4V pack cell
+; voltage (PWRMGT_VOLTAGE_BOOTLOCK) the node sleeps in SYSTEMOFF instead of boot-flapping
+; on a drained pack, and LPCOMP wakes it once the pack recharges past ~3.7V cell.
+; See docs/nrf52_power_management.md.
+[env:RAK_3401_repeater_voltaic]
+extends = env:RAK_3401_repeater
+build_flags =
+  ${env:RAK_3401_repeater.build_flags}
+  -D PIN_VBAT_READ=31            ; P0.31 = WisBlock AIN1 = RAK19007 J11 pin 1
+  -D ADC_MULTIPLIER=7200         ; SBU = 1/2 cell voltage -> report full cell mV
+  -D PWRMGT_VOLTAGE_BOOTLOCK=3400 ; sleep below 3.4V pack cell (variant.h default is 3300)
+  -D PWRMGT_LPCOMP_AIN=7         ; LPCOMP watches AIN7 = P0.31 (the SBU input), not AIN0's divider
+  -D PWRMGT_LPCOMP_REFSEL=12     ; wake at 9/16 VDD = ~1.86V at pin = ~3.7V pack cell
+
 [env:RAK_3401_room_server]
 extends = rak3401
 build_flags =

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -80,11 +80,25 @@ extern "C"
 
 // Power management boot protection threshold (millivolts)
 // Set to 0 to disable boot protection
-#define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+#ifndef PWRMGT_VOLTAGE_BOOTLOCK
+  #define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+#endif
 // LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
 // AIN3 = P0.05 = PIN_A0 / PIN_VBAT_READ
-#define PWRMGT_LPCOMP_AIN 3
-#define PWRMGT_LPCOMP_REFSEL 4  // 5/8 VDD (~3.13-3.44V)
+#ifndef PWRMGT_LPCOMP_AIN
+  #define PWRMGT_LPCOMP_AIN 3
+#endif
+// PWRMGT_LPCOMP_REFSEL sets the LPCOMP wake threshold as a fraction of VDD (3.3V rail).
+// Valid values are the nRF52840 LPCOMP REFSEL register codes (see the nRF52840 Product
+// Specification, LPCOMP chapter, and NRF52Board::configureVoltageWake):
+//   0-6  = 1/8, 2/8, ... 7/8 of VDD
+//   7    = external reference on the AREF pin
+//   8-15 = 1/16, 3/16, 5/16, ... 15/16 of VDD
+// Default 4 = 5/8 VDD = ~2.06V at the pin; through the base board's 1M/1.5M battery
+// divider (0.6 ratio) that is VBAT ~3.44V (~3.13V if the VDD rail is at 3.0V).
+#ifndef PWRMGT_LPCOMP_REFSEL
+  #define PWRMGT_LPCOMP_REFSEL 4
+#endif
 
 // Other pins
 #define WB_I2C1_SDA (13) // SENSOR_SLOT IO_SLOT
@@ -194,17 +208,6 @@ static const uint8_t AREF = PIN_AREF;
 #define PIN_GPS_1PPS PIN_GPS_PPS
 #define GPS_BAUD_RATE 9600
 #define GPS_ADDRESS 0x42  //i2c address for GPS
-
-// Battery
-// The battery sense is hooked to pin A0 (5)
-#define BATTERY_PIN PIN_A0
-// and has 12 bit resolution
-#define BATTERY_SENSE_RESOLUTION_BITS 12
-#define BATTERY_SENSE_RESOLUTION 4096.0
-#undef AREF_VOLTAGE
-#define AREF_VOLTAGE 3.0
-#define VBAT_AR_INTERNAL AR_INTERNAL_3_0
-#define ADC_MULTIPLIER 1.73
 
 #define HAS_RTC 1
 

--- a/variants/rak4631/RAK4631Board.h
+++ b/variants/rak4631/RAK4631Board.h
@@ -5,8 +5,12 @@
 #include <helpers/NRF52Board.h>
 
 // built-ins
-#define  PIN_VBAT_READ    5
-#define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+#ifndef PIN_VBAT_READ
+  #define  PIN_VBAT_READ    5
+#endif
+#ifndef ADC_MULTIPLIER
+  #define  ADC_MULTIPLIER   (3 * 1.73 * 1.187 * 1000)
+#endif
 
 class RAK4631Board : public NRF52BoardDCDC {
 protected:

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -106,11 +106,25 @@ extern "C"
 
 // Power management boot protection threshold (millivolts)
 // Set to 0 to disable boot protection
-#define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+#ifndef PWRMGT_VOLTAGE_BOOTLOCK
+  #define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+#endif
 // LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
 // AIN3 = P0.05 = PIN_A0 / PIN_VBAT_READ
-#define PWRMGT_LPCOMP_AIN 3
-#define PWRMGT_LPCOMP_REFSEL 4  // 5/8 VDD (~3.13-3.44V)
+#ifndef PWRMGT_LPCOMP_AIN
+  #define PWRMGT_LPCOMP_AIN 3
+#endif
+// PWRMGT_LPCOMP_REFSEL sets the LPCOMP wake threshold as a fraction of VDD (3.3V rail).
+// Valid values are the nRF52840 LPCOMP REFSEL register codes (see the nRF52840 Product
+// Specification, LPCOMP chapter, and NRF52Board::configureVoltageWake):
+//   0-6  = 1/8, 2/8, ... 7/8 of VDD
+//   7    = external reference on the AREF pin
+//   8-15 = 1/16, 3/16, 5/16, ... 15/16 of VDD
+// Default 4 = 5/8 VDD = ~2.06V at the pin; through the base board's 1M/1.5M battery
+// divider (0.6 ratio) that is VBAT ~3.44V (~3.13V if the VDD rail is at 3.0V).
+#ifndef PWRMGT_LPCOMP_REFSEL
+  #define PWRMGT_LPCOMP_REFSEL 4
+#endif
 
 // Other pins
 #define PIN_AREF (2)


### PR DESCRIPTION
## Summary

Makes the RAK4631/RAK3401 battery sense overridable from build flags, so nodes powered by an external pack can report the pack's real charge instead of the (meaningless) on-board charger float voltage.

The motivating setup: a Voltaic V25/V50/V75 pack reports its charge level on the USB-C SBU pins as **1/2 of its internal cell voltage** ([Voltaic write-up](https://blog.voltaicsystems.com/updated-usb-c-pd-and-always-on-for-v25-v50-v75-batteries/)). Wire that SBU pin to the RAK19007 J11 header pin 1 (AIN1 = P0.31), build with `-D PIN_VBAT_READ=31 -D ADC_MULTIPLIER=7200`, and the node reports the pack's true cell voltage (~3.2V empty to ~4.2V full) through every existing path (`stats-core`, telemetry LPP voltage, companion app).

Incorporates and supersedes #3328 — the `variants/rak4631` hunks here are byte-identical to that PR. Credit to @andyshinn for the override mechanism; this PR extends it to the RAK3401 (1W Booster Kit) variant, where it needs one extra fix to work at all (see below), and adds a power-management escape hatch plus a documented example env.

## What changed

- **`variants/rak4631/RAK4631Board.h`, `variants/rak3401/RAK3401Board.h`** — `PIN_VBAT_READ` / `ADC_MULTIPLIER` wrapped in `#ifndef` guards (same pattern as the rak3112 / heltec_v3 variants). Defaults unchanged. `ADC_MULTIPLIER` semantics: reported millivolts at ADC full scale (3.6V), so `3600` reports the pin voltage as-is and `7200` doubles it for half-scale sources like the SBU pin.
- **`variants/rak4631/variant.h`, `variants/rak3401/variant.h`** — `PWRMGT_VOLTAGE_BOOTLOCK`, `PWRMGT_LPCOMP_AIN`, `PWRMGT_LPCOMP_REFSEL` wrapped in `#ifndef` guards (the bootlock guard makes the already-documented "set to 0 to disable" actually settable per-env), plus a comment block decoding the LPCOMP `REFSEL` register values (0-6 = n/8 VDD, 7 = AREF, 8-15 = odd sixteenths).
- **`variants/rak3401/variant.h`** — removed the unused Meshtastic-leftover battery block (`BATTERY_PIN`, `BATTERY_SENSE_RESOLUTION*`, `AREF_VOLTAGE`, `VBAT_AR_INTERNAL`, `ADC_MULTIPLIER 1.73`). This is required, not cosmetic — see the safety analysis below.
- **`variants/rak3401/platformio.ini`** — new documented `RAK_3401_repeater_voltaic` example env.

## Why deleting the rak3401 variant.h battery block is safe (and necessary)

- **Necessary:** `variant.h` is included via `Arduino.h` *before* the board header in every translation unit, and its unconditional `#define ADC_MULTIPLIER 1.73` therefore wins against both the new `#ifndef` default (stock battery reads would become `raw × 1.73 / 4096` ≈ 2mV) and any `-D ADC_MULTIPLIER=...` build flag (an in-file `#define` overrides a command-line define; the redefinition warning is hidden by the project-wide `-w`). Pre-PR the same shadowing existed harmlessly in the other direction — the board header's unconditional define silently replaced 1.73.
- **The repo copy is the one compiled:** a `-H` include trace on the real build command shows exactly one `variant.h` opened — `variants/rak3401/variant.h` (the pinned meshcore-dev Adafruit_nRF52 framework fork contains no RAK variant to shadow it).
- **Zero references in the whole compile closure:** grepping all five symbol families across the framework fork's `cores/` + `libraries/`, every library in `.pio/libdeps/`, and the repo's `src/` + `examples/` finds nothing. The only occurrences anywhere are other variants' own copies (t1000-e, xiao, ikoka, heltec) in their own directories, never in a rak3401 build's include path.
- **Provenance:** the block arrived wholesale in the variant's initial commit (copied from Meshtastic's rak4631 variant, whose arch code consumes those names — MeshCore has no such consumer) and was never touched since. MeshCore's own `rak4631/variant.h` never had it; removing it restores parity.
- **Binary proof:** stock `RAK_3401_repeater` firmware built before and after this PR differs by exactly 3 bytes — RTClib's embedded `__DATE__ __TIME__` compile timestamp, which differs between any two builds of identical source. Section sizes and the full symbol table are identical.

## The example env

`RAK_3401_repeater_voltaic` extends `RAK_3401_repeater` and keeps nRF52 power management **enabled**, rerouted to the SBU input: below 3.4V pack cell voltage the node enters SYSTEMOFF instead of boot-flapping on a drained pack (weak morning sun → boot → 1W TX sags the pack → brownout → repeat), and LPCOMP wakes it once the pack recharges past ~3.7V cell (9/16 VDD at the pin; ~half charge, not full — the only usable REFSEL step between 3.3V and 4.1V given the SBU's ÷2 scaling). `configureVoltageWake` also arms USB-detect, so plugging in wakes it for maintenance. Note the boot-voltage check only engages when `isExternalPowered()` is false, i.e. when the node is not powered via USB VBUS (true for e.g. the RAK13302 external-5V input).

## Testing

- `RAK_3401_repeater`, `RAK_3401_repeater_voltaic`, and `RAK_4631_repeater` all build clean; `pio run -t envdump` confirms every override lands in `CPPDEFINES`.
- Stock-env binary identity verified as described above (only the RTClib timestamp bytes differ).
- Hardware validation on the motivating setup (RAK19007 + RAK3401 + RAK13302 1W, Voltaic V25 on the SBU line) is in progress; the readings path is the existing `getBattMilliVolts()` code with different constants.

