### PR TITLE
Revert nRF52 toolchain to gcc 9.3.1 to avoid build errors

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -86,7 +86,7 @@ platform_packages =
   ; https://github.com/meshcore-dev/MeshCore/pull/1177
   ; https://github.com/meshcore-dev/MeshCore/pull/1295
   framework-arduinoadafruitnrf52 @ https://github.com/meshcore-dev/Adafruit_nRF52_Arduino#d541301
-  platformio/toolchain-gccarmnoneeabi@^1.140201.0
+  platformio/toolchain-gccarmnoneeabi@^1.90301.200702
 extra_scripts = create-uf2.py
 build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM


### PR DESCRIPTION
This fixes build errors introduced by #3246. The `stevemarple/MicroNMEA` dependency does not currently support newer versions of gcc, and neither does our MicroNMEALocationProvider class.

I have tested, and of the gcc versions made available by toolchain-gccarmnoneeabi, 9.3.1 is the newest that allows us to build successfully. This is still an upgrade over the version we were previously using, 7.2.1. 10.3.1 and newer results in the following error:

```
Linking .pio/build/RAK_4631_repeater/firmware.elf
/home/yoshi/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld: .pio/build/RAK_4631_repeater/variants/rak4631/target.cpp.o: in function `MicroNMEALocationProvider::MicroNMEALocationProvider(Stream&, mesh::RTCClock*, int, int, RefCountedDigitalPin*)':
/mnt/d/git/MeshCore/src/helpers/sensors/MicroNMEALocationProvider.h:63:(.text._ZN25MicroNMEALocationProviderC2ER6StreamPN4mesh8RTCClockEiiP20RefCountedDigitalPin[_ZN25MicroNMEALocationProviderC5ER6StreamPN4mesh8RTCClockEiiP20RefCountedDigitalPin]+0x88): undefined reference to `vtable for LocationProvider'
/home/yoshi/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld: .pio/build/RAK_4631_repeater/libFrameworkArduino.a(Uart.cpp.o): in function `Uart::Uart(NRF_UARTE_Type*, IRQn_Type, unsigned char, unsigned char)':
/home/yoshi/.platformio/packages/framework-arduinoadafruitnrf52/cores/nRF5/Uart.cpp:48:(.text._ZN4UartC2EP14NRF_UARTE_Type9IRQn_Typehh+0x64): undefined reference to `vtable for HardwareSerial'
collect2: error: ld returned 1 exit status
*** [.pio/build/RAK_4631_repeater/firmware.elf] Error 1
```