### PR TITLE
Improve null checks and index validation in StaticPoolPacketManager

### DIFF
--- a/src/helpers/StaticPoolPacketManager.cpp
+++ b/src/helpers/StaticPoolPacketManager.cpp
@@ -44,7 +44,7 @@ mesh::Packet* PacketQueue::get(uint32_t now) {
 }
 
 mesh::Packet* PacketQueue::removeByIdx(int i) {
-  if (i >= _num) return NULL;  // invalid index
+  if (i < 0 || i >= _num) return NULL;  // invalid index
 
   mesh::Packet* item = _table[i];
   _num--;
@@ -80,10 +80,14 @@ mesh::Packet* StaticPoolPacketManager::allocNew() {
 }
 
 void StaticPoolPacketManager::free(mesh::Packet* packet) {
-  unused.add(packet, 0, 0);
+  if (packet == NULL) return;
+  if (!unused.add(packet, 0, 0)) {
+    MESH_DEBUG_PRINTLN("free: unused queue full, possible double-free detected");
+  }
 }
 
 void StaticPoolPacketManager::queueOutbound(mesh::Packet* packet, uint8_t priority, uint32_t scheduled_for) {
+  if (packet == NULL) return;
   if (!send_queue.add(packet, priority, scheduled_for)) {
     MESH_DEBUG_PRINTLN("queueOutbound: send queue full, dropping packet");
     free(packet);
@@ -115,6 +119,7 @@ mesh::Packet* StaticPoolPacketManager::removeOutboundByIdx(int i) {
 }
 
 void StaticPoolPacketManager::queueInbound(mesh::Packet* packet, uint32_t scheduled_for) {
+  if (packet == NULL) return;
   if (!rx_queue.add(packet, 0, scheduled_for)) {
     MESH_DEBUG_PRINTLN("queueInbound: rx queue full, dropping packet");
     free(packet);

--- a/src/helpers/StaticPoolPacketManager.h
+++ b/src/helpers/StaticPoolPacketManager.h
@@ -14,7 +14,10 @@ public:
   bool add(mesh::Packet* packet, uint8_t priority, uint32_t scheduled_for);
   int count() const { return _num; }
   int countBefore(uint32_t now) const;
-  mesh::Packet* itemAt(int i) const { return _table[i]; }
+  mesh::Packet* itemAt(int i) const {
+    if (i < 0 || i >= _num) return NULL;
+    return _table[i];
+  }
   mesh::Packet* removeByIdx(int i);
 };
 


### PR DESCRIPTION
StaticPoolPacketManager trusts its own state a bit too much:

- `PacketQueue::get()` checks the upper bound but not the sign, so a negative index reads before the table.
- `itemAt()` returns `_table[i]` with no bounds check at all.
- `free()`, `queueOutbound()` and `queueInbound()` dereference a NULL packet, or pass one to `add()`, before any check.

Adds the sign and bounds checks, early-outs on NULL packets, and logs when the unused queue refuses a freed packet, which is the symptom of a double free.