### PR TITLE
Default transmit duty cycle to 10% instead of 50%

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -565,12 +565,14 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 **Parameters:**
 - `value`: Duty cycle percentage (1-100)
 
-**Default:** `50%` (equivalent to airtime factor 1.0)
+**Default:** `10%` (equivalent to airtime factor 9.0), the ETSI EN 300 220-2 limit for the
+869.4-869.65 MHz sub-band that the default frequency uses. Builds for regions without a duty
+cycle limit can override this with the `MAX_DUTY_CYCLE` build flag.
 
 **Examples:**
 - `set dutycycle 100` — no duty cycle limit
-- `set dutycycle 50` — 50% duty cycle (default)
-- `set dutycycle 10` — 10% duty cycle
+- `set dutycycle 50` — 50% duty cycle
+- `set dutycycle 10` — 10% duty cycle (default)
 - `set dutycycle 1` — 1% duty cycle (strictest EU requirement)
 
 > **Note:** Added in firmware v1.15.0

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -943,7 +943,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   send_unscoped = false;
 
   // defaults
-  _prefs.airtime_factor = 1.0;
+  _prefs.airtime_factor = DEFAULT_AIRTIME_FACTOR;
   strcpy(_prefs.node_name, "NONAME");
   _prefs.freq = LORA_FREQ;
   _prefs.sf = LORA_SF;

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -887,7 +887,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
 #endif
 
   // defaults
-  _prefs.airtime_factor = 1.0;
+  _prefs.airtime_factor = DEFAULT_AIRTIME_FACTOR;
   _prefs.rx_delay_base = 0.0f;   // turn off by default, was 10.0;
   _prefs.tx_delay_factor = 0.5f; // was 0.25f
   _prefs.direct_tx_delay_factor = 0.3f; // was 0.2

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -644,7 +644,7 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   recv_pkt_region = NULL;
 
   // defaults
-  _prefs.airtime_factor = 1.0;
+  _prefs.airtime_factor = DEFAULT_AIRTIME_FACTOR;
   _prefs.rx_delay_base = 0.0f;   // off by default, was 10.0
   _prefs.tx_delay_factor = 0.5f; // was 0.25f;
   _prefs.direct_tx_delay_factor = 0.2f; // was zero

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -285,7 +285,7 @@ public:
   {
     // defaults
     memset(&_prefs, 0, sizeof(_prefs));
-    _prefs.airtime_factor = 1.0;
+    _prefs.airtime_factor = DEFAULT_AIRTIME_FACTOR;
     strcpy(_prefs.node_name, "NONAME");
     _prefs.freq = LORA_FREQ;
     _prefs.tx_power_dbm = LORA_TX_POWER;

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -710,7 +710,7 @@ SensorMesh::SensorMesh(mesh::MainBoard& board, mesh::Radio& radio, mesh::Millise
   set_radio_at = revert_radio_at = 0;
 
   // defaults
-  _prefs.airtime_factor = 1.0;
+  _prefs.airtime_factor = DEFAULT_AIRTIME_FACTOR;
   _prefs.rx_delay_base =   0.0f;  // turn off by default, was 10.0;
   _prefs.tx_delay_factor = 0.5f;   // was 0.25f
   _prefs.direct_tx_delay_factor = 0.2f; // was zero

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -32,7 +32,7 @@ void Dispatcher::begin() {
 }
 
 float Dispatcher::getAirtimeBudgetFactor() const {
-  return 1.0;
+  return DEFAULT_AIRTIME_FACTOR;
 }
 
 void Dispatcher::updateTxBudget() {

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -6,6 +6,16 @@
 #include <Utils.h>
 #include <string.h>
 
+// Default transmit duty cycle limit, as a percentage of the duty cycle window.
+// 10% is the ETSI EN 300 220-2 limit for the 869.4-869.65 MHz sub-band, which is where
+// the default LORA_FREQ lives. Override per build for regions without a duty cycle limit.
+#ifndef MAX_DUTY_CYCLE
+  #define MAX_DUTY_CYCLE  10
+#endif
+
+// Airtime budget factor equivalent of MAX_DUTY_CYCLE (see CommonCLI 'set dutycycle')
+#define DEFAULT_AIRTIME_FACTOR  ((100.0f / (MAX_DUTY_CYCLE)) - 1.0f)
+
 namespace mesh {
 
 /**


### PR DESCRIPTION
Refs #2047.

## Problem

The shipped default is `airtime_factor = 1.0`, which `get dutycycle` reports as `50.0%`.

The default frequency is `-D LORA_FREQ=869.618` (`platformio.ini:29`). That falls in the 869.4 to 869.65 MHz sub-band, which ETSI EN 300 220-2 V3.2.1 caps at 10%. Per-sub-band limits for EU868 are 0.1% (863-865), 1% (865-868), 1% (868-868.6), 0.1% (868.7-869.2), 10% (869.4-869.65) and 1% (869.7-870); see https://www.actility.com/understanding-duty-cycle-lorawan/ for the table and the standard reference. The same 10% figure applies in the UK.

So the default configuration allows five times the duty cycle that applies to its own default frequency. Every EU and UK operator has to change this by hand on each node, and the value is not discoverable unless you already know that `af` means duty cycle.

## Change

- `src/Dispatcher.h`: new `MAX_DUTY_CYCLE` (percent, default 10) and `DEFAULT_AIRTIME_FACTOR`, derived with the same conversion `set dutycycle` already uses (`CommonCLI.cpp:455`).
- The five node types that hardcoded `_prefs.airtime_factor = 1.0` now use `DEFAULT_AIRTIME_FACTOR`: companion_radio, simple_repeater, simple_room_server, simple_secure_chat, simple_sensor.
- `Dispatcher::getAirtimeBudgetFactor()` returned a hardcoded `1.0` as the base class fallback; it now uses the same constant.
- `docs/cli_commands.md` documented 50% as the default.

Builds for regions without a duty cycle limit can keep the old behaviour with `-D MAX_DUTY_CYCLE=100`.

## What this does not change

Only the default for a node with no stored preferences. The persisted field is still `airtime_factor` (key `af` in the config serializer, offset 0 in the legacy prefs file), and `set dutycycle` and `set af` behave exactly as before. Existing nodes keep whatever they have configured.

## Scope left out deliberately

Two things I noticed while reading the duty cycle code and did not touch here, to keep this to one change:

1. The token bucket in `Dispatcher::updateTxBudget()` starts full and its ceiling is a full window's allowance. In the worst case a node can spend the full bucket plus a window of refill inside one observation window, so roughly twice the nominal duty cycle in that window. ETSI measures over a one hour observation period, so this can overshoot even when configured correctly.
2. The `constrain(airtime_factor, 0, 9.0f)` sanitisation only exists in `loadPrefsInt()`, the legacy `/com_prefs` loader. The `/prefs.json` path via `loadSerial()` does not clamp, so `set dutycycle 1` (af 99) persists there but is reset to 10% for a node migrating from the legacy format.

Happy to open separate issues for either if useful.

## Testing

Not covered by a unit test. The native test environment (`platformio.ini`, `[env:native]`) does not compile `Dispatcher.cpp` and uses a mock `Mesh.h`, so testing this would mean adding a mock radio to that environment, which is a larger change than the default itself. Verified instead that `DEFAULT_AIRTIME_FACTOR` resolves in all five translation units: each includes `<Mesh.h>`, which includes `<Dispatcher.h>` at `src/Mesh.h:3`. The CI build matrix covers the compile.
