### PR TITLE
Honour advert location policy in builds without GPS

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -168,6 +168,7 @@ void CommonCLI::savePrefs() {
 }
 
 uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
+#if ENV_INCLUDE_GPS == 1
   if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
     AdvertDataBuilder builder(node_type, _prefs->node_name);
     return builder.encodeTo(app_data);
@@ -178,6 +179,16 @@ uint8_t CommonCLI::buildAdvertData(uint8_t node_type, uint8_t* app_data) {
     AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
     return builder.encodeTo(app_data);
   }
+#else
+  // No GPS support: sensed coordinates are never populated, so honour
+  // ADVERT_LOC_NONE and otherwise fall back to the configured position.
+  if (_prefs->advert_loc_policy == ADVERT_LOC_NONE) {
+    AdvertDataBuilder builder(node_type, _prefs->node_name);
+    return builder.encodeTo(app_data);
+  }
+  AdvertDataBuilder builder(node_type, _prefs->node_name, _prefs->node_lat, _prefs->node_lon);
+  return builder.encodeTo(app_data);
+#endif
 }
 
 void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* reply) {


### PR DESCRIPTION
In `buildAdvertData()`, ADVERT_LOC_SHARE reads `_sensors->node_lat` and `node_lon`. Builds compiled without GPS never populate those, so a node set to share its location advertises coordinates 0,0.

Gates the function on ENV_INCLUDE_GPS like the rest of the GPS paths: builds without GPS honour ADVERT_LOC_NONE and otherwise fall back to the configured `node_lat`/`node_lon`.