### PR TITLE
[Feature request] Add configurable guest environment telemetry levels via CLI

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -152,9 +152,27 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 ---
 
 ### Packet stats - Packet counters: Received, Sent
-**Usage:** `stats-packets`
+**Usage:** `stats-packets <mode>`
 
 **Serial Only:** Yes
+
+### View or change guest telemetry access
+**Usage:**
+- `get guest.enviroment`
+- `set guest.enviroment <mode>`
+
+**Parameters:**
+- `mode`: `normal`, `gps` or `all`
+  - `normal`: guests can see battery level and CPU temperature
+  - `gps`: guests can also see the node's GPS position
+  - `all`: guests can see all available telemetry
+
+**Default:** `normal`
+
+**Notes:**
+- The setting applies only to telemetry returned to guest clients.
+- It does not change the node's position in advertisements.
+- The spelling `enviroment` is part of the CLI command for compatibility.
 
 ---
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -245,7 +245,13 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
 
     // query other sensors -- target specific
     if ((sender->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST) {
-      perm_mask = 0x00;  // just base telemetry allowed
+      if (_prefs.guest_environment == GUEST_ENVIRONMENT_GPS) {
+        perm_mask &= TELEM_PERM_LOCATION;
+      } else if (_prefs.guest_environment == GUEST_ENVIRONMENT_ALL) {
+        perm_mask &= TELEM_PERM_LOCATION | TELEM_PERM_ENVIRONMENT;
+      } else {
+        perm_mask &= 0x00; // just base telemetry allowed
+      }
     }
     sensors.querySensors(perm_mask, telemetry);
 

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -185,7 +185,13 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
     telemetry.addVoltage(TELEM_CHANNEL_SELF, (float)board.getBattMilliVolts() / 1000.0f);
     // query other sensors -- target specific
     if ((sender->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST) {
-      perm_mask = 0x00;  // just base telemetry allowed
+      if (_prefs.guest_environment == GUEST_ENVIRONMENT_GPS) {
+        perm_mask &= TELEM_PERM_LOCATION;
+      } else if (_prefs.guest_environment == GUEST_ENVIRONMENT_ALL) {
+        perm_mask &= TELEM_PERM_LOCATION | TELEM_PERM_ENVIRONMENT;
+      } else {
+        perm_mask &= 0x00; // just base telemetry allowed
+      }
     }
     sensors.querySensors(perm_mask, telemetry);
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -507,6 +507,21 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     StrHelper::strncpy(_prefs->guest_password, &config[15], sizeof(_prefs->guest_password));
     savePrefs();
     strcpy(reply, "OK");
+  } else if (memcmp(config, "guest.enviroment ", 17) == 0) {
+    const char* value = &config[17];
+    uint8_t mode;
+    if (strcmp(value, "normal") == 0) {
+      _prefs->guest_environment = GUEST_ENVIRONMENT_NORMAL;
+    } else if (strcmp(value, "gps") == 0) {
+      _prefs->guest_environment = GUEST_ENVIRONMENT_GPS;
+    } else if (strcmp(value, "all") == 0) {
+      _prefs->guest_environment = GUEST_ENVIRONMENT_ALL;
+    } else {
+      strcpy(reply, "Error: expected normal, gps or all");
+      return;
+    }
+    savePrefs();
+    strcpy(reply, "OK");
   } else if (memcmp(config, "prv.key ", 8) == 0) {
     uint8_t prv_key[PRV_KEY_SIZE];
     bool success = mesh::Utils::fromHex(prv_key, PRV_KEY_SIZE, &config[8]);
@@ -829,6 +844,14 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %d", ((uint32_t) _prefs->advert_interval) * 2);
   } else if (memcmp(config, "guest.password", 14) == 0) {
     sprintf(reply, "> %s", _prefs->guest_password);
+  } else if (memcmp(config, "guest.enviroment", 16) == 0) {
+    const char* mode = "normal";
+    if (_prefs->guest_environment == GUEST_ENVIRONMENT_GPS) {
+      mode = "gps";
+    } else if (_prefs->guest_environment == GUEST_ENVIRONMENT_ALL) {
+      mode = "all";
+    }
+    sprintf(reply, "> %s", mode);
   } else if (sender_timestamp == 0 && memcmp(config, "prv.key", 7) == 0) {  // from serial command line only
     uint8_t prv_key[PRV_KEY_SIZE];
     int len = _callbacks->getSelfId().writeTo(prv_key, PRV_KEY_SIZE);

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -20,6 +20,10 @@
 #define LOOP_DETECT_MODERATE  2
 #define LOOP_DETECT_STRICT    3
 
+#define GUEST_ENVIRONMENT_NORMAL  0
+#define GUEST_ENVIRONMENT_GPS     1
+#define GUEST_ENVIRONMENT_ALL     2
+
 class NodePrefs : public ConfigSerializer {
 public:
   // in-memory backing data
@@ -40,6 +44,7 @@ public:
   uint8_t sf = 0;
   uint8_t cr = 0;
   uint8_t allow_read_only = 0;
+  uint8_t guest_environment = GUEST_ENVIRONMENT_NORMAL;
   uint8_t multi_acks = 0;
   float bw = 0;
   uint8_t flood_max = 0;
@@ -171,6 +176,7 @@ protected:
     def("name", node_name, sizeof(node_name));
     def("pass", password, sizeof(password));
     def("guest", guest_password, sizeof(guest_password));
+    def("guest_env", guest_environment);
     def("owner", owner_info, sizeof(owner_info));
     def("adv_int", advert_interval);
     def("f_adv_int", flood_advert_interval);


### PR DESCRIPTION
Allows users to configure guest telemetry exposure for repeaters and room servers instead of relying on hardcoded telemetry levels.

**Use Case & Problem Solved:**
When deploying nodes as weather stations or multi-sensor units based on an existing repeater, guests could not access environmental metrics due to hardcoded telemetry restrictions. This change allows node operators to expose telemetry selectively to guest clients without compromising full access.

### Changes

* Added the `guest.environment` configuration parameter to the CLI.
* Implemented getter and setter CLI commands to manage telemetry exposure levels.
* Updated documentation/examples to reflect the new command options.

### Supported Modes

* `normal` (default) – Exposes battery level and CPU temperature.
* `gps` – Exposes battery level, CPU temperature, and GPS position.
* `all` – Exposes all available telemetry metrics (including environmental sensors).

### CLI Usage

```bash
get guest.environment
set guest.environment <normal|gps|all>

```