### PR TITLE
Notify the app when a CLI command changes node identity or position

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -359,6 +359,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       _prefs->node_lat = _sensors->node_lat;
       _prefs->node_lon = _sensors->node_lon;
       savePrefs();
+      _callbacks->onNodeConfigChanged();
       strcpy(reply, "ok");
     } else if (memcmp(command, "gps advert", 10) == 0) {
       if (strlen(command) == 10) {
@@ -504,6 +505,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     if (isValidName(&config[5])) {
       StrHelper::strncpy(_prefs->node_name, &config[5], sizeof(_prefs->node_name));
       savePrefs();
+      _callbacks->onNodeConfigChanged();
       strcpy(reply, "OK");
     } else {
       strcpy(reply, "Error, bad chars");
@@ -515,10 +517,12 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (memcmp(config, "lat ", 4) == 0) {
     _prefs->node_lat = atof(&config[4]);
     savePrefs();
+    _callbacks->onNodeConfigChanged();
     strcpy(reply, "OK");
   } else if (memcmp(config, "lon ", 4) == 0) {
     _prefs->node_lon = atof(&config[4]);
     savePrefs();
+    _callbacks->onNodeConfigChanged();
     strcpy(reply, "OK");
   } else if (memcmp(config, "flood.max.unscoped ", 19) == 0) {
     uint8_t m = atoi(&config[19]);

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -250,6 +250,12 @@ public:
   virtual void sendSelfAdvertisement(int delay_millis, bool flood) = 0;
   virtual void updateAdvertTimer() = 0;
   virtual void updateFloodAdvertTimer() = 0;
+
+  // Fired after a CLI command changes node identity or position ("set name",
+  // "set lat", "set lon", "gps setloc"), so the app can react to the change.
+  virtual void onNodeConfigChanged() {
+    // no op by default
+  }
   virtual void setLoggingOn(bool enable) = 0;
   virtual void eraseLogFile() = 0;
   virtual void dumpLogFile() = 0;


### PR DESCRIPTION
`set name`, `set lat`, `set lon` and `gps setloc` update the prefs and save them, but the app never hears about it. Anything the app derives from identity or position only catches up after a reboot.

Adds a virtual no-op `onNodeConfigChanged()` to the CommonCLI callbacks and fires it after those four commands succeed.