### PR TITLE
Fix room server: Read-Only ACL role can still post messages

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -477,7 +477,8 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
           send_ack = false; // and no ACK...  user shoudn't be sending these
         }
       } else { // TXT_TYPE_PLAIN
-        if ((client->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST) {
+        uint8_t role = client->permissions & PERM_ACL_ROLE_MASK;
+        if (role == PERM_ACL_GUEST || role == PERM_ACL_READ_ONLY) {
           temp[5] = 0;      // no reply
           send_ack = false; // no ACK
         } else {


### PR DESCRIPTION
## Summary

The room server's ACL has four roles: Guest, Read-Only, Read-Write, and Admin. A contact can be given the Read-Only role directly via the `setperm` CLI command (or the app's ACL/permissions editor, which uses it). However, that role doesn't actually prevent posting.

## Root cause

The check that decides whether an incoming plain-text message gets accepted as a post only excludes the Guest role:

```cpp
if ((client->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST) {
  // dropped, no ack
} else {
  addPost(client, ...);  // accepted and stored
}
```

A client explicitly set to `PERM_ACL_READ_ONLY` is not `PERM_ACL_GUEST`, so it falls into the `else` branch and gets to post exactly like a Read-Write client would.

## Fix

Exclude both `PERM_ACL_GUEST` and `PERM_ACL_READ_ONLY` from the posting gate, so only `PERM_ACL_READ_WRITE` and `PERM_ACL_ADMIN` can post.

## Testing

- `pio run -e heltec_v4_r8_room_server`: builds successfully
- Native unit tests (`pio test -e native`) currently fail to build on this branch's base for an unrelated, pre-existing reason (missing `<cstdlib>` include in `ConfigSerializer.cpp`, causing `atoi`/`atof`/`atol` to be undeclared) — not something this change touches.

## Compatibility

- No change to Guest or Admin behavior.
- No change to login/authorization logic (separate from #940/#2995, which address the blank-password login case).
- Only effect: a contact explicitly assigned Read-Only via `setperm` can no longer post.