### PR TITLE
Add isGPSDetected() capability probe to SensorManager

### DIFF
--- a/src/helpers/SensorManager.h
+++ b/src/helpers/SensorManager.h
@@ -23,6 +23,7 @@ public:
   virtual const char* getSettingValue(int i) const { return NULL; }
   virtual bool setSettingValue(const char* name, const char* value) { return false; }
   virtual LocationProvider* getLocationProvider() { return NULL; }
+  virtual bool isGPSDetected() const { return false; }
 
   // Helper functions to manage setting by keys (useful in many places ...)
   const char* getSettingByKey(const char* key) {

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -38,6 +38,7 @@ public:
   #if ENV_INCLUDE_GPS
   EnvironmentSensorManager(LocationProvider &location): _location(&location){};
   LocationProvider* getLocationProvider() { return _location; }
+  bool isGPSDetected() const override { return gps_detected; }
   #else
   EnvironmentSensorManager(){};
   #endif


### PR DESCRIPTION
ENV_INCLUDE_GPS says a build can have GPS. It says nothing about whether one is actually attached, and there is no way for the app to ask.

Adds a virtual `isGPSDetected()` to SensorManager, returning false by default, overridden in EnvironmentSensorManager to return its existing `gps_detected` flag. Builds without GPS keep the default.