### PR TITLE
Validate set af input to prevent out-of-range airtime factors

### DIFF
--- a/src/helpers/CommonRadioPrefs.cpp
+++ b/src/helpers/CommonRadioPrefs.cpp
@@ -67,8 +67,14 @@ bool CommonRadioPrefs::handleCommand(const char* command, uint32_t sender_timest
     return true;
   }
   if (memcmp(command, "set af ", 7) == 0) {
-    setAirtimeFactor(atof(&command[7]));
-    strcpy(reply, "OK");
+    char* end;
+    float af = strtof(&command[7], &end);
+    if (end == &command[7] || af < 0 || af > 9) {
+      strcpy(reply, "ERROR: af must be 0-9");
+    } else {
+      setAirtimeFactor(af);
+      strcpy(reply, "OK");
+    }
     return true;
   }
 


### PR DESCRIPTION
`set af` took whatever `atof` returned, with no validation:

- `set af abc` applies `0.0` and replies `OK`. Factor 0 reads back as a 100% duty cycle, so a typo silently removes airtime limiting.
- `set af 99` or `set af -3` applies the value and persists it right away. The `constrain()` in `loadPrefsInt()` only repairs the stored value after a reboot, and a negative factor breaks the dutycycle math in `get dutycycle` (`100 / (af + 1)` divides by zero at -1, goes negative below it).

This adds the input validation the neighbouring setters already have (`set dutycycle` 1-100, `set txdelay` 0-2, `set rxdelay` 0-20): input with no digits, or a value outside 0-9, replies `ERROR: af must be 0-9` and leaves the stored value untouched.