### PR TITLE
Fix CMD_SEND_CHANNEL_DATA payload validation

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1266,8 +1266,8 @@ void MyMesh::handleCmdFrame(size_t len) {
       writeErrFrame(ERR_CODE_NOT_FOUND); // bad channel_idx
     } else if (data_type == DATA_TYPE_RESERVED) {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
-    } else if (payload_len > MAX_CHANNEL_DATA_LENGTH) {
-      MESH_DEBUG_PRINTLN("CMD_SEND_CHANNEL_DATA payload too long: %d > %d", payload_len, MAX_CHANNEL_DATA_LENGTH);
+    } else if (payload_len > MAX_GROUP_DATA_LENGTH) {
+      MESH_DEBUG_PRINTLN("CMD_SEND_CHANNEL_DATA payload too long: %d > %d", payload_len, MAX_GROUP_DATA_LENGTH);
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
     } else if (sendGroupData(channel.channel, path, path_len, data_type, payload, payload_len)) {
       writeOKFrame();


### PR DESCRIPTION
Fixes #3345

Validate `CMD_SEND_CHANNEL_DATA` payloads against `MAX_GROUP_DATA_LENGTH` instead of
`MAX_CHANNEL_DATA_LENGTH`.

This rejects 166-167 byte payloads with `ERR_CODE_ILLEGAL_ARG` before they reach
`sendGroupData()`, while leaving the receive-side `MAX_CHANNEL_DATA_LENGTH` check unchanged.

Verified:
- 164-165 byte payloads pass the validation check
- 166-168 byte payloads are rejected by the validation check
- `Heltec_v3_companion_radio_ble` builds successfully