### PR TITLE
fix(ikoka): preserve GPIO0 pull-up for repeater button

### DIFF
--- a/variants/ikoka_stick_nrf/target.cpp
+++ b/variants/ikoka_stick_nrf/target.cpp
@@ -6,7 +6,7 @@ IkokaStickNRFBoard board;
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;
-  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true, true);
 #endif
 
 RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);


### PR DESCRIPTION
## Summary

Fixes USB/CLI loss on `ikoka_stick_nrf_33dbm_repeater` introduced in v1.17.

- v1.16 works correctly.
- v1.17 and v1.17.1 fail.
- Git bisect identified first bad commit:
  `76c6e73fb6ff1a6e2f238e25f150aaecbaa877d7`.

## Root cause

The Ikoka board initially configures GPIO0 as `INPUT_PULLUP`. During repeater UI initialization, `MomentaryButton::begin()` subsequently reconfigured the pin as floating `INPUT`.

A floating GPIO0 can register a false active-low long press. That arms `_powering_off_at`; the delayed shutdown path ultimately enters nRF52840 `SYSTEMOFF`. USB CDC then disappears, making Config and the serial CLI unavailable.

## Fix

Enable MomentaryButton's pull configuration for the Ikoka target:

```diff
-  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true, true);
```

This preserves `INPUT_PULLUP` for the active-low button while preserving the existing long-press power-off functionality.

## Hardware validation

Validated on v1.17.1:

- USB enumerates automatically.
- CLI responds correctly.
- MeshCore Config connects.
- Configuration saves successfully.
- Settings persist after reboot.
- Advertisement transmission succeeds.