### PR TITLE
fix(companion): gate CMD_SEND_CHANNEL_DATA payload on MAX_GROUP_DATA_LENGTH

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1270,8 +1270,8 @@ void MyMesh::handleCmdFrame(size_t len) {
       writeErrFrame(ERR_CODE_NOT_FOUND); // bad channel_idx
     } else if (data_type == DATA_TYPE_RESERVED) {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
-    } else if (payload_len > MAX_CHANNEL_DATA_LENGTH) {
-      MESH_DEBUG_PRINTLN("CMD_SEND_CHANNEL_DATA payload too long: %d > %d", payload_len, MAX_CHANNEL_DATA_LENGTH);
+    } else if (payload_len > MAX_GROUP_DATA_LENGTH) {
+      MESH_DEBUG_PRINTLN("CMD_SEND_CHANNEL_DATA payload too long: %d > %d", payload_len, MAX_GROUP_DATA_LENGTH);
       writeErrFrame(ERR_CODE_ILLEGAL_ARG);
     } else if (sendGroupData(channel.channel, path, path_len, data_type, payload, payload_len)) {
       writeOKFrame();


### PR DESCRIPTION
## Summary
Fixes #3345.

`CMD_SEND_CHANNEL_DATA` (0x3E) in `examples/companion_radio/MyMesh.cpp` gated outbound payloads against `MAX_CHANNEL_DATA_LENGTH` (`MAX_FRAME_SIZE - 9 = 167` bytes) instead of the radio-side bound `MAX_GROUP_DATA_LENGTH` (`184 - 16 - 3 = 165` bytes).

Payloads of 166 or 167 bytes passed the handler check, but were rejected by `BaseChatMesh::sendGroupData` (`data_len > MAX_GROUP_DATA_LENGTH`). Because `sendGroupData` returns `false`, `MyMesh.cpp` returned `ERR_CODE_TABLE_FULL` (3) instead of `ERR_CODE_ILLEGAL_ARG` (6).

Since `ERR_CODE_TABLE_FULL` indicates a transient queue-full condition, conforming clients would retry indefinitely on a payload that can never succeed.

## Changes
- In `examples/companion_radio/MyMesh.cpp`, check `payload_len > MAX_GROUP_DATA_LENGTH` instead of `MAX_CHANNEL_DATA_LENGTH` and update the accompanying debug log.
- `MAX_CHANNEL_DATA_LENGTH` is preserved in `onChannelDataRecv`, where it correctly bounds inbound host frames.

## Verification
- `pio test -e native` (PASSED 46/46)
- `pio test -e native_kiss_modem` (PASSED 8/8)
- `pio run -e Heltec_v3_companion_radio_ble` (SUCCESS)