### PR TITLE
Companion: keep a queued message until the sync reply is actually written 🤖🤖

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -246,18 +246,22 @@ void MyMesh::addToOfflineQueue(const uint8_t frame[], int len) {
   }
 }
 
-int MyMesh::getFromOfflineQueue(uint8_t frame[]) {
+int MyMesh::peekOfflineQueue(uint8_t frame[]) {
   if (offline_queue_len > 0) {         // check offline queue
-    size_t len = offline_queue[0].len; // take from top of queue
+    size_t len = offline_queue[0].len; // copy from top of queue, but leave it there
     memcpy(frame, offline_queue[0].buf, len);
+    return len;
+  }
+  return 0; // queue is empty
+}
 
+void MyMesh::popOfflineQueue() {
+  if (offline_queue_len > 0) {
     offline_queue_len--;
     for (int i = 0; i < offline_queue_len; i++) { // delete top item from queue
       offline_queue[i] = offline_queue[i + 1];
     }
-    return len;
   }
-  return 0; // queue is empty
 }
 
 float MyMesh::getAirtimeBudgetFactor() const {
@@ -1449,11 +1453,18 @@ void MyMesh::handleCmdFrame(size_t len) {
     }
   } else if (cmd_frame[0] == CMD_SYNC_NEXT_MESSAGE) {
     int out_len;
-    if ((out_len = getFromOfflineQueue(out_frame)) > 0) {
-      _serial->writeFrame(out_frame, out_len);
+    if ((out_len = peekOfflineQueue(out_frame)) > 0) {
+      // The frame stays queued until a transport has taken it. A write that
+      // puts nothing on the wire (BLE/WiFi send queue full, serial link not
+      // accepting) used to lose the message for good; now the client simply
+      // asks again. writeFrame() returns 0 only in that case, see
+      // BaseSerialInterface, so any other result consumes the frame.
+      if (_serial->writeFrame(out_frame, out_len) != 0) {
+        popOfflineQueue();
 #ifdef DISPLAY_CLASS
-      if (_ui) _ui->msgRead(offline_queue_len);
+        if (_ui) _ui->msgRead(offline_queue_len);
 #endif
+      }
     } else {
       out_frame[0] = RESP_CODE_NO_MORE_MESSAGES;
       _serial->writeFrame(out_frame, 1);

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -210,7 +210,8 @@ private:
   void writeContactRespFrame(uint8_t code, const ContactInfo &contact);
   void updateContactFromFrame(ContactInfo &contact, uint32_t& last_mod, const uint8_t *frame, int len);
   void addToOfflineQueue(const uint8_t frame[], int len);
-  int getFromOfflineQueue(uint8_t frame[]);
+  int peekOfflineQueue(uint8_t frame[]);   // copies the oldest frame, leaves it queued
+  void popOfflineQueue();                   // discards the oldest frame
   int getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]) override { 
     return _store->getBlobByKey(key, key_len, dest_buf);
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -172,6 +172,7 @@ build_src_filter =
   +<../src/Packet.cpp>
   +<../src/helpers/ConfigSerializer.cpp>
   +<../src/helpers/DynamicConfigSerializer.cpp>
+  +<../src/helpers/ArduinoSerialInterface.cpp>
 lib_deps =
   google/googletest @ 1.17.0
 

--- a/src/helpers/ArduinoSerialInterface.cpp
+++ b/src/helpers/ArduinoSerialInterface.cpp
@@ -32,8 +32,13 @@ size_t ArduinoSerialInterface::writeFrame(const uint8_t src[], size_t len) {
   hdr[1] = (len & 0xFF);  // LSB
   hdr[2] = (len >> 8);    // MSB
 
-  _serial->write(hdr, 3);
-  return _serial->write(src, len);
+  // See BaseSerialInterface::writeFrame(): 0 only when nothing went out, so
+  // the caller may retry; a torn frame counts as taken because a retry would
+  // only hand the receiver another header as payload.
+  size_t n = _serial->write(hdr, 3);
+  if (n == 0) return 0;
+  if (n == 3) _serial->write(src, len);
+  return len;
 }
 
 size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {

--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -17,6 +17,11 @@ public:
   virtual void loop() {};
 
   virtual bool isWriteBusy() const = 0;
+  // Returns len once the transport has taken the frame, and 0 only when
+  // nothing of it was written, so that a caller may safely offer the same
+  // frame again. A frame the transport tore (a short write on a serial link)
+  // counts as taken: a retry cannot mend it, the receiver would swallow the
+  // next header as the missing payload.
   virtual size_t writeFrame(const uint8_t src[], size_t len) = 0;
   virtual size_t checkRecvFrame(uint8_t dest[]) = 0;
 };

--- a/src/helpers/MultiSerialInterface.h
+++ b/src/helpers/MultiSerialInterface.h
@@ -163,18 +163,23 @@ public:
       return 0;
     }
 
-    // write frame to all enabled interfaces
-    bool allSuccessful = true;
+    // write frame to all enabled interfaces. It counts as delivered once ANY
+    // of them took it (see BaseSerialInterface::writeFrame): an interface that
+    // is enabled but has nobody attached (BLE advertising, an idle port) fails
+    // its write, and must not veto the delivery to the client that asked -- a
+    // caller that keeps a frame until it is delivered would otherwise resend
+    // it forever.
+    bool delivered = false;
     for(auto iface : _interfaces){
       if(iface.instance && iface.instance->isEnabled()){
-        if(iface.instance->writeFrame(src, len) != len){
-          allSuccessful = false;
+        if(iface.instance->writeFrame(src, len) == len){
+          delivered = true;
         }
       }
     }
 
-    // report success if all writes completed successfully
-    return allSuccessful ? len : 0; 
+    // report success if at least one interface delivered the frame
+    return delivered ? len : 0; 
   }
 
   size_t checkRecvFrame(uint8_t dest[]) override {

--- a/test/test_arduino_serial_interface/test_arduino_serial_interface.cpp
+++ b/test/test_arduino_serial_interface/test_arduino_serial_interface.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "helpers/ArduinoSerialInterface.h"
+
+namespace {
+
+// A stream that accepts only `capacity` more bytes, the way a CDC port with a
+// stalled host or a nearly full TX ring answers a write with a short count.
+class CappedStream : public Stream {
+public:
+  explicit CappedStream(size_t capacity) : _capacity(capacity) {}
+
+  size_t write(uint8_t b) override { return write(&b, 1); }
+  size_t write(const uint8_t* buffer, size_t size) override {
+    size_t n = size < _capacity ? size : _capacity;
+    wire.insert(wire.end(), buffer, buffer + n);
+    _capacity -= n;
+    return n;
+  }
+
+  std::vector<uint8_t> wire;
+
+private:
+  size_t _capacity;
+};
+
+const uint8_t PAYLOAD[] = { 0x10, 0x20, 0x30, 0x40 };
+const size_t LEN = sizeof(PAYLOAD);
+const std::vector<uint8_t> FRAME_ON_WIRE = { '>', LEN, 0, 0x10, 0x20, 0x30, 0x40 };
+
+size_t writeTo(CappedStream& stream) {
+  ArduinoSerialInterface iface;
+  iface.begin(stream);
+  iface.enable();
+  return iface.writeFrame(PAYLOAD, LEN);
+}
+
+}  // namespace
+
+TEST(ArduinoSerialInterface, WholeFrameIsTakenAndReportedAsLen) {
+  CappedStream stream(64);
+  EXPECT_EQ(writeTo(stream), LEN);
+  EXPECT_EQ(stream.wire, FRAME_ON_WIRE);
+}
+
+TEST(ArduinoSerialInterface, NothingWrittenReportsZeroSoTheCallerMayRetry) {
+  CappedStream stream(0);
+  EXPECT_EQ(writeTo(stream), 0u);
+  EXPECT_TRUE(stream.wire.empty());
+}
+
+TEST(ArduinoSerialInterface, TornHeaderCountsAsTaken) {
+  CappedStream stream(2);   // header cut short, payload never attempted
+  EXPECT_EQ(writeTo(stream), LEN);
+  EXPECT_EQ(stream.wire.size(), 2u);
+}
+
+TEST(ArduinoSerialInterface, TornPayloadCountsAsTaken) {
+  CappedStream stream(3 + LEN - 1);   // header out, payload one byte short
+  EXPECT_EQ(writeTo(stream), LEN);
+  EXPECT_EQ(stream.wire.size(), 3 + LEN - 1);
+}
+
+TEST(ArduinoSerialInterface, OversizedFrameIsRefusedWithoutWriting) {
+  CappedStream stream(1024);
+  uint8_t big[MAX_FRAME_SIZE + 1] = {0};
+  ArduinoSerialInterface iface;
+  iface.begin(stream);
+  iface.enable();
+  EXPECT_EQ(iface.writeFrame(big, sizeof(big)), 0u);
+  EXPECT_TRUE(stream.wire.empty());
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_multi_serial_interface/test_multi_serial_interface.cpp
+++ b/test/test_multi_serial_interface/test_multi_serial_interface.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "helpers/MultiSerialInterface.h"
+
+namespace {
+
+// A transport that either takes every frame whole or refuses them all, the way
+// a BLE/WiFi interface behaves with no client attached or a full send queue.
+class FakeInterface : public BaseSerialInterface {
+public:
+  explicit FakeInterface(bool accepts) : _accepts(accepts) {}
+
+  void enable() override { _enabled = true; }
+  void disable() override { _enabled = false; }
+  bool isEnabled() const override { return _enabled; }
+  bool isConnected() const override { return _accepts; }
+  bool isWriteBusy() const override { return false; }
+  size_t writeFrame(const uint8_t src[], size_t len) override {
+    writes++;
+    if (!_accepts) return 0;
+    last.assign(src, src + len);
+    return len;
+  }
+  size_t checkRecvFrame(uint8_t dest[]) override { return 0; }
+
+  int writes = 0;
+  std::vector<uint8_t> last;
+
+private:
+  bool _accepts;
+  bool _enabled = false;
+};
+
+const uint8_t FRAME[] = { 0x10, 0x20, 0x30 };
+const std::vector<uint8_t> FRAME_BYTES(FRAME, FRAME + sizeof(FRAME));
+
+}  // namespace
+
+TEST(MultiSerialInterface, DeliveredWhenOneOfTwoEnabledInterfacesAcceptsIt) {
+  FakeInterface ble(false);   // advertising, nobody connected
+  FakeInterface usb(true);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.addInterface(InterfaceType::USB, &usb);
+  multi.enable();
+
+  EXPECT_EQ(multi.writeFrame(FRAME, sizeof(FRAME)), sizeof(FRAME));
+  EXPECT_EQ(ble.writes, 1);   // still offered to every enabled interface
+  EXPECT_EQ(usb.writes, 1);
+  EXPECT_EQ(usb.last, FRAME_BYTES);
+}
+
+TEST(MultiSerialInterface, NotDeliveredWhenNoInterfaceAcceptsIt) {
+  FakeInterface ble(false);
+  FakeInterface usb(false);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.addInterface(InterfaceType::USB, &usb);
+  multi.enable();
+
+  EXPECT_EQ(multi.writeFrame(FRAME, sizeof(FRAME)), 0u);
+  EXPECT_EQ(ble.writes, 1);
+  EXPECT_EQ(usb.writes, 1);
+}
+
+TEST(MultiSerialInterface, DisabledInterfaceIsNeitherWrittenNorCounted) {
+  FakeInterface ble(true);
+  FakeInterface usb(false);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.addInterface(InterfaceType::USB, &usb);
+  multi.enable();
+  ble.disable();
+
+  EXPECT_EQ(multi.writeFrame(FRAME, sizeof(FRAME)), 0u);
+  EXPECT_EQ(ble.writes, 0);
+  EXPECT_EQ(usb.writes, 1);
+}
+
+TEST(MultiSerialInterface, NothingIsWrittenWhileDisabledOrEmpty) {
+  FakeInterface usb(true);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::USB, &usb);
+
+  EXPECT_EQ(multi.writeFrame(FRAME, sizeof(FRAME)), 0u);   // manager not enabled
+  multi.enable();
+  EXPECT_EQ(multi.writeFrame(FRAME, 0), 0u);               // empty frame
+  EXPECT_EQ(usb.writes, 0);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
`CMD_SYNC_NEXT_MESSAGE` takes the oldest frame out of the offline queue and then ignores the return value of `writeFrame()`. Both BLE interfaces and the WiFi interface return 0 while their send queue is full, and a serial write can come back short; in each of those cases the message is gone for good, while the client saw nothing and asks for the next one.

## Change

* **`MyMesh`**: the frame stays queued until the transport reports that it took it whole. `getFromOfflineQueue()` is split into `peekOfflineQueue()` / `popOfflineQueue()`, and the sync handler pops only after a complete write. On failure the client simply repeats the request; nothing else changes for it.
* **`MultiSerialInterface::writeFrame()`** counted a frame as written only when *every* enabled interface accepted it. An interface that is enabled but has nobody attached (BLE advertising, an idle port) fails each write, which would turn the retry above into resending the same message forever on any build with more than one interface. It now reports success once *any* enabled interface took the frame. Single-interface builds, which is everything upstream ships, are unaffected: with one interface "any" and "all" coincide.
* **`ArduinoSerialInterface::writeFrame()`** reports 0 only when nothing went out. A torn frame (a short write on a CDC port whose host has stalled) counts as taken: a retry cannot mend it, the receiver would swallow the next header as the missing payload, so the message is consumed exactly as before this change. The contract is now spelled out on `BaseSerialInterface`; BLE, WiFi and Ethernet already behaved that way (0 while their send queue is full, `len` otherwise).

## Testing

* Two new native googletests: `test_multi_serial_interface` (4 cases; the first fails against the previous `MultiSerialInterface`, the other three pass on both versions, so it pins exactly the changed behaviour) and `test_arduino_serial_interface` (5 cases: whole, nothing, torn header, torn payload, oversized). `ArduinoSerialInterface.cpp` is added to the native build filter for that.
* Built `heltec_v4_r8_companion_radio_usb`, `Heltec_v3_companion_radio_usb`, `RAK_4631_companion_radio_ble`, `heltec_v4_companion_radio_wifi` and `Xiao_S3_WIO_companion_radio_serial` (HWCDC, UART bridge, nRF52 BLE, WiFi, hardware serial).
* The failing-write path was not exercised on hardware; it needs a full BLE send queue or a serial port that accepts nothing. The happy path is unchanged.

## Known limits

* An interface that accepts frames with nobody attached still counts as delivery. The plain serial interface is one: its `isConnected()` is unconditionally `true` and `write()` succeeds into the TX buffer whether or not a host reads it. Giving it a real connection state is what #3214 does; the two changes compose but do not depend on each other.
* With two clients attached at once, a frame that one of them refuses is still consumed once the other took it, exactly as today. Judging by "all connected interfaces" instead would let a port with a charger on it veto every frame, so "any" is the safe choice.
* A torn serial write still loses the message, as today: the retry only engages when nothing was written. Not tearing frames in the first place is a transport matter (#3214 does it with whole-frame writes and pacing).

Found while reviewing #3214, where flow control makes a 0 return from `writeFrame()` a normal event rather than a rare one.

---

*Prepared with Claude Code (Claude Fable 5.1), which did the analysis, the patch and the test; a human reviewed and approved the change before submission. The patch was also put through an independent cross-provider review with Codex (`gpt-6-astra`, reasoning effort `max`) before posting; its one finding, that retrying after a torn serial write would corrupt the stream, led to the `writeFrame()` contract above.*
